### PR TITLE
feat(crypto): etype registry

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -18,3 +18,43 @@ change will be elaborated on in time):
   KDC-sealed encrypted part of the ticket rather than from the client-supplied authenticator. This closes
   [jcmturner/gokrb5#577](https://github.com/jcmturner/gokrb5/issues/577), where a client could authenticate with a
   ticket for its own principal while presenting an arbitrary realm as its identity.
+- Which encryption types the library will use is now decided by a configurable registry in the
+  `github.com/go-krb5/krb5/crypto` package rather than being fixed at compile time, and the encryption types RFC 8429
+  deprecates are no longer registered by default. `des3-cbc-sha1-kd` and `rc4-hmac` (with their `hmac-sha1-des3-kd` and
+  `kerb-checksum-hmac-md5` checksum types) are still implemented but must be opted back in with
+  `crypto.RegisterDeprecatedDes3CbcSha1Kd()` or `crypto.RegisterDeprecatedRC4HMAC()` during application start up. Until
+  they are, `crypto.GetEType` and `crypto.GetChecksumEType` reject them, and `config.LibDefaults.DefaultTktEnctypeIDs`,
+  `DefaultTGSEnctypeIDs` and `PermittedEnctypeIDs` exclude them so they are never advertised to a KDC. Active Directory
+  deployments that have not been migrated off `rc4-hmac` will need the opt in.
+- The encryption type lookup functions have been renamed so that `EType` is spelled consistently across the module, and
+  the abbreviation `Chksum` is spelled out. Callers must be updated; there are no aliases under the old names:
+
+  | Before                        | After                         |
+  |:------------------------------|:------------------------------|
+  | `crypto.GetEtype`             | `crypto.GetEType`             |
+  | `crypto.GetChksumEtype`       | `crypto.GetChecksumEType`     |
+  | `iana/etypeID.EtypeSupported` | `iana/etypeID.ETypeSupported` |
+
+  The signatures are otherwise unchanged, except that `crypto.GetEType` and `crypto.GetChecksumEType` now return the
+  single registered instance of an implementation rather than a fresh copy per call. The implementations this module
+  provides are stateless empty structs so this is not observable for them, but an implementation registered by an
+  application must be stateless and safe for concurrent use. Both functions also now return a pointer to the
+  implementation, so a type assertion against the value type, such as `e.(crypto.Aes256CtsHmacSha96)`, must become
+  `e.(*crypto.Aes256CtsHmacSha96)`.
+- `iana/etypeID.ETypeSupported` is deprecated in addition to being renamed. It reports the fixed set of encryption types
+  the module implements, which is no longer the same as the set it will use. Resolve the name with
+  `etypeID.ETypesByName` and then check `crypto.GetEType` instead.
+- The following functions are new in `github.com/go-krb5/krb5/crypto` and make up the registry. They are listed here
+  only because they are the replacement for behaviour that used to be fixed at compile time; they break nothing on
+  their own:
+
+  | Function                                 | Purpose                                                     |
+  |:-----------------------------------------|:------------------------------------------------------------|
+  | `crypto.AddEType`                        | Register an encryption type implementation against an ID.   |
+  | `crypto.DeleteEType`                     | Unregister an encryption type ID.                           |
+  | `crypto.ETypeIDs`                        | List the registered encryption type IDs in ascending order. |
+  | `crypto.AddChecksumEType`                | Register a checksum type implementation against an ID.      |
+  | `crypto.DeleteChecksumEType`             | Unregister a checksum type ID.                              |
+  | `crypto.ChecksumETypeIDs`                | List the registered checksum type IDs in ascending order.   |
+  | `crypto.RegisterDeprecatedRC4HMAC`       | Opt back in to `rc4-hmac` and `kerb-checksum-hmac-md5`.     |
+  | `crypto.RegisterDeprecatedDes3CbcSha1Kd` | Opt back in to `des3-cbc-sha1-kd` and `hmac-sha1-des3-kd`.  |

--- a/client/as_xchange.go
+++ b/client/as_xchange.go
@@ -106,7 +106,7 @@ func setPAData(cl *Client, krberr *messages.KRBError, req *messages.ASReq) error
 				etn = int32(cl.Config.LibDefaults.PreferredPreauthTypes[0])
 			}
 
-			et, err = crypto.GetEtype(etn)
+			et, err = crypto.GetEType(etn)
 			if err != nil {
 				return krberror.Errorf(err, krberror.EncryptingError, "error getting etype for pre-auth encryption")
 			}
@@ -200,7 +200,7 @@ Loop:
 		}
 	}
 
-	etype, e = crypto.GetEtype(etypeID)
+	etype, e = crypto.GetEType(etypeID)
 	if e != nil {
 		err = krberror.Errorf(e, krberror.EncryptingError, "error creating etype")
 		return

--- a/config/krb5conf.go
+++ b/config/krb5conf.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/go-krb5/x/encoding/asn1"
 
+	"github.com/go-krb5/krb5/crypto"
 	"github.com/go-krb5/krb5/iana/etypeID"
 )
 
@@ -800,10 +801,19 @@ func parseETypes(s []string, w bool) []int32 {
 			}
 		}
 
-		i := etypeID.EtypeSupported(et)
-		if i != 0 {
-			eti = append(eti, i)
+		i, ok := etypeID.ETypesByName[et]
+		if !ok {
+			continue
 		}
+
+		// The crypto registry, not this package, decides what is supported: an application that unregisters an
+		// encryption type must not have it advertised to the KDC, and one that registers an additional
+		// implementation must be able to name it here.
+		if _, err := crypto.GetEType(i); err != nil {
+			continue
+		}
+
+		eti = append(eti, i)
 	}
 
 	return eti

--- a/config/krb5conf_test.go
+++ b/config/krb5conf_test.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/krb5/crypto"
+	"github.com/go-krb5/krb5/iana/etypeID"
 )
 
 const (
@@ -105,8 +108,7 @@ const (
     ],
     "DefaultTGSEnctypeIDs": [
       18,
-      17,
-      23
+      17
     ],
     "DefaultTktEnctypeIDs": [
       18,
@@ -139,8 +141,7 @@ const (
     ],
     "PermittedEnctypeIDs": [
       18,
-      17,
-      23
+      17
     ],
     "PreferredPreauthTypes": [
       17,
@@ -675,4 +676,52 @@ func TestJSON(t *testing.T) {
 	assert.Equal(t, krb5ConfJson, j)
 
 	t.Log(j)
+}
+
+// TestParseETypesShouldFollowCryptoRegistry asserts the crypto registry, not a list fixed at compile time, decides
+// which encryption types reach the KDC. An application that unregisters one must not have it advertised, and one that
+// registers an additional implementation must be able to name it in krb5.conf.
+func TestParseETypesShouldFollowCryptoRegistry(t *testing.T) {
+	// The registry is process wide so this test cannot run in parallel with anything that reads it.
+	t.Run("ShouldExcludeUnregistered", func(t *testing.T) {
+		crypto.DeleteEType(etypeID.AES128_CTS_HMAC_SHA1_96)
+
+		t.Cleanup(func() {
+			require.NoError(t, crypto.AddEType(etypeID.AES128_CTS_HMAC_SHA1_96, &crypto.Aes128CtsHmacSha96{}))
+		})
+
+		have := parseETypes([]string{"aes256-cts-hmac-sha1-96", "aes128-cts-hmac-sha1-96"}, false)
+		assert.Equal(t, []int32{etypeID.AES256_CTS_HMAC_SHA1_96}, have)
+	})
+
+	t.Run("ShouldIncludeNewlyRegistered", func(t *testing.T) {
+		require.NoError(t, crypto.AddEType(etypeID.CAMELLIA256_CTS_CMAC, &crypto.Aes256CtsHmacSha96{}))
+
+		t.Cleanup(func() {
+			crypto.DeleteEType(etypeID.CAMELLIA256_CTS_CMAC)
+		})
+
+		have := parseETypes([]string{"camellia256-cts-cmac"}, false)
+		assert.Equal(t, []int32{etypeID.CAMELLIA256_CTS_CMAC}, have)
+	})
+
+	t.Run("ShouldExcludeDeprecatedByDefault", func(t *testing.T) {
+		have := parseETypes([]string{"aes256-cts-hmac-sha1-96", "des3-cbc-sha1-kd", "arcfour-hmac-md5"}, false)
+		assert.Equal(t, []int32{etypeID.AES256_CTS_HMAC_SHA1_96}, have)
+	})
+
+	t.Run("ShouldExcludeWeakUnlessAllowed", func(t *testing.T) {
+		require.NoError(t, crypto.AddEType(etypeID.DES_CBC_MD5, &crypto.Aes256CtsHmacSha96{}))
+
+		t.Cleanup(func() {
+			crypto.DeleteEType(etypeID.DES_CBC_MD5)
+		})
+
+		assert.Empty(t, parseETypes([]string{"des-cbc-md5"}, false))
+		assert.Equal(t, []int32{etypeID.DES_CBC_MD5}, parseETypes([]string{"des-cbc-md5"}, true))
+	})
+
+	t.Run("ShouldExcludeUnknownName", func(t *testing.T) {
+		assert.Empty(t, parseETypes([]string{"not-an-enctype"}, true))
+	})
 }

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -6,72 +6,15 @@ import (
 	"fmt"
 
 	"github.com/go-krb5/krb5/crypto/etype"
-	"github.com/go-krb5/krb5/iana/chksumtype"
-	"github.com/go-krb5/krb5/iana/etypeID"
 	"github.com/go-krb5/krb5/iana/patype"
 	"github.com/go-krb5/krb5/types"
 )
-
-// GetEtype returns an instances of the required etype struct for the etype ID.
-func GetEtype(id int32) (etype.EType, error) {
-	switch id {
-	case etypeID.AES128_CTS_HMAC_SHA1_96:
-		var et Aes128CtsHmacSha96
-		return et, nil
-	case etypeID.AES256_CTS_HMAC_SHA1_96:
-		var et Aes256CtsHmacSha96
-		return et, nil
-	case etypeID.AES128_CTS_HMAC_SHA256_128:
-		var et Aes128CtsHmacSha256128
-		return et, nil
-	case etypeID.AES256_CTS_HMAC_SHA384_192:
-		var et Aes256CtsHmacSha384192
-		return et, nil
-	case etypeID.DES3_CBC_SHA1_KD:
-		var et Des3CbcSha1Kd
-		return et, nil
-	case etypeID.RC4_HMAC:
-		var et RC4HMAC
-		return et, nil
-	default:
-		return nil, fmt.Errorf("unknown or unsupported EType: %d", id)
-	}
-}
-
-// GetChksumEtype returns an instances of the required etype struct for the checksum ID.
-func GetChksumEtype(id int32) (etype.EType, error) {
-	switch id {
-	case chksumtype.HMAC_SHA1_96_AES128:
-		var et Aes128CtsHmacSha96
-		return et, nil
-	case chksumtype.HMAC_SHA1_96_AES256:
-		var et Aes256CtsHmacSha96
-		return et, nil
-	case chksumtype.HMAC_SHA256_128_AES128:
-		var et Aes128CtsHmacSha256128
-		return et, nil
-	case chksumtype.HMAC_SHA384_192_AES256:
-		var et Aes256CtsHmacSha384192
-		return et, nil
-	case chksumtype.HMAC_SHA1_DES3_KD:
-		var et Des3CbcSha1Kd
-		return et, nil
-	case chksumtype.KERB_CHECKSUM_HMAC_MD5:
-		var et RC4HMAC
-		return et, nil
-	// case chksumtype.KERB_CHECKSUM_HMAC_MD5_UNSIGNED:
-	//	var et RC4HMAC
-	//	return et, nil
-	default:
-		return nil, fmt.Errorf("unknown or unsupported checksum type: %d", id)
-	}
-}
 
 // GetKeyFromPassword generates an encryption key from the principal's password.
 func GetKeyFromPassword(passwd string, cname types.PrincipalName, realm string, etypeID int32, pas types.PADataSequence) (types.EncryptionKey, etype.EType, error) {
 	var key types.EncryptionKey
 
-	et, err := GetEtype(etypeID)
+	et, err := GetEType(etypeID)
 	if err != nil {
 		return key, et, fmt.Errorf("error getting encryption type: %w", err)
 	}
@@ -104,7 +47,7 @@ func GetKeyFromPassword(passwd string, cname types.PrincipalName, realm string, 
 			}
 
 			if etypeID != eti[0].EType {
-				et, err = GetEtype(eti[0].EType)
+				et, err = GetEType(eti[0].EType)
 				if err != nil {
 					return key, et, fmt.Errorf("error getting encryption type: %w", err)
 				}
@@ -124,7 +67,7 @@ func GetKeyFromPassword(passwd string, cname types.PrincipalName, realm string, 
 			}
 
 			if etypeID != et2[0].EType {
-				et, err = GetEtype(et2[0].EType)
+				et, err = GetEType(et2[0].EType)
 				if err != nil {
 					return key, et, fmt.Errorf("error getting encryption type: %w", err)
 				}
@@ -160,7 +103,7 @@ func GetKeyFromPassword(passwd string, cname types.PrincipalName, realm string, 
 func GetEncryptedData(plainBytes []byte, key types.EncryptionKey, usage uint32, kvno int) (types.EncryptedData, error) {
 	var ed types.EncryptedData
 
-	et, err := GetEtype(key.KeyType)
+	et, err := GetEType(key.KeyType)
 	if err != nil {
 		return ed, fmt.Errorf("error getting etype: %w", err)
 	}
@@ -186,7 +129,7 @@ func DecryptEncPart(ed types.EncryptedData, key types.EncryptionKey, usage uint3
 
 // DecryptMessage decrypts the ciphertext and verifies the integrity.
 func DecryptMessage(ciphertext []byte, key types.EncryptionKey, usage uint32) ([]byte, error) {
-	et, err := GetEtype(key.KeyType)
+	et, err := GetEType(key.KeyType)
 	if err != nil {
 		return []byte{}, fmt.Errorf("error decrypting: %w", err)
 	}

--- a/crypto/registry.go
+++ b/crypto/registry.go
@@ -1,0 +1,186 @@
+package crypto
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+
+	"github.com/go-krb5/krb5/crypto/etype"
+	"github.com/go-krb5/krb5/iana/chksumtype"
+	"github.com/go-krb5/krb5/iana/etypeID"
+)
+
+// AddEType registers an etype.EType implementation against an encryption type ID, replacing any implementation
+// previously registered against that ID. It allows an application to support encryption types this library does not
+// implement, or to substitute its own implementation of one that it does.
+//
+// The encryption type ID 0 is reserved by RFC 3961 and cannot be registered.
+//
+// The registered value is shared by every caller of GetEType, so implementations must be stateless and safe for
+// concurrent use. Registration is safe to perform concurrently with use of the registry, though changing the registry
+// while Kerberos exchanges are in flight may cause those exchanges to fail.
+func AddEType(id int32, e etype.EType) (err error) {
+	if e == nil {
+		return errors.New("no EType provided")
+	}
+
+	if id == etypeIDReserved {
+		return fmt.Errorf("cannot register reserved EType: %d", id)
+	}
+
+	muRegistryEType.Lock()
+	defer muRegistryEType.Unlock()
+
+	registryEType[id] = e
+
+	return nil
+}
+
+// DeleteEType unregisters the encryption type ID so that GetEType no longer resolves it. Deleting an ID that is not
+// registered is a no-op. This is the mechanism by which an application restricts itself to a set of encryption types
+// it considers acceptable.
+func DeleteEType(id int32) {
+	muRegistryEType.Lock()
+	defer muRegistryEType.Unlock()
+
+	delete(registryEType, id)
+}
+
+// ETypeIDs returns the encryption type IDs currently registered, in ascending order.
+func ETypeIDs() (ids []int32) {
+	muRegistryEType.RLock()
+	defer muRegistryEType.RUnlock()
+
+	return sortedKeys(registryEType)
+}
+
+// GetEType returns an instances of the required etype struct for the etype ID.
+func GetEType(id int32) (e etype.EType, err error) {
+	muRegistryEType.RLock()
+	defer muRegistryEType.RUnlock()
+
+	var ok bool
+
+	if e, ok = registryEType[id]; !ok {
+		return nil, fmt.Errorf("unknown or unsupported EType: %d", id)
+	}
+
+	return e, nil
+}
+
+// AddChecksumEType registers an etype.EType implementation against a checksum type ID, replacing any implementation
+// previously registered against that ID.
+//
+// The checksum type ID 0 is reserved by RFC 3961 and cannot be registered.
+//
+// The same concurrency requirements as AddEType apply to the registered value.
+func AddChecksumEType(id int32, e etype.EType) (err error) {
+	if e == nil {
+		return errors.New("no EType provided")
+	}
+
+	if id == chksumtypeIDReserved {
+		return fmt.Errorf("cannot register reserved checksum type: %d", id)
+	}
+
+	muRegistryChecksumEType.Lock()
+	defer muRegistryChecksumEType.Unlock()
+
+	registryChecksumEType[id] = e
+
+	return nil
+}
+
+// DeleteChecksumEType unregisters the checksum type ID so that GetChecksumEType no longer resolves it. Deleting an ID that
+// is not registered is a no-op.
+func DeleteChecksumEType(id int32) {
+	muRegistryChecksumEType.Lock()
+	defer muRegistryChecksumEType.Unlock()
+
+	delete(registryChecksumEType, id)
+}
+
+// ChecksumETypeIDs returns the checksum type IDs currently registered, in ascending order.
+func ChecksumETypeIDs() (ids []int32) {
+	muRegistryChecksumEType.RLock()
+	defer muRegistryChecksumEType.RUnlock()
+
+	return sortedKeys(registryChecksumEType)
+}
+
+// GetChecksumEType returns an instances of the required etype struct for the checksum ID.
+func GetChecksumEType(id int32) (e etype.EType, err error) {
+	muRegistryChecksumEType.RLock()
+	defer muRegistryChecksumEType.RUnlock()
+
+	var ok bool
+
+	if e, ok = registryChecksumEType[id]; !ok {
+		return nil, fmt.Errorf("unknown or unsupported checksum type: %d", id)
+	}
+
+	return e, nil
+}
+
+// RegisterDeprecatedRC4HMAC registers rc4-hmac and its kerb-checksum-hmac-md5 checksum type, neither of which is
+// registered by default. RFC 8429 deprecates rc4-hmac and it should not be used, however some Active Directory
+// deployments still require it. Call this during application start up if such a deployment must be supported.
+func RegisterDeprecatedRC4HMAC() {
+	e := &RC4HMAC{}
+
+	_ = AddEType(etypeID.RC4_HMAC, e)
+	_ = AddChecksumEType(chksumtype.KERB_CHECKSUM_HMAC_MD5, e)
+}
+
+// RegisterDeprecatedDes3CbcSha1Kd registers des3-cbc-sha1-kd and its hmac-sha1-des3-kd checksum type, neither of which
+// is registered by default. RFC 8429 deprecates des3-cbc-sha1-kd and it should not be used. Call this during
+// application start up if a realm that still requires it must be supported.
+func RegisterDeprecatedDes3CbcSha1Kd() {
+	e := &Des3CbcSha1Kd{}
+
+	_ = AddEType(etypeID.DES3_CBC_SHA1_KD, e)
+	_ = AddChecksumEType(chksumtype.HMAC_SHA1_DES3_KD, e)
+}
+
+func sortedKeys(registry map[int32]etype.EType) (ids []int32) {
+	ids = make([]int32, 0, len(registry))
+
+	for id := range registry {
+		ids = append(ids, id)
+	}
+
+	slices.Sort(ids)
+
+	return ids
+}
+
+// Encryption type and checksum type ID 0 is reserved by RFC 3961 and must never resolve to an implementation.
+const (
+	etypeIDReserved      int32 = 0
+	chksumtypeIDReserved int32 = 0
+)
+
+var (
+	muRegistryEType sync.RWMutex
+
+	// registryEType holds only the encryption types RFC 8429 does not deprecate. des3-cbc-sha1-kd and rc4-hmac are
+	// implemented by this library but are not registered by default; see the RegisterDeprecated* helpers.
+	registryEType = map[int32]etype.EType{
+		etypeID.AES128_CTS_HMAC_SHA1_96:    &Aes128CtsHmacSha96{},
+		etypeID.AES256_CTS_HMAC_SHA1_96:    &Aes256CtsHmacSha96{},
+		etypeID.AES128_CTS_HMAC_SHA256_128: &Aes128CtsHmacSha256128{},
+		etypeID.AES256_CTS_HMAC_SHA384_192: &Aes256CtsHmacSha384192{},
+	}
+
+	muRegistryChecksumEType sync.RWMutex
+
+	// registryChecksumEType mirrors registryEType: the checksum types belonging to the deprecated encryption types are
+	// not registered by default.
+	registryChecksumEType = map[int32]etype.EType{
+		chksumtype.HMAC_SHA1_96_AES128:    &Aes128CtsHmacSha96{},
+		chksumtype.HMAC_SHA1_96_AES256:    &Aes256CtsHmacSha96{},
+		chksumtype.HMAC_SHA256_128_AES128: &Aes128CtsHmacSha256128{},
+		chksumtype.HMAC_SHA384_192_AES256: &Aes256CtsHmacSha384192{},
+	}
+)

--- a/crypto/registry_test.go
+++ b/crypto/registry_test.go
@@ -1,0 +1,332 @@
+package crypto
+
+import (
+	"maps"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/krb5/crypto/etype"
+	"github.com/go-krb5/krb5/iana/chksumtype"
+	"github.com/go-krb5/krb5/iana/etypeID"
+	"github.com/go-krb5/krb5/types"
+)
+
+// etypeIDCustom is an ID from the unassigned range, used to prove an application can register an implementation of an
+// encryption type this library does not know about.
+const etypeIDCustom int32 = 4096
+
+func TestGetETypeShouldResolveDefaults(t *testing.T) {
+	restoreRegistries(t)
+
+	testCases := []struct {
+		name string
+		id   int32
+		want etype.EType
+	}{
+		{"AES128_CTS_HMAC_SHA1_96", etypeID.AES128_CTS_HMAC_SHA1_96, &Aes128CtsHmacSha96{}},
+		{"AES256_CTS_HMAC_SHA1_96", etypeID.AES256_CTS_HMAC_SHA1_96, &Aes256CtsHmacSha96{}},
+		{"AES128_CTS_HMAC_SHA256_128", etypeID.AES128_CTS_HMAC_SHA256_128, &Aes128CtsHmacSha256128{}},
+		{"AES256_CTS_HMAC_SHA384_192", etypeID.AES256_CTS_HMAC_SHA384_192, &Aes256CtsHmacSha384192{}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e, err := GetEType(tc.id)
+			require.NoError(t, err)
+			assert.IsType(t, tc.want, e)
+			assert.Equal(t, tc.id, e.GetETypeID())
+		})
+	}
+
+	assert.Equal(t, []int32{
+		etypeID.AES128_CTS_HMAC_SHA1_96,
+		etypeID.AES256_CTS_HMAC_SHA1_96,
+		etypeID.AES128_CTS_HMAC_SHA256_128,
+		etypeID.AES256_CTS_HMAC_SHA384_192,
+	}, ETypeIDs())
+}
+
+// TestGetETypeShouldNotResolveDeprecatedByDefault asserts RFC 8429 deprecated encryption types are implemented but not
+// enabled, and that opting back in works.
+func TestGetETypeShouldNotResolveDeprecatedByDefault(t *testing.T) {
+	restoreRegistries(t)
+
+	for _, tc := range []struct {
+		name       string
+		id         int32
+		chksum     int32
+		register   func()
+		wantEType  etype.EType
+		wantChksum etype.EType
+	}{
+		{"RC4_HMAC", etypeID.RC4_HMAC, chksumtype.KERB_CHECKSUM_HMAC_MD5, RegisterDeprecatedRC4HMAC, &RC4HMAC{}, &RC4HMAC{}},
+		{"DES3_CBC_SHA1_KD", etypeID.DES3_CBC_SHA1_KD, chksumtype.HMAC_SHA1_DES3_KD, RegisterDeprecatedDes3CbcSha1Kd, &Des3CbcSha1Kd{}, &Des3CbcSha1Kd{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			restoreRegistries(t)
+
+			_, err := GetEType(tc.id)
+			assert.EqualError(t, err, "unknown or unsupported EType: "+itoa(tc.id))
+
+			_, err = GetChecksumEType(tc.chksum)
+			assert.EqualError(t, err, "unknown or unsupported checksum type: "+itoa(tc.chksum))
+
+			tc.register()
+
+			e, err := GetEType(tc.id)
+			require.NoError(t, err)
+			assert.IsType(t, tc.wantEType, e)
+
+			c, err := GetChecksumEType(tc.chksum)
+			require.NoError(t, err)
+			assert.IsType(t, tc.wantChksum, c)
+		})
+	}
+}
+
+func TestGetChecksumETypeShouldResolveDefaults(t *testing.T) {
+	restoreRegistries(t)
+
+	testCases := []struct {
+		name string
+		id   int32
+		want etype.EType
+	}{
+		{"HMAC_SHA1_96_AES128", chksumtype.HMAC_SHA1_96_AES128, &Aes128CtsHmacSha96{}},
+		{"HMAC_SHA1_96_AES256", chksumtype.HMAC_SHA1_96_AES256, &Aes256CtsHmacSha96{}},
+		{"HMAC_SHA256_128_AES128", chksumtype.HMAC_SHA256_128_AES128, &Aes128CtsHmacSha256128{}},
+		{"HMAC_SHA384_192_AES256", chksumtype.HMAC_SHA384_192_AES256, &Aes256CtsHmacSha384192{}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e, err := GetChecksumEType(tc.id)
+			require.NoError(t, err)
+			assert.IsType(t, tc.want, e)
+		})
+	}
+
+	assert.Equal(t, []int32{
+		chksumtype.HMAC_SHA1_96_AES128,
+		chksumtype.HMAC_SHA1_96_AES256,
+		chksumtype.HMAC_SHA256_128_AES128,
+		chksumtype.HMAC_SHA384_192_AES256,
+	}, ChecksumETypeIDs())
+}
+
+func TestAddEType(t *testing.T) {
+	t.Run("ShouldRejectNil", func(t *testing.T) {
+		restoreRegistries(t)
+
+		assert.EqualError(t, AddEType(etypeIDCustom, nil), "no EType provided")
+		assert.NotContains(t, ETypeIDs(), etypeIDCustom)
+	})
+
+	t.Run("ShouldRejectReservedID", func(t *testing.T) {
+		restoreRegistries(t)
+
+		assert.EqualError(t, AddEType(0, &Aes256CtsHmacSha96{}), "cannot register reserved EType: 0")
+
+		_, err := GetEType(0)
+		assert.EqualError(t, err, "unknown or unsupported EType: 0")
+	})
+
+	t.Run("ShouldRegisterUnassignedID", func(t *testing.T) {
+		restoreRegistries(t)
+
+		require.NoError(t, AddEType(etypeIDCustom, &Aes256CtsHmacSha96{}))
+
+		e, err := GetEType(etypeIDCustom)
+		require.NoError(t, err)
+		assert.IsType(t, &Aes256CtsHmacSha96{}, e)
+		assert.Contains(t, ETypeIDs(), etypeIDCustom)
+	})
+
+	t.Run("ShouldReplaceExistingID", func(t *testing.T) {
+		restoreRegistries(t)
+
+		require.NoError(t, AddEType(etypeID.AES256_CTS_HMAC_SHA1_96, &Aes128CtsHmacSha96{}))
+
+		e, err := GetEType(etypeID.AES256_CTS_HMAC_SHA1_96)
+		require.NoError(t, err)
+		assert.IsType(t, &Aes128CtsHmacSha96{}, e)
+		assert.Len(t, ETypeIDs(), 4)
+	})
+}
+
+func TestAddChecksumEType(t *testing.T) {
+	t.Run("ShouldRejectNil", func(t *testing.T) {
+		restoreRegistries(t)
+
+		assert.EqualError(t, AddChecksumEType(etypeIDCustom, nil), "no EType provided")
+		assert.NotContains(t, ChecksumETypeIDs(), etypeIDCustom)
+	})
+
+	t.Run("ShouldRejectReservedID", func(t *testing.T) {
+		restoreRegistries(t)
+
+		assert.EqualError(t, AddChecksumEType(0, &Aes256CtsHmacSha96{}), "cannot register reserved checksum type: 0")
+
+		_, err := GetChecksumEType(0)
+		assert.EqualError(t, err, "unknown or unsupported checksum type: 0")
+	})
+
+	// Checksum type IDs are not constrained to positive values: kerb-checksum-hmac-md5 is -138.
+	t.Run("ShouldRegisterNegativeID", func(t *testing.T) {
+		restoreRegistries(t)
+
+		require.NoError(t, AddChecksumEType(chksumtype.KERB_CHECKSUM_HMAC_MD5, &RC4HMAC{}))
+
+		e, err := GetChecksumEType(chksumtype.KERB_CHECKSUM_HMAC_MD5)
+		require.NoError(t, err)
+		assert.IsType(t, &RC4HMAC{}, e)
+	})
+}
+
+func TestDeleteEType(t *testing.T) {
+	t.Run("ShouldUnregister", func(t *testing.T) {
+		restoreRegistries(t)
+
+		DeleteEType(etypeID.AES128_CTS_HMAC_SHA1_96)
+
+		_, err := GetEType(etypeID.AES128_CTS_HMAC_SHA1_96)
+		assert.EqualError(t, err, "unknown or unsupported EType: 17")
+		assert.NotContains(t, ETypeIDs(), etypeID.AES128_CTS_HMAC_SHA1_96)
+
+		// Unrelated encryption types are unaffected.
+		_, err = GetEType(etypeID.AES256_CTS_HMAC_SHA1_96)
+		require.NoError(t, err)
+	})
+
+	t.Run("ShouldIgnoreUnregistered", func(t *testing.T) {
+		restoreRegistries(t)
+
+		DeleteEType(etypeIDCustom)
+		assert.Len(t, ETypeIDs(), 4)
+	})
+}
+
+func TestDeleteChecksumEType(t *testing.T) {
+	t.Run("ShouldUnregister", func(t *testing.T) {
+		restoreRegistries(t)
+
+		DeleteChecksumEType(chksumtype.HMAC_SHA1_96_AES128)
+
+		_, err := GetChecksumEType(chksumtype.HMAC_SHA1_96_AES128)
+		assert.EqualError(t, err, "unknown or unsupported checksum type: 15")
+		assert.NotContains(t, ChecksumETypeIDs(), chksumtype.HMAC_SHA1_96_AES128)
+	})
+
+	t.Run("ShouldIgnoreUnregistered", func(t *testing.T) {
+		restoreRegistries(t)
+
+		DeleteChecksumEType(etypeIDCustom)
+		assert.Len(t, ChecksumETypeIDs(), 4)
+	})
+}
+
+// TestUnregisteredETypeShouldFailClearly asserts the callers of the registry surface an actionable error rather than
+// panicking or silently falling back to another encryption type, which is the point of being able to unregister one.
+func TestUnregisteredETypeShouldFailClearly(t *testing.T) {
+	restoreRegistries(t)
+
+	DeleteEType(etypeID.AES256_CTS_HMAC_SHA1_96)
+
+	key := types.EncryptionKey{
+		KeyType:  etypeID.AES256_CTS_HMAC_SHA1_96,
+		KeyValue: make([]byte, 32),
+	}
+
+	t.Run("GetKeyFromPassword", func(t *testing.T) {
+		_, _, err := GetKeyFromPassword("password", types.PrincipalName{NameString: []string{"user"}}, "EXAMPLE.ORG", key.KeyType, types.PADataSequence{})
+		assert.EqualError(t, err, "error getting encryption type: unknown or unsupported EType: 18")
+	})
+
+	t.Run("GetEncryptedData", func(t *testing.T) {
+		_, err := GetEncryptedData([]byte("secret"), key, 1, 1)
+		assert.EqualError(t, err, "error getting etype: unknown or unsupported EType: 18")
+	})
+
+	t.Run("DecryptMessage", func(t *testing.T) {
+		_, err := DecryptMessage([]byte("ciphertext"), key, 1)
+		assert.EqualError(t, err, "error decrypting: unknown or unsupported EType: 18")
+	})
+}
+
+// TestRegistryShouldBeConcurrencySafe is meaningful under -race: mutating a registry while it is being read must not
+// trip the runtime's concurrent map access detection.
+func TestRegistryShouldBeConcurrencySafe(t *testing.T) {
+	restoreRegistries(t)
+
+	var wg sync.WaitGroup
+
+	for range 8 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for range 100 {
+				_, _ = GetEType(etypeID.AES256_CTS_HMAC_SHA1_96)
+				_, _ = GetChecksumEType(chksumtype.HMAC_SHA1_96_AES256)
+				_ = ETypeIDs()
+				_ = ChecksumETypeIDs()
+			}
+		}()
+	}
+
+	for range 4 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for range 100 {
+				_ = AddEType(etypeIDCustom, &Aes256CtsHmacSha96{})
+				_ = AddChecksumEType(etypeIDCustom, &Aes256CtsHmacSha96{})
+				DeleteEType(etypeIDCustom)
+				DeleteChecksumEType(etypeIDCustom)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// restoreRegistries takes a copy of both registries and restores them when the test finishes, so a test that mutates
+// the process wide registry cannot affect any other.
+func restoreRegistries(t *testing.T) {
+	t.Helper()
+
+	var etypes, chksums map[int32]etype.EType
+
+	muRegistryEType.RLock()
+
+	etypes = maps.Clone(registryEType)
+
+	muRegistryEType.RUnlock()
+
+	muRegistryChecksumEType.RLock()
+
+	chksums = maps.Clone(registryChecksumEType)
+
+	muRegistryChecksumEType.RUnlock()
+
+	t.Cleanup(func() {
+		muRegistryEType.Lock()
+		registryEType = etypes
+		muRegistryEType.Unlock()
+
+		muRegistryChecksumEType.Lock()
+		registryChecksumEType = chksums
+		muRegistryChecksumEType.Unlock()
+	})
+}
+
+func itoa(id int32) string {
+	return strconv.FormatInt(int64(id), 10)
+}

--- a/gssapi/mic_token.go
+++ b/gssapi/mic_token.go
@@ -104,7 +104,7 @@ func (mt *MICToken) checksum(key types.EncryptionKey, keyUsage uint32) (sum []by
 	copy(d[0:], mt.Payload)
 	copy(d[len(mt.Payload):], mt.getMICChecksumHeader())
 
-	encType, err := crypto.GetEtype(key.KeyType)
+	encType, err := crypto.GetEType(key.KeyType)
 	if err != nil {
 		return nil, err
 	}

--- a/gssapi/security_layer.go
+++ b/gssapi/security_layer.go
@@ -119,7 +119,7 @@ func NewSecurityLayerSession(key types.EncryptionKey, layer SecurityLayer, isIni
 		return nil, fmt.Errorf("invalid maximum buffer size: %d", maxBufferSize)
 	}
 
-	et, err := crypto.GetEtype(key.KeyType)
+	et, err := crypto.GetEType(key.KeyType)
 	if err != nil {
 		return nil, fmt.Errorf("could not get the encryption type of the session key: %w", err)
 	}

--- a/gssapi/security_layer_test.go
+++ b/gssapi/security_layer_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -21,6 +22,15 @@ import (
 	"github.com/go-krb5/krb5/iana/keyusage"
 	"github.com/go-krb5/krb5/types"
 )
+
+// TestMain registers the RFC 8429 deprecated encryption types, which crypto does not register by default. The security
+// layer tests exercise them deliberately because the library still implements them and callers may opt back in.
+func TestMain(m *testing.M) {
+	crypto.RegisterDeprecatedDes3CbcSha1Kd()
+	crypto.RegisterDeprecatedRC4HMAC()
+
+	os.Exit(m.Run())
+}
 
 // securityLayerEtypes are the encryption types a security layer session is exercised against. They cover the
 // ciphertext stealing types, the stream cipher and the one type whose message block size makes filler necessary.
@@ -38,7 +48,7 @@ var securityLayerEtypes = []int32{
 func testSecurityLayerKey(t *testing.T, id int32) types.EncryptionKey {
 	t.Helper()
 
-	et, err := crypto.GetEtype(id)
+	et, err := crypto.GetEType(id)
 	require.NoError(t, err)
 
 	kv := make([]byte, et.GetKeyByteSize())

--- a/gssapi/wrap_token.go
+++ b/gssapi/wrap_token.go
@@ -122,7 +122,7 @@ func (wt *WrapToken) computeCheckSum(key types.EncryptionKey, keyUsage uint32) (
 	copy(checksumMe[0:], wt.Payload)
 	copy(checksumMe[len(wt.Payload):], getChecksumHeader(wt.Flags, wt.SndSeqNum))
 
-	encType, err := crypto.GetEtype(key.KeyType)
+	encType, err := crypto.GetEType(key.KeyType)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func (wt *WrapToken) Unmarshal(b []byte, expectFromAcceptor bool) error {
 // Note that in certain circumstances you may need to provide a sequence number that has been defined earlier.
 // This is currently not supported.
 func NewInitiatorWrapToken(payload []byte, key types.EncryptionKey) (*WrapToken, error) {
-	encType, err := crypto.GetEtype(key.KeyType)
+	encType, err := crypto.GetEType(key.KeyType)
 	if err != nil {
 		return nil, err
 	}

--- a/iana/etypeID/constants.go
+++ b/iana/etypeID/constants.go
@@ -76,9 +76,13 @@ var ETypesByName = map[string]int32{
 	"subkey-keymaterial":           SUBKEY_KEYMATERIAL,
 }
 
-// EtypeSupported resolves the etype name string to the etype ID.
+// ETypeSupported resolves the etype name string to the etype ID.
 // If zero is returned the etype is not supported by krb5.
-func EtypeSupported(etype string) int32 {
+//
+// Deprecated: this reports the fixed set of encryption types the library implements, which is not the same as the set
+// it will use. Which encryption types are usable is decided by the crypto package registry and is configurable at
+// runtime, so resolve the name with ETypesByName and then check crypto.GetEType instead.
+func ETypeSupported(etype string) int32 {
 	// Slice of supported enctype IDs.
 	s := []int32{
 		AES128_CTS_HMAC_SHA1_96,

--- a/kadmin/passwd.go
+++ b/kadmin/passwd.go
@@ -30,7 +30,7 @@ func ChangePasswdMsg(cname types.PrincipalName, realm, password string, tkt mess
 		return
 	}
 
-	etype, err := crypto.GetEtype(sessionKey.KeyType)
+	etype, err := crypto.GetEType(sessionKey.KeyType)
 	if err != nil {
 		err = krberror.Errorf(err, krberror.KRBMsgError, "error generating subkey etype")
 		return

--- a/keytab/keytab_test.go
+++ b/keytab/keytab_test.go
@@ -12,11 +12,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-krb5/krb5/crypto"
 	"github.com/go-krb5/krb5/iana/etypeID"
 	"github.com/go-krb5/krb5/iana/nametype"
 	"github.com/go-krb5/krb5/test/testdata"
 	"github.com/go-krb5/krb5/types"
 )
+
+// TestMain registers the RFC 8429 deprecated encryption types, which crypto does not register by default. The keytab
+// tests reproduce ktutil output that includes an rc4-hmac entry.
+func TestMain(m *testing.M) {
+	crypto.RegisterDeprecatedRC4HMAC()
+
+	os.Exit(m.Run())
+}
 
 func TestUnmarshal(t *testing.T) {
 	t.Parallel()

--- a/messages/kdc_rep.go
+++ b/messages/kdc_rep.go
@@ -329,7 +329,7 @@ func (k *ASRep) Verify(cfg *config.Config, creds *credentials.Credentials, asReq
 					return false, krberror.Errorf(err, krberror.EncodingError, "KDC FAST negotiation response error, could not unmarshal PA_REQ_ENC_PA_REP")
 				}
 
-				etype, err := crypto.GetChksumEtype(pafast.ChksumType)
+				etype, err := crypto.GetChecksumEType(pafast.ChksumType)
 				if err != nil {
 					return false, krberror.Errorf(err, krberror.ChksumError, "KDC FAST negotiation response error")
 				}

--- a/messages/kdc_req.go
+++ b/messages/kdc_req.go
@@ -257,7 +257,7 @@ func (k *TGSReq) setPAData(paRealm string, tgt Ticket, sessionKey types.Encrypti
 		return krberror.Errorf(err, krberror.EncodingError, "error marshaling TGS_REQ body")
 	}
 
-	etype, err := crypto.GetEtype(sessionKey.KeyType)
+	etype, err := crypto.GetEType(sessionKey.KeyType)
 	if err != nil {
 		return krberror.Errorf(err, krberror.EncryptingError, "error getting etype to encrypt authenticator")
 	}

--- a/messages/ticket.go
+++ b/messages/ticket.go
@@ -61,7 +61,7 @@ type TransitedEncoding struct {
 
 // NewTicket creates a new Ticket instance.
 func NewTicket(cname types.PrincipalName, crealm string, sname types.PrincipalName, srealm string, flags asn1.BitString, sktab *keytab.Keytab, eTypeID int32, kvno int, authTime, startTime, endTime, renewTill time.Time) (Ticket, types.EncryptionKey, error) {
-	etype, err := crypto.GetEtype(eTypeID)
+	etype, err := crypto.GetEType(eTypeID)
 	if err != nil {
 		return Ticket{}, types.EncryptionKey{}, krberror.Errorf(err, krberror.EncryptingError, "error getting etype for new ticket")
 	}

--- a/pac/pac_type.go
+++ b/pac/pac_type.go
@@ -274,7 +274,7 @@ func (pac *PACType) verify(key types.EncryptionKey) (bool, error) {
 		return false, errors.New("PAC Info Buffers does not contain a ClientInfo")
 	}
 
-	etype, err := crypto.GetChksumEtype(int32(pac.ServerChecksum.SignatureType))
+	etype, err := crypto.GetChecksumEType(int32(pac.ServerChecksum.SignatureType))
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This adds support for an EType registry which allows customizing the Encryption Type and Checksum Type mappings. This is particularly useful in secure environments where you only want to register secure algorithms. In addition it facilitates implementers providing their own implementations which is not recommended but may be useful regardless. This also renames some functions to be consistent, and removes deprecated algorithms by default.