### PR TITLE
SPNEGO: add RFC 4178 multi-leg auth + RFC 4121 sealed wrap tokens

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5,6 +5,7 @@
 * [RFC 3961 Encryption and Checksum Specifications for Kerberos 5](https://tools.ietf.org/html/rfc3961)
 * [RFC 3962 Advanced Encryption Standard (AES) Encryption for Kerberos 5](https://tools.ietf.org/html/rfc3962)
 * [RFC 4121 The Kerberos Version 5 GSS-API Mechanism](https://tools.ietf.org/html/rfc4121)
+  * Note: DCE-style wrap tokens (RFC 4121 Section 4.2.4) rotate ciphertext by RRC bytes.
 * [RFC 4178 The Simple and Protected Generic Security Service Application Program Interface (GSS-API) Negotiation Mechanism](https://tools.ietf.org/html/rfc4178.html)
 * [RFC 4559 SPNEGO-based Kerberos and NTLM HTTP Authentication in Microsoft Windows](https://tools.ietf.org/html/rfc4559.html)
 * [RFC 4757 The RC4-HMAC Kerberos Encryption Types Used by Microsoft Windows](https://tools.ietf.org/html/rfc4757)

--- a/gssapi/wrap_token.go
+++ b/gssapi/wrap_token.go
@@ -20,6 +20,13 @@ const (
 	HdrLen = 16
 	// FillerByte is a filler in the WrapToken structure.
 	FillerByte byte = 0xFF
+
+	// WrapTokenFlagSentByAcceptor indicates the token was sent by the acceptor.
+	WrapTokenFlagSentByAcceptor byte = 0x01
+	// WrapTokenFlagSealed indicates the payload is encrypted (confidentiality).
+	WrapTokenFlagSealed byte = 0x02
+	// WrapTokenFlagAcceptorSubkey indicates the acceptor's subkey is used.
+	WrapTokenFlagAcceptorSubkey byte = 0x04
 )
 
 // WrapToken represents a GSS API Wrap token, as defined in RFC 4121.
@@ -216,4 +223,287 @@ func NewInitiatorWrapToken(payload []byte, key types.EncryptionKey) (*WrapToken,
 	}
 
 	return &token, nil
+}
+
+// SealedWrapToken represents a GSS API Wrap token with confidentiality (encryption).
+// Per RFC 4121, the encrypted portion contains { data | filler | header }.
+type SealedWrapToken struct {
+	// Flags contains: acceptor (0x01), sealed (0x02), acceptor subkey (0x04).
+	Flags byte
+	// EC is the filler length for sealed tokens.
+	EC uint16
+	// RRC is the right rotation count.
+	RRC uint16
+	// SndSeqNum is the sender's sequence number.
+	SndSeqNum uint64
+	// Payload is the decrypted user data.
+	Payload []byte
+	// Ciphertext is the encrypted data (set during Marshal, used during Unmarshal).
+	Ciphertext []byte
+}
+
+// IsSealed returns true if the token has the sealed (confidentiality) flag set.
+func (wt *WrapToken) IsSealed() bool {
+	return wt.Flags&WrapTokenFlagSealed != 0
+}
+
+// NewSealedWrapToken creates a new sealed (encrypted) wrap token.
+// The payload is encrypted along with a copy of the header per RFC 4121.
+func NewSealedWrapToken(payload []byte, key types.EncryptionKey, keyUsage uint32, flags byte, seqNum uint64) ([]byte, error) {
+	encType, err := crypto.GetEtype(key.KeyType)
+	if err != nil {
+		return nil, fmt.Errorf("error getting encryption type: %w", err)
+	}
+
+	// Set the sealed flag.
+	flags |= WrapTokenFlagSealed
+
+	// EC is the filler length. For simplicity, we use 0 filler.
+	// MIT Kerberos also uses 0 filler in production (non-CFX_EXERCISE mode).
+	ec := uint16(0)
+
+	// Build the header with EC (filler length) and RRC=0.
+	// Per RFC 4121, EC and RRC are set to 0 in the header copy used for encryption.
+	header := make([]byte, HdrLen)
+	copy(header[0:2], getGssWrapTokenId()[:])
+	header[2] = flags
+	header[3] = FillerByte
+	binary.BigEndian.PutUint16(header[4:6], ec)
+	binary.BigEndian.PutUint16(header[6:8], 0) // RRC = 0 for encryption.
+	binary.BigEndian.PutUint64(header[8:16], seqNum)
+
+	// Build plaintext: data | filler | header.
+	// Since ec=0, there's no filler bytes.
+	plaintext := make([]byte, len(payload)+int(ec)+HdrLen)
+	copy(plaintext[0:], payload)
+	// Filler would go here if ec > 0.
+	copy(plaintext[len(payload)+int(ec):], header)
+
+	// Encrypt the plaintext.
+	_, ciphertext, err := encType.EncryptMessage(key.KeyValue, plaintext, keyUsage)
+	if err != nil {
+		return nil, fmt.Errorf("error encrypting wrap token: %w", err)
+	}
+
+	// Build the final token: header | ciphertext.
+	// Update EC in header to reflect actual filler length (still 0).
+	token := make([]byte, HdrLen+len(ciphertext))
+	copy(token[0:HdrLen], header)
+	copy(token[HdrLen:], ciphertext)
+
+	return token, nil
+}
+
+// parseSealedHeader parses and validates the header of a sealed wrap token.
+func parseSealedHeader(tokenBytes []byte, expectFromAcceptor bool) (flags byte, ec, rrc uint16, seqNum uint64, err error) {
+	if len(tokenBytes) < HdrLen {
+		return 0, 0, 0, 0, errors.New("token too short")
+	}
+
+	// Verify token ID.
+	if !bytes.Equal(getGssWrapTokenId()[:], tokenBytes[0:2]) {
+		return 0, 0, 0, 0, fmt.Errorf("wrong Token ID. Expected %s, was %s",
+			hex.EncodeToString(getGssWrapTokenId()[:]),
+			hex.EncodeToString(tokenBytes[0:2]))
+	}
+
+	flags = tokenBytes[2]
+
+	// Verify sealed flag is set.
+	if flags&WrapTokenFlagSealed == 0 {
+		return 0, 0, 0, 0, errors.New("token is not sealed (use Unwrap for sign-only tokens)")
+	}
+
+	// Check the acceptor flag.
+	if err := validateAcceptorFlag(flags, expectFromAcceptor); err != nil {
+		return 0, 0, 0, 0, err
+	}
+
+	// Check the filler byte.
+	if tokenBytes[3] != FillerByte {
+		return 0, 0, 0, 0, fmt.Errorf("unexpected filler byte: expecting 0xFF, was %s",
+			hex.EncodeToString(tokenBytes[3:4]))
+	}
+
+	ec = binary.BigEndian.Uint16(tokenBytes[4:6])
+	rrc = binary.BigEndian.Uint16(tokenBytes[6:8])
+	seqNum = binary.BigEndian.Uint64(tokenBytes[8:16])
+
+	return flags, ec, rrc, seqNum, nil
+}
+
+// validateAcceptorFlag checks if the acceptor flag matches expectations.
+func validateAcceptorFlag(flags byte, expectFromAcceptor bool) error {
+	isFromAcceptor := flags&WrapTokenFlagSentByAcceptor != 0
+
+	if isFromAcceptor && !expectFromAcceptor {
+		return errors.New("unexpected acceptor flag is set")
+	}
+
+	if !isFromAcceptor && expectFromAcceptor {
+		return errors.New("expected acceptor flag is not set")
+	}
+
+	return nil
+}
+
+// buildExpectedHeader constructs the expected header for verification.
+func buildExpectedHeader(flags byte, ec uint16, seqNum uint64) []byte {
+	header := make([]byte, HdrLen)
+	copy(header[0:2], getGssWrapTokenId()[:])
+	header[2] = flags
+	header[3] = FillerByte
+	binary.BigEndian.PutUint16(header[4:6], ec)
+	binary.BigEndian.PutUint16(header[6:8], 0) // RRC was 0 during encryption.
+	binary.BigEndian.PutUint64(header[8:16], seqNum)
+
+	return header
+}
+
+// UnwrapSealed decrypts a sealed wrap token and returns the payload.
+// It verifies the token structure and integrity per RFC 4121.
+func UnwrapSealed(tokenBytes []byte, key types.EncryptionKey, keyUsage uint32, expectFromAcceptor bool) ([]byte, error) {
+	flags, ec, rrc, seqNum, err := parseSealedHeader(tokenBytes, expectFromAcceptor)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the ciphertext and undo RRC rotation if needed.
+	ciphertext := make([]byte, len(tokenBytes)-HdrLen)
+	copy(ciphertext, tokenBytes[HdrLen:])
+
+	if rrc > 0 && len(ciphertext) > 0 {
+		rotateRight(ciphertext, int(rrc))
+	}
+
+	// Decrypt the ciphertext.
+	encType, err := crypto.GetEtype(key.KeyType)
+	if err != nil {
+		return nil, fmt.Errorf("error getting encryption type: %w", err)
+	}
+
+	plaintext, err := encType.DecryptMessage(key.KeyValue, ciphertext, keyUsage)
+	if err != nil {
+		return nil, fmt.Errorf("error decrypting wrap token: %w", err)
+	}
+
+	// The plaintext is: data | filler | header.
+	if len(plaintext) < HdrLen+int(ec) {
+		return nil, errors.New("decrypted data too short")
+	}
+
+	// Extract and verify the header.
+	headerOffset := len(plaintext) - HdrLen
+	decryptedHeader := plaintext[headerOffset:]
+	expectedHeader := buildExpectedHeader(flags, ec, seqNum)
+
+	if !bytes.Equal(decryptedHeader, expectedHeader) {
+		return nil, errors.New("header mismatch in decrypted data")
+	}
+
+	// Extract the payload (skip filler).
+	payloadLen := headerOffset - int(ec)
+	if payloadLen < 0 {
+		return nil, errors.New("invalid filler length")
+	}
+
+	return plaintext[:payloadLen], nil
+}
+
+// UnwrapResult contains the result of unwrapping a token.
+type UnwrapResult struct {
+	// Payload is the decrypted/verified data.
+	Payload []byte
+	// Sealed indicates whether the token was encrypted (true) or sign-only (false).
+	Sealed bool
+	// SeqNum is the sequence number from the token.
+	SeqNum uint64
+}
+
+// Unwrap automatically detects whether a token is sealed or sign-only and processes it accordingly.
+// This provides a unified API similar to SSPI's DecryptMessage.
+// Returns the payload, whether it was sealed, and any error.
+func Unwrap(tokenBytes []byte, key types.EncryptionKey, keyUsage uint32, expectFromAcceptor bool) (*UnwrapResult, error) {
+	if len(tokenBytes) < HdrLen {
+		return nil, errors.New("token too short")
+	}
+
+	// Verify token ID.
+	if !bytes.Equal(getGssWrapTokenId()[:], tokenBytes[0:2]) {
+		return nil, fmt.Errorf("wrong Token ID. Expected %s, was %s",
+			hex.EncodeToString(getGssWrapTokenId()[:]),
+			hex.EncodeToString(tokenBytes[0:2]))
+	}
+
+	flags := tokenBytes[2]
+
+	// Check direction.
+	if err := validateAcceptorFlag(flags, expectFromAcceptor); err != nil {
+		return nil, err
+	}
+
+	// Check the filler byte.
+	if tokenBytes[3] != FillerByte {
+		return nil, fmt.Errorf("unexpected filler byte: expecting 0xFF, was %s",
+			hex.EncodeToString(tokenBytes[3:4]))
+	}
+
+	seqNum := binary.BigEndian.Uint64(tokenBytes[8:16])
+
+	// Dispatch based on sealed flag.
+	if flags&WrapTokenFlagSealed != 0 {
+		payload, err := UnwrapSealed(tokenBytes, key, keyUsage, expectFromAcceptor)
+		if err != nil {
+			return nil, err
+		}
+
+		return &UnwrapResult{
+			Payload: payload,
+			Sealed:  true,
+			SeqNum:  seqNum,
+		}, nil
+	}
+
+	// Sign-only token - parse and verify.
+	var wt WrapToken
+	if err := wt.Unmarshal(tokenBytes, expectFromAcceptor); err != nil {
+		return nil, err
+	}
+
+	ok, err := wt.Verify(key, keyUsage)
+	if err != nil {
+		return nil, fmt.Errorf("error verifying wrap token: %w", err)
+	}
+
+	if !ok {
+		return nil, errors.New("wrap token verification failed")
+	}
+
+	return &UnwrapResult{
+		Payload: wt.Payload,
+		Sealed:  false,
+		SeqNum:  wt.SndSeqNum,
+	}, nil
+}
+
+// rotateRight performs a right rotation of the data by n bytes.
+// This undoes the RRC (Right Rotation Count) applied by the sender.
+func rotateRight(data []byte, n int) {
+	if len(data) == 0 {
+		return
+	}
+
+	n %= len(data)
+	if n == 0 {
+		return
+	}
+
+	// Right rotation by n is equivalent to left rotation by len-n.
+	leftRotate := len(data) - n
+
+	// Use a temporary buffer.
+	tmp := make([]byte, leftRotate)
+	copy(tmp, data[:leftRotate])
+	copy(data, data[leftRotate:])
+	copy(data[n:], tmp)
 }

--- a/gssapi/wrap_token.go
+++ b/gssapi/wrap_token.go
@@ -247,9 +247,28 @@ func (wt *WrapToken) IsSealed() bool {
 	return wt.Flags&WrapTokenFlagSealed != 0
 }
 
-// NewSealedWrapToken creates a new sealed (encrypted) wrap token.
-// The payload is encrypted along with a copy of the header per RFC 4121.
-func NewSealedWrapToken(payload []byte, key types.EncryptionKey, keyUsage uint32, flags byte, seqNum uint64) ([]byte, error) {
+// NewSealedWrapToken creates a new sealed (encrypted) wrap token per RFC 4121.
+// This produces a standard CFX wrap token (RRC=0, no rotation). For DCE-style
+// tokens (used by WSMan/PSRP), use NewSealedWrapTokenDCE.
+func NewSealedWrapToken(payload []byte, key types.EncryptionKey, keyUsage uint32, flags byte, seqNum uint64, ec uint16) ([]byte, error) {
+	return newSealedWrapToken(payload, key, keyUsage, flags, seqNum, ec, false)
+}
+
+// NewSealedWrapTokenDCE creates a DCE-style sealed wrap token per RFC 4121
+// Section 4.2.4. The ciphertext is rotated right by RRC bytes.
+//
+// The ec parameter controls the filler/padding length:
+// - EC = 0: No filler bytes (Windows WinRM mode)
+//   RRC = confounder(16) + checksum(12) = 28 bytes
+// - EC = 16: One AES block of padding (MS-KILE mode)
+//   RRC = EC(16) + confounder(16) + checksum(12) = 44 bytes
+//
+// See: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/e94b3acd-8415-4d0d-9786-749d0c39d550
+func NewSealedWrapTokenDCE(payload []byte, key types.EncryptionKey, keyUsage uint32, flags byte, seqNum uint64, ec uint16) ([]byte, error) {
+	return newSealedWrapToken(payload, key, keyUsage, flags, seqNum, ec, true)
+}
+
+func newSealedWrapToken(payload []byte, key types.EncryptionKey, keyUsage uint32, flags byte, seqNum uint64, ec uint16, dceStyle bool) ([]byte, error) {
 	encType, err := crypto.GetEtype(key.KeyType)
 	if err != nil {
 		return nil, fmt.Errorf("error getting encryption type: %w", err)
@@ -258,12 +277,19 @@ func NewSealedWrapToken(payload []byte, key types.EncryptionKey, keyUsage uint32
 	// Set the sealed flag.
 	flags |= WrapTokenFlagSealed
 
-	// EC is the filler length. For simplicity, we use 0 filler.
-	// MIT Kerberos also uses 0 filler in production (non-CFX_EXERCISE mode).
-	ec := uint16(0)
+	// Calculate RRC for DCE-style rotation.
+	// RRC = EC + confounder + checksum
+	// When EC=0 (WinRM): RRC = 0 + 16 + 12 = 28 for AES-SHA1
+	// When EC=16 (MS-KILE): RRC = 16 + 16 + 12 = 44 for AES-SHA1
+	checksumLen := uint16(encType.GetHMACBitLength() / 8)
+	confounderLen := uint16(encType.GetConfounderByteSize())
+	var rrc uint16
+	if dceStyle {
+		rrc = ec + confounderLen + checksumLen
+	}
 
-	// Build the header with EC (filler length) and RRC=0.
-	// Per RFC 4121, EC and RRC are set to 0 in the header copy used for encryption.
+	// Build the header with EC and RRC=0 for the encrypted copy.
+	// Per RFC 4121, the header included in encryption has EC and RRC set to 0.
 	header := make([]byte, HdrLen)
 	copy(header[0:2], getGssWrapTokenId()[:])
 	header[2] = flags
@@ -273,10 +299,10 @@ func NewSealedWrapToken(payload []byte, key types.EncryptionKey, keyUsage uint32
 	binary.BigEndian.PutUint64(header[8:16], seqNum)
 
 	// Build plaintext: data | filler | header.
-	// Since ec=0, there's no filler bytes.
+	// The filler is EC bytes of padding (value 0x00).
 	plaintext := make([]byte, len(payload)+int(ec)+HdrLen)
 	copy(plaintext[0:], payload)
-	// Filler would go here if ec > 0.
+	// Filler bytes (ec bytes of 0x00) are already zero from make().
 	copy(plaintext[len(payload)+int(ec):], header)
 
 	// Encrypt the plaintext.
@@ -285,10 +311,17 @@ func NewSealedWrapToken(payload []byte, key types.EncryptionKey, keyUsage uint32
 		return nil, fmt.Errorf("error encrypting wrap token: %w", err)
 	}
 
-	// Build the final token: header | ciphertext.
-	// Update EC in header to reflect actual filler length (still 0).
+	// Apply DCE-style right rotation by RRC bytes.
+	// This moves the trailing metadata (checksum, confounder portion) to the front.
+	if dceStyle && rrc > 0 && len(ciphertext) > 0 {
+		rotateRight(ciphertext, int(rrc))
+	}
+
+	// Build the final token: header | rotated_ciphertext.
+	// The outer header has the actual RRC value (not 0).
 	token := make([]byte, HdrLen+len(ciphertext))
 	copy(token[0:HdrLen], header)
+	binary.BigEndian.PutUint16(token[6:8], rrc) // Set actual RRC in outer header.
 	copy(token[HdrLen:], ciphertext)
 
 	return token, nil
@@ -369,11 +402,12 @@ func UnwrapSealed(tokenBytes []byte, key types.EncryptionKey, keyUsage uint32, e
 	}
 
 	// Get the ciphertext and undo RRC rotation if needed.
+	// The sender applied right rotation, so we apply left rotation to undo.
 	ciphertext := make([]byte, len(tokenBytes)-HdrLen)
 	copy(ciphertext, tokenBytes[HdrLen:])
 
 	if rrc > 0 && len(ciphertext) > 0 {
-		rotateRight(ciphertext, int(rrc))
+		rotateLeft(ciphertext, int(rrc))
 	}
 
 	// Decrypt the ciphertext.
@@ -486,8 +520,29 @@ func Unwrap(tokenBytes []byte, key types.EncryptionKey, keyUsage uint32, expectF
 	}, nil
 }
 
+// GetSealedTokenRRC returns the RRC (Right Rotation Count) from a sealed wrap token.
+// This is useful for MS-WSMV format where SignatureLength = HdrLen + RRC.
+func GetSealedTokenRRC(tokenBytes []byte) (uint16, error) {
+	if len(tokenBytes) < HdrLen {
+		return 0, errors.New("token too short")
+	}
+
+	// Verify token ID.
+	if !bytes.Equal(getGssWrapTokenId()[:], tokenBytes[0:2]) {
+		return 0, errors.New("wrong Token ID")
+	}
+
+	// Verify sealed flag is set.
+	if tokenBytes[2]&WrapTokenFlagSealed == 0 {
+		return 0, errors.New("token is not sealed")
+	}
+
+	return binary.BigEndian.Uint16(tokenBytes[6:8]), nil
+}
+
 // rotateRight performs a right rotation of the data by n bytes.
-// This undoes the RRC (Right Rotation Count) applied by the sender.
+// After right rotation, the last n bytes move to the front.
+// Used by sender to apply DCE-style rotation.
 func rotateRight(data []byte, n int) {
 	if len(data) == 0 {
 		return
@@ -506,4 +561,24 @@ func rotateRight(data []byte, n int) {
 	copy(tmp, data[:leftRotate])
 	copy(data, data[leftRotate:])
 	copy(data[n:], tmp)
+}
+
+// rotateLeft performs a left rotation of the data by n bytes.
+// After left rotation, the first n bytes move to the end.
+// Used by receiver to undo DCE-style rotation.
+func rotateLeft(data []byte, n int) {
+	if len(data) == 0 {
+		return
+	}
+
+	n %= len(data)
+	if n == 0 {
+		return
+	}
+
+	// Left rotation: first n bytes move to end.
+	tmp := make([]byte, n)
+	copy(tmp, data[:n])
+	copy(data, data[n:])
+	copy(data[len(data)-n:], tmp)
 }

--- a/gssapi/wrap_token_test.go
+++ b/gssapi/wrap_token_test.go
@@ -211,3 +211,386 @@ func TestNewInitiatorTokenSignatureAndMarshalling(t *testing.T) {
 	assert.Nil(t, tErr)
 	assert.Equal(t, getResponseReference(), token)
 }
+
+// Tests for sealed (encrypted) wrap tokens.
+
+func getAES256Key() types.EncryptionKey {
+	// 32-byte key for AES256-CTS-HMAC-SHA1-96.
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i)
+	}
+
+	return types.EncryptionKey{
+		KeyType:  18, // AES256-CTS-HMAC-SHA1-96.
+		KeyValue: key,
+	}
+}
+
+func TestSealedWrapToken_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	key := getAES256Key()
+	payload := []byte("test payload for sealed wrap token")
+
+	// Create a sealed token as initiator.
+	var flags byte = 0 // Initiator.
+
+	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, flags, 12345)
+	require.NoError(t, err)
+	require.NotNil(t, tokenBytes)
+
+	// Verify the token has the sealed flag.
+	assert.Equal(t, byte(0x05), tokenBytes[0])
+	assert.Equal(t, byte(0x04), tokenBytes[1])
+	assert.Equal(t, WrapTokenFlagSealed, tokenBytes[2]&WrapTokenFlagSealed)
+
+	// Decrypt the token.
+	decrypted, err := UnwrapSealed(tokenBytes, key, initiatorSeal, false)
+	require.NoError(t, err)
+	assert.Equal(t, payload, decrypted)
+}
+
+func TestSealedWrapToken_Acceptor(t *testing.T) {
+	t.Parallel()
+
+	key := getAES256Key()
+	payload := []byte("response from acceptor")
+
+	// Create a sealed token as acceptor.
+	flags := WrapTokenFlagSentByAcceptor
+
+	tokenBytes, err := NewSealedWrapToken(payload, key, acceptorSeal, flags, 99999)
+	require.NoError(t, err)
+
+	// Verify flags.
+	assert.Equal(t, WrapTokenFlagSentByAcceptor|WrapTokenFlagSealed, tokenBytes[2])
+
+	// Decrypt expecting from acceptor.
+	decrypted, err := UnwrapSealed(tokenBytes, key, acceptorSeal, true)
+	require.NoError(t, err)
+	assert.Equal(t, payload, decrypted)
+}
+
+func TestSealedWrapToken_WithAcceptorSubkey(t *testing.T) {
+	t.Parallel()
+
+	key := getAES256Key()
+	payload := []byte("data with acceptor subkey")
+
+	// Create a sealed token with acceptor subkey flag.
+	flags := WrapTokenFlagAcceptorSubkey
+
+	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, flags, 1)
+	require.NoError(t, err)
+
+	// Verify flags.
+	expectedFlags := WrapTokenFlagAcceptorSubkey | WrapTokenFlagSealed
+	assert.Equal(t, expectedFlags, tokenBytes[2])
+
+	// Decrypt.
+	decrypted, err := UnwrapSealed(tokenBytes, key, initiatorSeal, false)
+	require.NoError(t, err)
+	assert.Equal(t, payload, decrypted)
+}
+
+func TestSealedWrapToken_EmptyPayload(t *testing.T) {
+	t.Parallel()
+
+	key := getAES256Key()
+	payload := []byte{}
+
+	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, 0, 0)
+	require.NoError(t, err)
+
+	decrypted, err := UnwrapSealed(tokenBytes, key, initiatorSeal, false)
+	require.NoError(t, err)
+	assert.Equal(t, payload, decrypted)
+}
+
+func TestSealedWrapToken_LargePayload(t *testing.T) {
+	t.Parallel()
+
+	key := getAES256Key()
+
+	// Create a large payload.
+	payload := make([]byte, 64*1024) // 64KB.
+	for i := range payload {
+		payload[i] = byte(i % 256)
+	}
+
+	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, 0, 0)
+	require.NoError(t, err)
+
+	decrypted, err := UnwrapSealed(tokenBytes, key, initiatorSeal, false)
+	require.NoError(t, err)
+	assert.Equal(t, payload, decrypted)
+}
+
+func TestSealedWrapToken_WrongKey(t *testing.T) {
+	t.Parallel()
+
+	key := getAES256Key()
+	payload := []byte("secret data")
+
+	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, 0, 0)
+	require.NoError(t, err)
+
+	// Try to decrypt with wrong key.
+	wrongKey := getAES256Key()
+	wrongKey.KeyValue[0] = 0xFF
+
+	_, err = UnwrapSealed(tokenBytes, wrongKey, initiatorSeal, false)
+	assert.Error(t, err)
+}
+
+func TestSealedWrapToken_WrongKeyUsage(t *testing.T) {
+	t.Parallel()
+
+	key := getAES256Key()
+	payload := []byte("test data")
+
+	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, 0, 0)
+	require.NoError(t, err)
+
+	// Try to decrypt with wrong key usage.
+	_, err = UnwrapSealed(tokenBytes, key, acceptorSeal, false)
+	assert.Error(t, err)
+}
+
+func TestSealedWrapToken_WrongDirection(t *testing.T) {
+	t.Parallel()
+
+	key := getAES256Key()
+	payload := []byte("test data")
+
+	// Create token from initiator.
+	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, 0, 0)
+	require.NoError(t, err)
+
+	// Try to unwrap expecting from acceptor.
+	_, err = UnwrapSealed(tokenBytes, key, initiatorSeal, true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected acceptor flag")
+}
+
+func TestSealedWrapToken_TruncatedToken(t *testing.T) {
+	t.Parallel()
+
+	key := getAES256Key()
+
+	// Token shorter than header.
+	_, err := UnwrapSealed([]byte{0x05, 0x04}, key, initiatorSeal, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "token too short")
+}
+
+func TestSealedWrapToken_NotSealed(t *testing.T) {
+	t.Parallel()
+
+	key := getAES256Key()
+
+	// Create a sign-only token.
+	signOnlyToken, err := NewInitiatorWrapToken([]byte{0x01, 0x02}, getSessionKey())
+	require.NoError(t, err)
+
+	tokenBytes, err := signOnlyToken.Marshal()
+	require.NoError(t, err)
+
+	// Try to unwrap as sealed.
+	_, err = UnwrapSealed(tokenBytes, key, initiatorSeal, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not sealed")
+}
+
+func TestSealedWrapToken_CorruptedCiphertext(t *testing.T) {
+	t.Parallel()
+
+	key := getAES256Key()
+	payload := []byte("test data")
+
+	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, 0, 0)
+	require.NoError(t, err)
+
+	// Corrupt the ciphertext.
+	tokenBytes[HdrLen] ^= 0xFF
+
+	_, err = UnwrapSealed(tokenBytes, key, initiatorSeal, false)
+	assert.Error(t, err)
+}
+
+func TestIsSealed(t *testing.T) {
+	t.Parallel()
+
+	// Sign-only token.
+	signOnly := &WrapToken{Flags: 0x00}
+	assert.False(t, signOnly.IsSealed())
+
+	// Sealed token.
+	sealed := &WrapToken{Flags: WrapTokenFlagSealed}
+	assert.True(t, sealed.IsSealed())
+
+	// Sealed from acceptor.
+	sealedFromAcceptor := &WrapToken{Flags: WrapTokenFlagSealed | WrapTokenFlagSentByAcceptor}
+	assert.True(t, sealedFromAcceptor.IsSealed())
+}
+
+func TestRotateRight(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    []byte
+		n        int
+		expected []byte
+	}{
+		{
+			name:     "no rotation",
+			input:    []byte{1, 2, 3, 4, 5},
+			n:        0,
+			expected: []byte{1, 2, 3, 4, 5},
+		},
+		{
+			name:     "rotate by 1",
+			input:    []byte{1, 2, 3, 4, 5},
+			n:        1,
+			expected: []byte{5, 1, 2, 3, 4},
+		},
+		{
+			name:     "rotate by 2",
+			input:    []byte{1, 2, 3, 4, 5},
+			n:        2,
+			expected: []byte{4, 5, 1, 2, 3},
+		},
+		{
+			name:     "rotate by length (full cycle)",
+			input:    []byte{1, 2, 3, 4, 5},
+			n:        5,
+			expected: []byte{1, 2, 3, 4, 5},
+		},
+		{
+			name:     "rotate by more than length",
+			input:    []byte{1, 2, 3, 4, 5},
+			n:        7,
+			expected: []byte{4, 5, 1, 2, 3}, // Same as 7 % 5 = 2.
+		},
+		{
+			name:     "empty slice",
+			input:    []byte{},
+			n:        5,
+			expected: []byte{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data := make([]byte, len(tc.input))
+			copy(data, tc.input)
+			rotateRight(data, tc.n)
+			assert.Equal(t, tc.expected, data)
+		})
+	}
+}
+
+// Tests for auto-detect Unwrap function.
+
+func TestUnwrap_AutoDetectSealed(t *testing.T) {
+	t.Parallel()
+
+	key := getAES256Key()
+	payload := []byte("sealed message for auto-detect")
+
+	// Create a sealed token.
+	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, 0, 42)
+	require.NoError(t, err)
+
+	// Use auto-detect Unwrap.
+	result, err := Unwrap(tokenBytes, key, initiatorSeal, false)
+	require.NoError(t, err)
+
+	assert.Equal(t, payload, result.Payload)
+	assert.True(t, result.Sealed, "should detect as sealed")
+	assert.Equal(t, uint64(42), result.SeqNum)
+}
+
+func TestUnwrap_AutoDetectSignOnly(t *testing.T) {
+	t.Parallel()
+
+	key := getSessionKey()
+	payload := []byte{0x01, 0x01, 0x00, 0x00}
+
+	// Create a sign-only token.
+	token, err := NewInitiatorWrapToken(payload, key)
+	require.NoError(t, err)
+
+	tokenBytes, err := token.Marshal()
+	require.NoError(t, err)
+
+	// Use auto-detect Unwrap.
+	result, err := Unwrap(tokenBytes, key, initiatorSeal, false)
+	require.NoError(t, err)
+
+	assert.Equal(t, payload, result.Payload)
+	assert.False(t, result.Sealed, "should detect as sign-only")
+	assert.Equal(t, uint64(0), result.SeqNum)
+}
+
+func TestUnwrap_AutoDetectFromAcceptor(t *testing.T) {
+	t.Parallel()
+
+	key := getAES256Key()
+	payload := []byte("response from server")
+
+	// Create a sealed token from acceptor.
+	tokenBytes, err := NewSealedWrapToken(payload, key, acceptorSeal, WrapTokenFlagSentByAcceptor, 100)
+	require.NoError(t, err)
+
+	// Use auto-detect Unwrap expecting from acceptor.
+	result, err := Unwrap(tokenBytes, key, acceptorSeal, true)
+	require.NoError(t, err)
+
+	assert.Equal(t, payload, result.Payload)
+	assert.True(t, result.Sealed)
+	assert.Equal(t, uint64(100), result.SeqNum)
+}
+
+func TestUnwrap_AutoDetectWrongDirection(t *testing.T) {
+	t.Parallel()
+
+	key := getAES256Key()
+	payload := []byte("test")
+
+	// Create a sealed token from initiator.
+	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, 0, 0)
+	require.NoError(t, err)
+
+	// Try to unwrap expecting from acceptor - should fail.
+	_, err = Unwrap(tokenBytes, key, initiatorSeal, true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected acceptor flag")
+}
+
+func TestUnwrap_TooShort(t *testing.T) {
+	t.Parallel()
+
+	key := getAES256Key()
+
+	_, err := Unwrap([]byte{0x05}, key, initiatorSeal, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "token too short")
+}
+
+func TestUnwrap_WrongTokenID(t *testing.T) {
+	t.Parallel()
+
+	key := getAES256Key()
+
+	// Invalid token ID.
+	badToken := make([]byte, HdrLen)
+	badToken[0] = 0x00
+	badToken[1] = 0x00
+
+	_, err := Unwrap(badToken, key, initiatorSeal, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "wrong Token ID")
+}

--- a/gssapi/wrap_token_test.go
+++ b/gssapi/wrap_token_test.go
@@ -236,7 +236,7 @@ func TestSealedWrapToken_RoundTrip(t *testing.T) {
 	// Create a sealed token as initiator.
 	var flags byte = 0 // Initiator.
 
-	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, flags, 12345)
+	tokenBytes, err := NewSealedWrapTokenDCE(payload, key, initiatorSeal, flags, 12345, 16)
 	require.NoError(t, err)
 	require.NotNil(t, tokenBytes)
 
@@ -251,6 +251,40 @@ func TestSealedWrapToken_RoundTrip(t *testing.T) {
 	assert.Equal(t, payload, decrypted)
 }
 
+func TestSealedWrapToken_MSKILE_EC_RRC(t *testing.T) {
+	t.Parallel()
+
+	key := getAES256Key()
+	payload := []byte("test payload")
+
+	tokenBytes, err := NewSealedWrapTokenDCE(payload, key, initiatorSeal, 0, 0, 16)
+	require.NoError(t, err)
+
+	// Verify EC and RRC values per MS-KILE specification.
+	// For AES256-CTS-HMAC-SHA1-96:
+	// - EC = 16 (one AES block)
+	// - RRC = EC + confounder + checksum = 16 + 16 + 12 = 44
+	ec := binary.BigEndian.Uint16(tokenBytes[4:6])
+	rrc := binary.BigEndian.Uint16(tokenBytes[6:8])
+
+	assert.Equal(t, uint16(16), ec, "EC should be 16 (one AES block) for MS-KILE compatibility")
+	assert.Equal(t, uint16(44), rrc, "RRC should be 44 (EC + confounder + checksum) for MS-KILE compatibility")
+
+	// Verify SignatureLength calculation for MS-WSMV format.
+	signatureLen := HdrLen + int(rrc)
+	assert.Equal(t, 60, signatureLen, "SignatureLength should be 60 (16 header + 44 RRC)")
+
+	// Verify the helper function works.
+	extractedRRC, err := GetSealedTokenRRC(tokenBytes)
+	require.NoError(t, err)
+	assert.Equal(t, uint16(44), extractedRRC)
+
+	// Verify round-trip still works with the new EC/RRC values.
+	decrypted, err := UnwrapSealed(tokenBytes, key, initiatorSeal, false)
+	require.NoError(t, err)
+	assert.Equal(t, payload, decrypted)
+}
+
 func TestSealedWrapToken_Acceptor(t *testing.T) {
 	t.Parallel()
 
@@ -260,7 +294,7 @@ func TestSealedWrapToken_Acceptor(t *testing.T) {
 	// Create a sealed token as acceptor.
 	flags := WrapTokenFlagSentByAcceptor
 
-	tokenBytes, err := NewSealedWrapToken(payload, key, acceptorSeal, flags, 99999)
+	tokenBytes, err := NewSealedWrapTokenDCE(payload, key, acceptorSeal, flags, 99999, 16)
 	require.NoError(t, err)
 
 	// Verify flags.
@@ -281,7 +315,7 @@ func TestSealedWrapToken_WithAcceptorSubkey(t *testing.T) {
 	// Create a sealed token with acceptor subkey flag.
 	flags := WrapTokenFlagAcceptorSubkey
 
-	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, flags, 1)
+	tokenBytes, err := NewSealedWrapTokenDCE(payload, key, initiatorSeal, flags, 1, 16)
 	require.NoError(t, err)
 
 	// Verify flags.
@@ -300,7 +334,7 @@ func TestSealedWrapToken_EmptyPayload(t *testing.T) {
 	key := getAES256Key()
 	payload := []byte{}
 
-	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, 0, 0)
+	tokenBytes, err := NewSealedWrapTokenDCE(payload, key, initiatorSeal, 0, 0, 16)
 	require.NoError(t, err)
 
 	decrypted, err := UnwrapSealed(tokenBytes, key, initiatorSeal, false)
@@ -319,7 +353,7 @@ func TestSealedWrapToken_LargePayload(t *testing.T) {
 		payload[i] = byte(i % 256)
 	}
 
-	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, 0, 0)
+	tokenBytes, err := NewSealedWrapTokenDCE(payload, key, initiatorSeal, 0, 0, 16)
 	require.NoError(t, err)
 
 	decrypted, err := UnwrapSealed(tokenBytes, key, initiatorSeal, false)
@@ -333,7 +367,7 @@ func TestSealedWrapToken_WrongKey(t *testing.T) {
 	key := getAES256Key()
 	payload := []byte("secret data")
 
-	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, 0, 0)
+	tokenBytes, err := NewSealedWrapTokenDCE(payload, key, initiatorSeal, 0, 0, 16)
 	require.NoError(t, err)
 
 	// Try to decrypt with wrong key.
@@ -350,7 +384,7 @@ func TestSealedWrapToken_WrongKeyUsage(t *testing.T) {
 	key := getAES256Key()
 	payload := []byte("test data")
 
-	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, 0, 0)
+	tokenBytes, err := NewSealedWrapTokenDCE(payload, key, initiatorSeal, 0, 0, 16)
 	require.NoError(t, err)
 
 	// Try to decrypt with wrong key usage.
@@ -365,7 +399,7 @@ func TestSealedWrapToken_WrongDirection(t *testing.T) {
 	payload := []byte("test data")
 
 	// Create token from initiator.
-	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, 0, 0)
+	tokenBytes, err := NewSealedWrapTokenDCE(payload, key, initiatorSeal, 0, 0, 16)
 	require.NoError(t, err)
 
 	// Try to unwrap expecting from acceptor.
@@ -409,7 +443,7 @@ func TestSealedWrapToken_CorruptedCiphertext(t *testing.T) {
 	key := getAES256Key()
 	payload := []byte("test data")
 
-	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, 0, 0)
+	tokenBytes, err := NewSealedWrapTokenDCE(payload, key, initiatorSeal, 0, 0, 16)
 	require.NoError(t, err)
 
 	// Corrupt the ciphertext.
@@ -492,6 +526,88 @@ func TestRotateRight(t *testing.T) {
 	}
 }
 
+func TestRotateLeft(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    []byte
+		n        int
+		expected []byte
+	}{
+		{
+			name:     "no rotation",
+			input:    []byte{1, 2, 3, 4, 5},
+			n:        0,
+			expected: []byte{1, 2, 3, 4, 5},
+		},
+		{
+			name:     "rotate by 1",
+			input:    []byte{1, 2, 3, 4, 5},
+			n:        1,
+			expected: []byte{2, 3, 4, 5, 1},
+		},
+		{
+			name:     "rotate by 2",
+			input:    []byte{1, 2, 3, 4, 5},
+			n:        2,
+			expected: []byte{3, 4, 5, 1, 2},
+		},
+		{
+			name:     "rotate by length (full cycle)",
+			input:    []byte{1, 2, 3, 4, 5},
+			n:        5,
+			expected: []byte{1, 2, 3, 4, 5},
+		},
+		{
+			name:     "rotate by more than length",
+			input:    []byte{1, 2, 3, 4, 5},
+			n:        7,
+			expected: []byte{3, 4, 5, 1, 2}, // Same as 7 % 5 = 2.
+		},
+		{
+			name:     "empty slice",
+			input:    []byte{},
+			n:        5,
+			expected: []byte{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data := make([]byte, len(tc.input))
+			copy(data, tc.input)
+			rotateLeft(data, tc.n)
+			assert.Equal(t, tc.expected, data)
+		})
+	}
+}
+
+func TestRotateLeftRightInverse(t *testing.T) {
+	t.Parallel()
+
+	// Rotating left by n and then right by n should give original.
+	original := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	for n := 0; n <= len(original)+2; n++ {
+		data := make([]byte, len(original))
+		copy(data, original)
+
+		rotateRight(data, n)
+		rotateLeft(data, n)
+		assert.Equal(t, original, data, "rotateRight then rotateLeft with n=%d", n)
+	}
+
+	// Rotating right by n and then left by n should also give original.
+	for n := 0; n <= len(original)+2; n++ {
+		data := make([]byte, len(original))
+		copy(data, original)
+
+		rotateLeft(data, n)
+		rotateRight(data, n)
+		assert.Equal(t, original, data, "rotateLeft then rotateRight with n=%d", n)
+	}
+}
+
 // Tests for auto-detect Unwrap function.
 
 func TestUnwrap_AutoDetectSealed(t *testing.T) {
@@ -501,7 +617,7 @@ func TestUnwrap_AutoDetectSealed(t *testing.T) {
 	payload := []byte("sealed message for auto-detect")
 
 	// Create a sealed token.
-	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, 0, 42)
+	tokenBytes, err := NewSealedWrapTokenDCE(payload, key, initiatorSeal, 0, 42, 16)
 	require.NoError(t, err)
 
 	// Use auto-detect Unwrap.
@@ -542,7 +658,7 @@ func TestUnwrap_AutoDetectFromAcceptor(t *testing.T) {
 	payload := []byte("response from server")
 
 	// Create a sealed token from acceptor.
-	tokenBytes, err := NewSealedWrapToken(payload, key, acceptorSeal, WrapTokenFlagSentByAcceptor, 100)
+	tokenBytes, err := NewSealedWrapTokenDCE(payload, key, acceptorSeal, WrapTokenFlagSentByAcceptor, 100, 16)
 	require.NoError(t, err)
 
 	// Use auto-detect Unwrap expecting from acceptor.
@@ -561,7 +677,7 @@ func TestUnwrap_AutoDetectWrongDirection(t *testing.T) {
 	payload := []byte("test")
 
 	// Create a sealed token from initiator.
-	tokenBytes, err := NewSealedWrapToken(payload, key, initiatorSeal, 0, 0)
+	tokenBytes, err := NewSealedWrapTokenDCE(payload, key, initiatorSeal, 0, 0, 16)
 	require.NoError(t, err)
 
 	// Try to unwrap expecting from acceptor - should fail.

--- a/spnego/client_ctx.go
+++ b/spnego/client_ctx.go
@@ -82,6 +82,16 @@ type ClientContext struct {
 
 	// mutualAuthComplete indicates whether mutual authentication succeeded.
 	mutualAuthComplete bool
+
+	// wrapTokenEC controls the EC (filler length) for sealed wrap tokens.
+	// - 0: No filler (Windows WinRM mode, RRC=28 for AES-SHA1)
+	// - 16: One AES block padding (MS-KILE mode, RRC=44 for AES-SHA1)
+	// Default is 0 for maximum compatibility with Windows WinRM.
+	wrapTokenEC uint16
+
+	// wrapTokenDCE enables DCE-style token rotation (RFC 4121 Section 4.2.4).
+	// This is required for WSMan/PSRP over HTTP.
+	wrapTokenDCE bool
 }
 
 // NewClientContext creates a new client-side security context.
@@ -94,7 +104,25 @@ func NewClientContext(sessionKey types.EncryptionKey, flags uint32, initialSeqNu
 		isInitiator: true,
 		flags:       flags,
 		sendSeqNum:  uint64(initialSeqNum),
+		wrapTokenEC: 0, // Default to EC=0 for Windows WinRM compatibility.
 	}
+}
+
+// SetWrapTokenEC sets the EC (filler length) for sealed wrap tokens.
+// - EC=0: No filler bytes (Windows WinRM mode, default)
+// - EC=16: One AES block padding (MS-KILE mode)
+func (c *ClientContext) SetWrapTokenEC(ec uint16) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.wrapTokenEC = ec
+}
+
+// SetWrapTokenDCE enables or disables DCE-style wrap token rotation.
+// DCE-style tokens are required for WSMan/PSRP over HTTP.
+func (c *ClientContext) SetWrapTokenDCE(enabled bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.wrapTokenDCE = enabled
 }
 
 // State returns the current context state.
@@ -414,7 +442,11 @@ func (c *ClientContext) WrapSealed(payload []byte) ([]byte, error) {
 		keyUsage = keyusage.GSSAPI_ACCEPTOR_SEAL
 	}
 
-	return gssapi.NewSealedWrapToken(payload, key, keyUsage, flags, c.nextSendSeqNumLocked())
+	if c.wrapTokenDCE {
+		return gssapi.NewSealedWrapTokenDCE(payload, key, keyUsage, flags, c.nextSendSeqNumLocked(), c.wrapTokenEC)
+	}
+
+	return gssapi.NewSealedWrapToken(payload, key, keyUsage, flags, c.nextSendSeqNumLocked(), c.wrapTokenEC)
 }
 
 // Unwrap verifies a sign-only wrapped payload and returns the plaintext.

--- a/spnego/client_ctx.go
+++ b/spnego/client_ctx.go
@@ -330,8 +330,9 @@ func (c *ClientContext) VerifyMIC(token *gssapi.MICToken, payload []byte) (bool,
 	return token.Verify(key, keyUsage)
 }
 
-// Wrap encrypts and signs the given payload.
+// Wrap creates a sign-only (integrity) wrap token for the given payload.
 // This method gates on context establishment.
+// For encrypted (sealed) tokens, use WrapSealed instead.
 func (c *ClientContext) Wrap(payload []byte) (*gssapi.WrapToken, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -353,11 +354,11 @@ func (c *ClientContext) Wrap(payload []byte) (*gssapi.WrapToken, error) {
 	// Determine flags based on role.
 	var flags byte
 	if !c.isInitiator {
-		flags |= 0x01 // Acceptor flag.
+		flags |= gssapi.WrapTokenFlagSentByAcceptor
 	}
 
 	if c.subkey != nil {
-		flags |= 0x04 // Acceptor subkey flag.
+		flags |= gssapi.WrapTokenFlagAcceptorSubkey
 	}
 
 	token := &gssapi.WrapToken{
@@ -381,14 +382,55 @@ func (c *ClientContext) Wrap(payload []byte) (*gssapi.WrapToken, error) {
 	return token, nil
 }
 
-// Unwrap decrypts and verifies a wrapped payload.
+// WrapSealed creates an encrypted (sealed) wrap token for the given payload.
+// This provides confidentiality in addition to integrity per RFC 4121.
 // This method gates on context establishment.
+func (c *ClientContext) WrapSealed(payload []byte) ([]byte, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.state != ContextStateEstablished {
+		return nil, fmt.Errorf("cannot wrap: context not established (state: %s)", c.state)
+	}
+
+	key := c.sessionKey
+	if c.subkey != nil {
+		key = *c.subkey
+	}
+
+	// Determine flags based on role.
+	var flags byte
+	if !c.isInitiator {
+		flags |= gssapi.WrapTokenFlagSentByAcceptor
+	}
+
+	if c.subkey != nil {
+		flags |= gssapi.WrapTokenFlagAcceptorSubkey
+	}
+
+	// Initiator uses GSSAPI_INITIATOR_SEAL, acceptor uses GSSAPI_ACCEPTOR_SEAL.
+	keyUsage := uint32(keyusage.GSSAPI_INITIATOR_SEAL)
+	if !c.isInitiator {
+		keyUsage = keyusage.GSSAPI_ACCEPTOR_SEAL
+	}
+
+	return gssapi.NewSealedWrapToken(payload, key, keyUsage, flags, c.nextSendSeqNumLocked())
+}
+
+// Unwrap verifies a sign-only wrapped payload and returns the plaintext.
+// This method gates on context establishment.
+// For encrypted (sealed) tokens, use UnwrapSealed instead.
 func (c *ClientContext) Unwrap(token *gssapi.WrapToken) ([]byte, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
 	if c.state != ContextStateEstablished {
 		return nil, fmt.Errorf("cannot unwrap: context not established (state: %s)", c.state)
+	}
+
+	// Check if this is a sealed token - if so, return an error.
+	if token.IsSealed() {
+		return nil, errors.New("token is sealed (use UnwrapSealed for encrypted tokens)")
 	}
 
 	key := c.sessionKey
@@ -399,7 +441,7 @@ func (c *ClientContext) Unwrap(token *gssapi.WrapToken) ([]byte, error) {
 	// Determine key usage based on who sent the token.
 	// If sent by acceptor (server), use GSSAPI_ACCEPTOR_SEAL.
 	keyUsage := uint32(keyusage.GSSAPI_ACCEPTOR_SEAL)
-	if token.Flags&0x01 == 0 {
+	if token.Flags&gssapi.WrapTokenFlagSentByAcceptor == 0 {
 		keyUsage = keyusage.GSSAPI_INITIATOR_SEAL
 	}
 
@@ -413,6 +455,63 @@ func (c *ClientContext) Unwrap(token *gssapi.WrapToken) ([]byte, error) {
 	}
 
 	return token.Payload, nil
+}
+
+// UnwrapSealed decrypts a sealed wrap token and returns the plaintext.
+// This method gates on context establishment.
+func (c *ClientContext) UnwrapSealed(tokenBytes []byte) ([]byte, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.state != ContextStateEstablished {
+		return nil, fmt.Errorf("cannot unwrap: context not established (state: %s)", c.state)
+	}
+
+	key := c.sessionKey
+	if c.subkey != nil {
+		key = *c.subkey
+	}
+
+	// Determine if we expect the token from acceptor.
+	// As initiator, we expect tokens from acceptor. As acceptor, we expect from initiator.
+	expectFromAcceptor := c.isInitiator
+
+	// Determine key usage based on who sent the token.
+	keyUsage := uint32(keyusage.GSSAPI_ACCEPTOR_SEAL)
+	if !expectFromAcceptor {
+		keyUsage = keyusage.GSSAPI_INITIATOR_SEAL
+	}
+
+	return gssapi.UnwrapSealed(tokenBytes, key, keyUsage, expectFromAcceptor)
+}
+
+// UnwrapAuto automatically detects whether a token is sealed or sign-only and processes it.
+// This provides a unified API similar to SSPI's DecryptMessage.
+// This method gates on context establishment.
+func (c *ClientContext) UnwrapAuto(tokenBytes []byte) (*gssapi.UnwrapResult, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.state != ContextStateEstablished {
+		return nil, fmt.Errorf("cannot unwrap: context not established (state: %s)", c.state)
+	}
+
+	key := c.sessionKey
+	if c.subkey != nil {
+		key = *c.subkey
+	}
+
+	// Determine if we expect the token from acceptor.
+	// As initiator, we expect tokens from acceptor. As acceptor, we expect from initiator.
+	expectFromAcceptor := c.isInitiator
+
+	// Determine key usage based on who sent the token.
+	keyUsage := uint32(keyusage.GSSAPI_ACCEPTOR_SEAL)
+	if !expectFromAcceptor {
+		keyUsage = keyusage.GSSAPI_INITIATOR_SEAL
+	}
+
+	return gssapi.Unwrap(tokenBytes, key, keyUsage, expectFromAcceptor)
 }
 
 // nextSendSeqNumLocked returns and increments the send sequence number.

--- a/spnego/client_ctx.go
+++ b/spnego/client_ctx.go
@@ -1,0 +1,492 @@
+package spnego
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/go-krb5/x/encoding/asn1"
+
+	"github.com/go-krb5/krb5/crypto"
+	"github.com/go-krb5/krb5/gssapi"
+	"github.com/go-krb5/krb5/iana/keyusage"
+	"github.com/go-krb5/krb5/messages"
+	"github.com/go-krb5/krb5/types"
+)
+
+// ContextState represents the state of a SPNEGO security context.
+type ContextState int
+
+const (
+	// ContextStateInitial indicates the context has not yet been initialized.
+	ContextStateInitial ContextState = iota
+	// ContextStateInProgress indicates the context establishment is in progress.
+	ContextStateInProgress
+	// ContextStateEstablished indicates the context has been fully established.
+	ContextStateEstablished
+	// ContextStateFailed indicates the context establishment failed.
+	ContextStateFailed
+)
+
+// String returns a human-readable representation of the context state.
+func (s ContextState) String() string {
+	switch s {
+	case ContextStateInitial:
+		return "Initial"
+	case ContextStateInProgress:
+		return "InProgress"
+	case ContextStateEstablished:
+		return "Established"
+	case ContextStateFailed:
+		return "Failed"
+	default:
+		return "Unknown"
+	}
+}
+
+// ClientContext represents a client-side SPNEGO/GSS-API security context.
+// It tracks the state machine for multi-leg authentication and provides
+// the keys and sequence numbers needed for per-message security (MIC/Wrap).
+type ClientContext struct {
+	mu sync.RWMutex
+
+	// state tracks the current context establishment state.
+	state ContextState
+
+	// flags holds the negotiated GSS-API context flags.
+	flags uint32
+
+	// sessionKey is the Kerberos session key from the service ticket.
+	sessionKey types.EncryptionKey
+
+	// subkey is the acceptor subkey from AP-REP (if provided).
+	// Per RFC 4121, if acceptor provides a subkey, it takes precedence.
+	subkey *types.EncryptionKey
+
+	// sendSeqNum is the sequence number for outgoing messages.
+	sendSeqNum uint64
+
+	// recvSeqNum is the sequence number for incoming messages.
+	recvSeqNum uint64
+
+	// isInitiator indicates this is the initiator (client) side.
+	isInitiator bool
+
+	// rawMechTypeListDER stores the raw DER bytes of the initial MechTypeList.
+	// This MUST be preserved exactly for mechListMIC computation per RFC 4178.
+	rawMechTypeListDER []byte
+
+	// mutualAuthRequired indicates whether mutual authentication was requested.
+	mutualAuthRequired bool
+
+	// mutualAuthComplete indicates whether mutual authentication succeeded.
+	mutualAuthComplete bool
+}
+
+// NewClientContext creates a new client-side security context.
+func NewClientContext(sessionKey types.EncryptionKey, flags uint32) *ClientContext {
+	return &ClientContext{
+		state:       ContextStateInitial,
+		sessionKey:  sessionKey,
+		isInitiator: true,
+		flags:       flags,
+	}
+}
+
+// State returns the current context state.
+func (c *ClientContext) State() ContextState {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.state
+}
+
+// IsEstablished returns true if the context is fully established.
+func (c *ClientContext) IsEstablished() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.state == ContextStateEstablished
+}
+
+// SetMechTypeListDER stores the raw DER bytes of the MechTypeList for MIC computation.
+// This MUST be called with the exact bytes from the initial NegTokenInit.
+func (c *ClientContext) SetMechTypeListDER(der []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Make a copy to ensure we own the bytes.
+	c.rawMechTypeListDER = make([]byte, len(der))
+	copy(c.rawMechTypeListDER, der)
+}
+
+// MechTypeListDER returns the stored raw DER bytes of the MechTypeList.
+func (c *ClientContext) MechTypeListDER() []byte {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.rawMechTypeListDER
+}
+
+// SetMutualAuthRequired sets whether mutual authentication is required.
+func (c *ClientContext) SetMutualAuthRequired(required bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.mutualAuthRequired = required
+}
+
+// SetInProgress transitions the context to the InProgress state.
+func (c *ClientContext) SetInProgress() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.state != ContextStateInitial && c.state != ContextStateInProgress {
+		return fmt.Errorf("cannot transition to InProgress from state %s", c.state)
+	}
+
+	c.state = ContextStateInProgress
+
+	return nil
+}
+
+// ProcessAPRep processes an AP-REP message from the server, completing mutual authentication.
+// It extracts the subkey and sequence number for subsequent per-message operations.
+func (c *ClientContext) ProcessAPRep(apRep *messages.APRep) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.state != ContextStateInProgress {
+		return fmt.Errorf("cannot process AP-REP in state %s", c.state)
+	}
+
+	// Decrypt the EncAPRepPart using the session key.
+	encType, err := crypto.GetEtype(c.sessionKey.KeyType)
+	if err != nil {
+		c.state = ContextStateFailed
+		return fmt.Errorf("error getting encryption type: %w", err)
+	}
+
+	decrypted, err := encType.DecryptMessage(c.sessionKey.KeyValue, apRep.EncPart.Cipher, keyusage.AP_REP_ENCPART)
+	if err != nil {
+		c.state = ContextStateFailed
+		return fmt.Errorf("error decrypting AP-REP: %w", err)
+	}
+
+	var encPart messages.EncAPRepPart
+	if err := encPart.Unmarshal(decrypted); err != nil {
+		c.state = ContextStateFailed
+		return fmt.Errorf("error unmarshalling EncAPRepPart: %w", err)
+	}
+
+	// Store the subkey if provided.
+	if encPart.Subkey.KeyType != 0 {
+		c.subkey = &encPart.Subkey
+	}
+
+	// Store the sequence number if provided.
+	if encPart.SequenceNumber != 0 {
+		c.recvSeqNum = uint64(encPart.SequenceNumber)
+	}
+
+	c.mutualAuthComplete = true
+
+	return nil
+}
+
+// SetEstablished transitions the context to the Established state.
+// This should only be called after mutual authentication completes (if required).
+func (c *ClientContext) SetEstablished() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.state != ContextStateInProgress {
+		return fmt.Errorf("cannot transition to Established from state %s", c.state)
+	}
+
+	// If mutual auth was required, verify it completed.
+	if c.mutualAuthRequired && !c.mutualAuthComplete {
+		return errors.New("mutual authentication required but not completed")
+	}
+
+	c.state = ContextStateEstablished
+
+	return nil
+}
+
+// SetFailed transitions the context to the Failed state.
+func (c *ClientContext) SetFailed() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.state = ContextStateFailed
+}
+
+// GetKey returns the key to use for per-message operations.
+// Per RFC 4121, if the acceptor provided a subkey, it takes precedence.
+func (c *ClientContext) GetKey() types.EncryptionKey {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.subkey != nil {
+		return *c.subkey
+	}
+
+	return c.sessionKey
+}
+
+// HasAcceptorSubkey returns true if the acceptor provided a subkey.
+func (c *ClientContext) HasAcceptorSubkey() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.subkey != nil
+}
+
+// NextSendSeqNum returns and increments the send sequence number.
+func (c *ClientContext) NextSendSeqNum() uint64 {
+	return atomic.AddUint64(&c.sendSeqNum, 1) - 1
+}
+
+// NextRecvSeqNum returns and increments the receive sequence number.
+func (c *ClientContext) NextRecvSeqNum() uint64 {
+	return atomic.AddUint64(&c.recvSeqNum, 1) - 1
+}
+
+// GetMIC creates a MIC token for the given payload.
+// This method gates on context establishment - it will return an error if
+// the context is not fully established.
+func (c *ClientContext) GetMIC(payload []byte) (*gssapi.MICToken, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.state != ContextStateEstablished {
+		return nil, fmt.Errorf("cannot create MIC: context not established (state: %s)", c.state)
+	}
+
+	key := c.sessionKey
+	if c.subkey != nil {
+		key = *c.subkey
+	}
+
+	// Determine flags based on role.
+	var flags byte
+	if !c.isInitiator {
+		flags |= gssapi.MICTokenFlagSentByAcceptor
+	}
+
+	if c.subkey != nil {
+		flags |= gssapi.MICTokenFlagAcceptorSubkey
+	}
+
+	token := &gssapi.MICToken{
+		Flags:     flags,
+		SndSeqNum: c.nextSendSeqNumLocked(),
+		Payload:   payload,
+	}
+
+	// Initiator uses GSSAPI_INITIATOR_SIGN, acceptor uses GSSAPI_ACCEPTOR_SIGN.
+	keyUsage := uint32(keyusage.GSSAPI_INITIATOR_SIGN)
+	if !c.isInitiator {
+		keyUsage = keyusage.GSSAPI_ACCEPTOR_SIGN
+	}
+
+	if err := token.SetChecksum(key, keyUsage); err != nil {
+		return nil, fmt.Errorf("error computing MIC checksum: %w", err)
+	}
+
+	return token, nil
+}
+
+// VerifyMIC verifies a MIC token for the given payload.
+// This method gates on context establishment.
+func (c *ClientContext) VerifyMIC(token *gssapi.MICToken, payload []byte) (bool, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.state != ContextStateEstablished {
+		return false, fmt.Errorf("cannot verify MIC: context not established (state: %s)", c.state)
+	}
+
+	key := c.sessionKey
+	if c.subkey != nil {
+		key = *c.subkey
+	}
+
+	// Set the payload for verification.
+	token.Payload = payload
+
+	// Determine key usage based on who sent the token.
+	// If sent by acceptor (server), use GSSAPI_ACCEPTOR_SIGN.
+	keyUsage := uint32(keyusage.GSSAPI_ACCEPTOR_SIGN)
+	if token.Flags&gssapi.MICTokenFlagSentByAcceptor == 0 {
+		keyUsage = keyusage.GSSAPI_INITIATOR_SIGN
+	}
+
+	return token.Verify(key, keyUsage)
+}
+
+// Wrap encrypts and signs the given payload.
+// This method gates on context establishment.
+func (c *ClientContext) Wrap(payload []byte) (*gssapi.WrapToken, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.state != ContextStateEstablished {
+		return nil, fmt.Errorf("cannot wrap: context not established (state: %s)", c.state)
+	}
+
+	key := c.sessionKey
+	if c.subkey != nil {
+		key = *c.subkey
+	}
+
+	encType, err := crypto.GetEtype(key.KeyType)
+	if err != nil {
+		return nil, fmt.Errorf("error getting encryption type: %w", err)
+	}
+
+	// Determine flags based on role.
+	var flags byte
+	if !c.isInitiator {
+		flags |= 0x01 // Acceptor flag.
+	}
+
+	if c.subkey != nil {
+		flags |= 0x04 // Acceptor subkey flag.
+	}
+
+	token := &gssapi.WrapToken{
+		Flags:     flags,
+		EC:        uint16(encType.GetHMACBitLength() / 8),
+		RRC:       0,
+		SndSeqNum: c.nextSendSeqNumLocked(),
+		Payload:   payload,
+	}
+
+	// Initiator uses GSSAPI_INITIATOR_SEAL, acceptor uses GSSAPI_ACCEPTOR_SEAL.
+	keyUsage := uint32(keyusage.GSSAPI_INITIATOR_SEAL)
+	if !c.isInitiator {
+		keyUsage = keyusage.GSSAPI_ACCEPTOR_SEAL
+	}
+
+	if err := token.SetCheckSum(key, keyUsage); err != nil {
+		return nil, fmt.Errorf("error computing wrap checksum: %w", err)
+	}
+
+	return token, nil
+}
+
+// Unwrap decrypts and verifies a wrapped payload.
+// This method gates on context establishment.
+func (c *ClientContext) Unwrap(token *gssapi.WrapToken) ([]byte, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.state != ContextStateEstablished {
+		return nil, fmt.Errorf("cannot unwrap: context not established (state: %s)", c.state)
+	}
+
+	key := c.sessionKey
+	if c.subkey != nil {
+		key = *c.subkey
+	}
+
+	// Determine key usage based on who sent the token.
+	// If sent by acceptor (server), use GSSAPI_ACCEPTOR_SEAL.
+	keyUsage := uint32(keyusage.GSSAPI_ACCEPTOR_SEAL)
+	if token.Flags&0x01 == 0 {
+		keyUsage = keyusage.GSSAPI_INITIATOR_SEAL
+	}
+
+	ok, err := token.Verify(key, keyUsage)
+	if err != nil {
+		return nil, fmt.Errorf("error verifying wrap token: %w", err)
+	}
+
+	if !ok {
+		return nil, errors.New("wrap token verification failed")
+	}
+
+	return token.Payload, nil
+}
+
+// nextSendSeqNumLocked returns and increments the send sequence number.
+// Caller must hold at least a read lock.
+func (c *ClientContext) nextSendSeqNumLocked() uint64 {
+	return atomic.AddUint64(&c.sendSeqNum, 1) - 1
+}
+
+// Flags returns the negotiated context flags.
+func (c *ClientContext) Flags() uint32 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.flags
+}
+
+// MechListMIC generates a MIC over the mechTypeList for SPNEGO.
+// Per RFC 4178, this MIC is computed over the raw DER bytes of the mechTypeList.
+func (c *ClientContext) MechListMIC() ([]byte, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.rawMechTypeListDER == nil {
+		return nil, errors.New("mechTypeList DER bytes not set")
+	}
+
+	key := c.sessionKey
+	if c.subkey != nil {
+		key = *c.subkey
+	}
+
+	// Create a MIC token over the mechTypeList DER bytes.
+	token := &gssapi.MICToken{
+		Flags:     0, // Initiator.
+		SndSeqNum: 0, // MechListMIC doesn't use sequence numbers.
+		Payload:   c.rawMechTypeListDER,
+	}
+
+	keyUsage := uint32(keyusage.GSSAPI_INITIATOR_SIGN)
+
+	if err := token.SetChecksum(key, keyUsage); err != nil {
+		return nil, fmt.Errorf("error computing mechListMIC: %w", err)
+	}
+
+	// Return just the checksum bytes, not the full MIC token.
+	return token.Checksum, nil
+}
+
+// VerifyMechListMIC verifies the mechListMIC from the server.
+func (c *ClientContext) VerifyMechListMIC(mic []byte) (bool, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.rawMechTypeListDER == nil {
+		return false, errors.New("mechTypeList DER bytes not set")
+	}
+
+	key := c.sessionKey
+	if c.subkey != nil {
+		key = *c.subkey
+	}
+
+	// Build a MIC token with the received checksum for verification.
+	token := &gssapi.MICToken{
+		Flags:     gssapi.MICTokenFlagSentByAcceptor, // From acceptor.
+		SndSeqNum: 0,
+		Payload:   c.rawMechTypeListDER,
+		Checksum:  mic,
+	}
+
+	keyUsage := uint32(keyusage.GSSAPI_ACCEPTOR_SIGN)
+
+	return token.Verify(key, keyUsage)
+}
+
+// MarshalMechTypeList marshals the given OIDs into the DER format for MIC computation.
+// This is exported for use when creating the initial NegTokenInit.
+func MarshalMechTypeList(mechTypes []asn1.ObjectIdentifier) ([]byte, error) {
+	return asn1.Marshal(mechTypes, asn1.WithMarshalSlicePreserveTypes(true))
+}

--- a/spnego/client_ctx.go
+++ b/spnego/client_ctx.go
@@ -85,12 +85,15 @@ type ClientContext struct {
 }
 
 // NewClientContext creates a new client-side security context.
-func NewClientContext(sessionKey types.EncryptionKey, flags uint32) *ClientContext {
+// The initialSeqNum should be the sequence number from the Authenticator in the AP-REQ.
+// Per RFC 4121, this is used as the starting sequence number for outgoing messages.
+func NewClientContext(sessionKey types.EncryptionKey, flags uint32, initialSeqNum int64) *ClientContext {
 	return &ClientContext{
 		state:       ContextStateInitial,
 		sessionKey:  sessionKey,
 		isInitiator: true,
 		flags:       flags,
+		sendSeqNum:  uint64(initialSeqNum),
 	}
 }
 

--- a/spnego/krb5_token.go
+++ b/spnego/krb5_token.go
@@ -171,6 +171,30 @@ func (m *KRB5Token) IsKRBError() bool {
 	return hex.EncodeToString(m.tokID) == TOK_ID_KRB_ERROR
 }
 
+// VerifyAPRep verifies an AP_REP token using the provided client context.
+// This is used for client-side mutual authentication. The session key from
+// the context is used to decrypt the EncAPRepPart.
+func (m *KRB5Token) VerifyAPRep(ctx *ClientContext) (bool, gssapi.Status) {
+	if !m.IsAPRep() {
+		return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: "token is not an AP_REP"}
+	}
+
+	if err := ctx.ProcessAPRep(&m.APRep); err != nil {
+		return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: err.Error()}
+	}
+
+	return true, gssapi.Status{Code: gssapi.StatusComplete}
+}
+
+// GetKRBError returns the KRB_ERROR if this token contains one, or an error otherwise.
+func (m *KRB5Token) GetKRBError() (*messages.KRBError, error) {
+	if !m.IsKRBError() {
+		return nil, errors.New("token is not a KRB_ERROR")
+	}
+
+	return &m.KRBError, nil
+}
+
 // Context returns the KRB5 token's context which will contain any verify user identity information.
 func (m *KRB5Token) Context() context.Context {
 	return m.context

--- a/spnego/krb5_token.go
+++ b/spnego/krb5_token.go
@@ -200,8 +200,17 @@ func (m *KRB5Token) Context() context.Context {
 	return m.context
 }
 
+// KRB5TokenResult contains the result of creating a KRB5 token, including
+// the token and the authenticator sequence number for context initialization.
+type KRB5TokenResult struct {
+	Token  KRB5Token
+	SeqNum int64
+}
+
 // NewKRB5TokenAPREQ creates a new KRB5 token with AP_REQ.
-func NewKRB5TokenAPREQ(cl *client.Client, tkt messages.Ticket, sessionKey types.EncryptionKey, flagsGSSAPI []int, optionsAP []int) (KRB5Token, error) {
+// Returns a KRB5TokenResult containing the token and the authenticator's
+// sequence number, which should be used to initialize the security context.
+func NewKRB5TokenAPREQ(cl *client.Client, tkt messages.Ticket, sessionKey types.EncryptionKey, flagsGSSAPI []int, optionsAP []int) (KRB5TokenResult, error) {
 	// TODO consider providing the SPN rather than the specific tkt and key and get these from the krb client.
 	var m KRB5Token
 
@@ -211,8 +220,11 @@ func NewKRB5TokenAPREQ(cl *client.Client, tkt messages.Ticket, sessionKey types.
 
 	auth, err := krb5TokenAuthenticator(cl.Credentials, flagsGSSAPI)
 	if err != nil {
-		return m, err
+		return KRB5TokenResult{}, err
 	}
+
+	// Capture the sequence number before the authenticator is encrypted.
+	seqNum := auth.SeqNumber
 
 	APReq, err := messages.NewAPReq(
 		tkt,
@@ -220,7 +232,7 @@ func NewKRB5TokenAPREQ(cl *client.Client, tkt messages.Ticket, sessionKey types.
 		auth,
 	)
 	if err != nil {
-		return m, err
+		return KRB5TokenResult{}, err
 	}
 
 	for _, o := range optionsAP {
@@ -229,7 +241,7 @@ func NewKRB5TokenAPREQ(cl *client.Client, tkt messages.Ticket, sessionKey types.
 
 	m.APReq = APReq
 
-	return m, nil
+	return KRB5TokenResult{Token: m, SeqNum: seqNum}, nil
 }
 
 // krb5TokenAuthenticator creates a new kerberos authenticator for kerberos MechToken.

--- a/spnego/krb5_token_test.go
+++ b/spnego/krb5_token_test.go
@@ -133,9 +133,14 @@ func TestNewAPREQKRB5Token_and_Marshal(t *testing.T) {
 		KeyValue: make([]byte, 32),
 	}
 
-	mt, err := NewKRB5TokenAPREQ(&cl, tkt, key, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, []int{})
+	result, err := NewKRB5TokenAPREQ(&cl, tkt, key, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, []int{})
 	require.NoError(t, err)
 
+	// Verify that we got a valid sequence number (30-bit masked).
+	assert.GreaterOrEqual(t, result.SeqNum, int64(0))
+	assert.LessOrEqual(t, result.SeqNum, int64(0x3fffffff))
+
+	mt := result.Token
 	mb, err := mt.Marshal()
 	require.NoError(t, err)
 

--- a/spnego/negotiate_client.go
+++ b/spnego/negotiate_client.go
@@ -333,9 +333,15 @@ func (c *NegotiateClient) verifyResponseToken(negResp *NegTokenResp) error {
 			return fmt.Errorf("failed to verify AP-REP: %s", status.Message)
 		}
 	} else if krb5Token.IsKRBError() {
-		krbErr, _ := krb5Token.GetKRBError()
-
 		c.ctx.SetFailed()
+
+		krbErr, err := krb5Token.GetKRBError()
+		if err != nil || krbErr == nil {
+			if err == nil {
+				err = errors.New("missing KRB_ERROR payload")
+			}
+			return fmt.Errorf("server returned KRB_ERROR: %w", err)
+		}
 
 		return fmt.Errorf("server returned KRB_ERROR: %s", krbErr.EText)
 	}
@@ -389,6 +395,9 @@ func (c *NegotiateClient) sendFinalRequest(req *http.Request, responseToken []by
 // handleSuccessResponse processes a successful response, potentially with a final token.
 func (c *NegotiateClient) handleSuccessResponse(resp *http.Response) (*http.Response, error) {
 	if err := c.processFinalAuthToken(resp); err != nil {
+		if resp.Body != nil {
+			resp.Body.Close()
+		}
 		return nil, err
 	}
 

--- a/spnego/negotiate_client.go
+++ b/spnego/negotiate_client.go
@@ -1,0 +1,549 @@
+package spnego
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/go-krb5/krb5/client"
+	"github.com/go-krb5/krb5/gssapi"
+	"github.com/go-krb5/krb5/iana/flags"
+	"github.com/go-krb5/krb5/types"
+)
+
+// NegotiateClient is a stateful HTTP client that handles multi-leg SPNEGO authentication.
+// It implements the client-side SPNEGO state machine per RFC 4178.
+type NegotiateClient struct {
+	// krb5Client is the underlying Kerberos client.
+	krb5Client *client.Client
+
+	// spn is the service principal name for the target service.
+	spn string
+
+	// transport is the underlying HTTP transport.
+	transport http.RoundTripper
+
+	// mu protects the context and state.
+	mu sync.Mutex
+
+	// ctx is the security context for the current negotiation.
+	ctx *ClientContext
+
+	// negTokenInit stores the initial NegTokenInit for mechListMIC verification.
+	negTokenInit *NegTokenInit
+
+	// mutualAuth indicates whether mutual authentication is required.
+	mutualAuth bool
+}
+
+// NegotiateClientOption is a function that configures a NegotiateClient.
+type NegotiateClientOption func(*NegotiateClient)
+
+// WithTransport sets the underlying HTTP transport.
+func WithTransport(t http.RoundTripper) NegotiateClientOption {
+	return func(c *NegotiateClient) {
+		c.transport = t
+	}
+}
+
+// WithMutualAuth enables mutual authentication requirement.
+func WithMutualAuth(enabled bool) NegotiateClientOption {
+	return func(c *NegotiateClient) {
+		c.mutualAuth = enabled
+	}
+}
+
+// NewNegotiateClient creates a new NegotiateClient for multi-leg SPNEGO authentication.
+func NewNegotiateClient(krb5Client *client.Client, spn string, opts ...NegotiateClientOption) *NegotiateClient {
+	c := &NegotiateClient{
+		krb5Client: krb5Client,
+		spn:        spn,
+		transport:  http.DefaultTransport,
+		mutualAuth: true, // Default to requiring mutual auth for security.
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// RoundTrip implements http.RoundTripper and handles the SPNEGO state machine.
+func (c *NegotiateClient) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Make the initial request.
+	resp, err := c.transport.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if we need to authenticate.
+	if resp.StatusCode != http.StatusUnauthorized {
+		return resp, nil
+	}
+
+	// Check for WWW-Authenticate: Negotiate header.
+	authHeader := resp.Header.Get(HTTPHeaderAuthResponse)
+	if !strings.HasPrefix(authHeader, HTTPHeaderAuthResponseValueKey) {
+		return resp, nil
+	}
+
+	// Drain and close the response body to reuse the connection.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	// Step 1: Handle bare "Negotiate" - send initial token.
+	authValue := strings.TrimPrefix(authHeader, HTTPHeaderAuthResponseValueKey)
+	authValue = strings.TrimSpace(authValue)
+
+	if authValue == "" {
+		// Bare Negotiate header - start authentication.
+		return c.handleInitialChallenge(req)
+	}
+
+	// Step 2: Handle "Negotiate <token>" - process server response.
+	return c.handleServerToken(req, authValue)
+}
+
+// handleInitialChallenge processes the initial 401 with bare "Negotiate" header.
+func (c *NegotiateClient) handleInitialChallenge(req *http.Request) (*http.Response, error) {
+	// Ensure we have a valid TGT.
+	if err := c.krb5Client.AffirmLogin(); err != nil {
+		return nil, fmt.Errorf("failed to affirm login: %w", err)
+	}
+
+	// Get service ticket.
+	tkt, sessionKey, err := c.krb5Client.GetServiceTicket(c.spn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service ticket: %w", err)
+	}
+
+	// Build GSSAPI flags.
+	gssFlags := []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}
+	if c.mutualAuth {
+		gssFlags = append(gssFlags, gssapi.ContextFlagMutual)
+	}
+
+	// Build AP options.
+	apOptions := []int{}
+	if c.mutualAuth {
+		apOptions = append(apOptions, flags.APOptionMutualRequired)
+	}
+
+	// Create NegTokenInit.
+	negTokenInit, err := NewNegTokenInitKRB5WithFlags(c.krb5Client, tkt, sessionKey, gssFlags, apOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create NegTokenInit: %w", err)
+	}
+
+	// Store the NegTokenInit for later mechListMIC verification.
+	c.negTokenInit = &negTokenInit
+
+	// Create security context.
+	flagsUint := uint32(0)
+	for _, f := range gssFlags {
+		flagsUint |= uint32(f)
+	}
+
+	c.ctx = NewClientContext(sessionKey, flagsUint)
+
+	// Store the raw MechTypes DER for MIC computation.
+	c.ctx.SetMechTypeListDER(negTokenInit.RawMechTypesDER())
+	c.ctx.SetMutualAuthRequired(c.mutualAuth)
+
+	// Transition context to InProgress.
+	if err := c.ctx.SetInProgress(); err != nil {
+		return nil, fmt.Errorf("failed to set context in progress: %w", err)
+	}
+
+	// Marshal and encode the token.
+	spnegoToken := &SPNEGOToken{
+		Init:         true,
+		NegTokenInit: negTokenInit,
+	}
+
+	tokenBytes, err := spnegoToken.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal SPNEGO token: %w", err)
+	}
+
+	// Clone the request and add the Authorization header.
+	newReq := cloneRequest(req)
+	newReq.Header.Set(HTTPHeaderAuthRequest, HTTPHeaderAuthResponseValueKey+" "+base64.StdEncoding.EncodeToString(tokenBytes))
+
+	// Send the request with the token.
+	resp, err := c.transport.RoundTrip(newReq)
+	if err != nil {
+		c.ctx.SetFailed()
+		return nil, err
+	}
+
+	// Check if we got a success (2xx) or another challenge (401).
+	if resp.StatusCode == http.StatusUnauthorized {
+		// Check for another Negotiate challenge.
+		authHeader := resp.Header.Get(HTTPHeaderAuthResponse)
+		if authValue, found := strings.CutPrefix(authHeader, HTTPHeaderAuthResponseValueKey); found {
+			authValue = strings.TrimSpace(authValue)
+
+			if authValue != "" {
+				// Drain and close response body.
+				_, _ = io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
+
+				// Process server's response token.
+				return c.handleServerToken(newReq, authValue)
+			}
+		}
+	}
+
+	// Check for success with potential final token.
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return c.handleSuccessResponse(resp)
+	}
+
+	return resp, nil
+}
+
+// handleServerToken processes a server's NegTokenResp.
+func (c *NegotiateClient) handleServerToken(req *http.Request, tokenB64 string) (*http.Response, error) {
+	if c.ctx == nil {
+		return nil, errors.New("received server token without active context")
+	}
+
+	negResp, err := c.decodeNegTokenResp(tokenB64)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := c.processNegTokenResp(negResp); err != nil {
+		return nil, err
+	}
+
+	return c.sendFinalRequest(req)
+}
+
+// decodeNegTokenResp decodes a base64 token and returns the NegTokenResp.
+func (c *NegotiateClient) decodeNegTokenResp(tokenB64 string) (*NegTokenResp, error) {
+	tokenBytes, err := base64.StdEncoding.DecodeString(tokenB64)
+	if err != nil {
+		c.ctx.SetFailed()
+		return nil, fmt.Errorf("failed to decode server token: %w", err)
+	}
+
+	var spnegoToken SPNEGOToken
+	if err := spnegoToken.Unmarshal(tokenBytes); err != nil {
+		c.ctx.SetFailed()
+		return nil, fmt.Errorf("failed to unmarshal server token: %w", err)
+	}
+
+	if !spnegoToken.Resp {
+		c.ctx.SetFailed()
+		return nil, errors.New("expected NegTokenResp from server")
+	}
+
+	return &spnegoToken.NegTokenResp, nil
+}
+
+// processNegTokenResp processes the negotiation response state and tokens.
+func (c *NegotiateClient) processNegTokenResp(negResp *NegTokenResp) error {
+	switch negResp.State() {
+	case NegStateReject:
+		c.ctx.SetFailed()
+		return errors.New("server rejected authentication")
+
+	case NegStateAcceptCompleted, NegStateAcceptIncomplete:
+		if err := c.verifyResponseToken(negResp); err != nil {
+			return err
+		}
+
+		if err := c.verifyMechListMIC(negResp); err != nil {
+			return err
+		}
+
+		if negResp.State() == NegStateAcceptCompleted {
+			if err := c.ctx.SetEstablished(); err != nil {
+				c.ctx.SetFailed()
+				return fmt.Errorf("failed to establish context: %w", err)
+			}
+		}
+
+	case NegStateRequestMIC:
+		c.ctx.SetFailed()
+		return errors.New("server requested MIC - not supported")
+	}
+
+	return nil
+}
+
+// verifyResponseToken verifies the KRB5 token in the response.
+func (c *NegotiateClient) verifyResponseToken(negResp *NegTokenResp) error {
+	if len(negResp.ResponseToken) == 0 {
+		return nil
+	}
+
+	krb5Token, err := negResp.GetKRB5Token()
+	if err != nil {
+		c.ctx.SetFailed()
+		return fmt.Errorf("failed to get KRB5 token: %w", err)
+	}
+
+	if krb5Token.IsAPRep() {
+		ok, status := krb5Token.VerifyAPRep(c.ctx)
+		if !ok {
+			c.ctx.SetFailed()
+			return fmt.Errorf("failed to verify AP-REP: %s", status.Message)
+		}
+	} else if krb5Token.IsKRBError() {
+		krbErr, _ := krb5Token.GetKRBError()
+
+		c.ctx.SetFailed()
+
+		return fmt.Errorf("server returned KRB_ERROR: %s", krbErr.EText)
+	}
+
+	return nil
+}
+
+// verifyMechListMIC verifies the mechListMIC if present.
+func (c *NegotiateClient) verifyMechListMIC(negResp *NegTokenResp) error {
+	if !negResp.HasMechListMIC() {
+		return nil
+	}
+
+	ok, err := c.ctx.VerifyMechListMIC(negResp.MechListMIC)
+	if err != nil {
+		c.ctx.SetFailed()
+		return fmt.Errorf("failed to verify mechListMIC: %w", err)
+	}
+
+	if !ok {
+		c.ctx.SetFailed()
+		return errors.New("mechListMIC verification failed")
+	}
+
+	return nil
+}
+
+// sendFinalRequest sends the final request after processing the server token.
+func (c *NegotiateClient) sendFinalRequest(req *http.Request) (*http.Response, error) {
+	newReq := cloneRequest(req)
+
+	resp, err := c.transport.RoundTrip(newReq)
+	if err != nil {
+		c.ctx.SetFailed()
+		return nil, err
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return c.handleSuccessResponse(resp)
+	}
+
+	return resp, nil
+}
+
+// handleSuccessResponse processes a successful response, potentially with a final token.
+func (c *NegotiateClient) handleSuccessResponse(resp *http.Response) (*http.Response, error) {
+	if err := c.processFinalAuthToken(resp); err != nil {
+		return nil, err
+	}
+
+	// Mark context as established if it's still in progress.
+	if c.ctx != nil && c.ctx.State() == ContextStateInProgress {
+		if err := c.ctx.SetEstablished(); err != nil {
+			// Log but don't fail - we got a success response.
+			c.ctx.SetFailed()
+		}
+	}
+
+	return resp, nil
+}
+
+// processFinalAuthToken processes a final Negotiate token in the response header.
+func (c *NegotiateClient) processFinalAuthToken(resp *http.Response) error {
+	authHeader := resp.Header.Get(HTTPHeaderAuthResponse)
+
+	authValue, found := strings.CutPrefix(authHeader, HTTPHeaderAuthResponseValueKey)
+	if !found {
+		return nil
+	}
+
+	authValue = strings.TrimSpace(authValue)
+	if authValue == "" || c.ctx == nil || c.ctx.State() != ContextStateInProgress {
+		return nil
+	}
+
+	tokenBytes, err := base64.StdEncoding.DecodeString(authValue)
+	if err != nil {
+		c.ctx.SetFailed()
+		return fmt.Errorf("failed to decode final token: %w", err)
+	}
+
+	var spnegoToken SPNEGOToken
+	if err := spnegoToken.Unmarshal(tokenBytes); err != nil {
+		c.ctx.SetFailed()
+		return fmt.Errorf("failed to unmarshal final token: %w", err)
+	}
+
+	if !spnegoToken.Resp {
+		return nil
+	}
+
+	return c.verifyFinalNegTokenResp(&spnegoToken.NegTokenResp)
+}
+
+// verifyFinalNegTokenResp verifies the final NegTokenResp from a success response.
+func (c *NegotiateClient) verifyFinalNegTokenResp(negResp *NegTokenResp) error {
+	if len(negResp.ResponseToken) > 0 {
+		krb5Token, err := negResp.GetKRB5Token()
+		if err != nil {
+			c.ctx.SetFailed()
+			return fmt.Errorf("failed to get final KRB5 token: %w", err)
+		}
+
+		if krb5Token.IsAPRep() {
+			ok, status := krb5Token.VerifyAPRep(c.ctx)
+			if !ok {
+				c.ctx.SetFailed()
+				return fmt.Errorf("failed to verify final AP-REP: %s", status.Message)
+			}
+		}
+	}
+
+	if negResp.HasMechListMIC() {
+		ok, err := c.ctx.VerifyMechListMIC(negResp.MechListMIC)
+		if err != nil {
+			c.ctx.SetFailed()
+			return fmt.Errorf("failed to verify final mechListMIC: %w", err)
+		}
+
+		if !ok {
+			c.ctx.SetFailed()
+			return errors.New("final mechListMIC verification failed")
+		}
+	}
+
+	return nil
+}
+
+// Context returns the security context if established.
+func (c *NegotiateClient) Context() *ClientContext {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.ctx
+}
+
+// IsEstablished returns true if the security context is established.
+func (c *NegotiateClient) IsEstablished() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.ctx != nil && c.ctx.IsEstablished()
+}
+
+// Reset clears the current context, allowing a fresh authentication.
+func (c *NegotiateClient) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.ctx = nil
+	c.negTokenInit = nil
+}
+
+// cloneRequest creates a shallow copy of a request for retry purposes.
+func cloneRequest(req *http.Request) *http.Request {
+	newReq := req.Clone(req.Context())
+	if req.Body != nil {
+		// Note: Body reuse is handled by the caller setting GetBody on the original request.
+		if req.GetBody != nil {
+			body, err := req.GetBody()
+			if err == nil {
+				newReq.Body = body
+			}
+		}
+	}
+
+	return newReq
+}
+
+// NegotiatingRoundTripper is an http.RoundTripper that handles SPNEGO authentication.
+// It is an alias for NegotiateClient to match the naming in the requirements.
+type NegotiatingRoundTripper = NegotiateClient
+
+// NewNegotiatingRoundTripper creates a new NegotiatingRoundTripper.
+// This is an alias for NewNegotiateClient.
+func NewNegotiatingRoundTripper(krb5Client *client.Client, spn string, opts ...NegotiateClientOption) *NegotiatingRoundTripper {
+	return NewNegotiateClient(krb5Client, spn, opts...)
+}
+
+// GetMIC creates a MIC token for message integrity.
+// Returns an error if the context is not established.
+func (c *NegotiateClient) GetMIC(payload []byte) (*gssapi.MICToken, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.ctx == nil {
+		return nil, errors.New("no security context")
+	}
+
+	return c.ctx.GetMIC(payload)
+}
+
+// VerifyMIC verifies a MIC token.
+// Returns an error if the context is not established.
+func (c *NegotiateClient) VerifyMIC(token *gssapi.MICToken, payload []byte) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.ctx == nil {
+		return false, errors.New("no security context")
+	}
+
+	return c.ctx.VerifyMIC(token, payload)
+}
+
+// Wrap encrypts and signs the payload.
+// Returns an error if the context is not established.
+func (c *NegotiateClient) Wrap(payload []byte) (*gssapi.WrapToken, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.ctx == nil {
+		return nil, errors.New("no security context")
+	}
+
+	return c.ctx.Wrap(payload)
+}
+
+// Unwrap decrypts and verifies a wrapped payload.
+// Returns an error if the context is not established.
+func (c *NegotiateClient) Unwrap(token *gssapi.WrapToken) ([]byte, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.ctx == nil {
+		return nil, errors.New("no security context")
+	}
+
+	return c.ctx.Unwrap(token)
+}
+
+// SessionKey returns the session key from the security context.
+// This is useful for protocols that need the raw key (like WinRM).
+func (c *NegotiateClient) SessionKey() (types.EncryptionKey, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.ctx == nil {
+		return types.EncryptionKey{}, errors.New("no security context")
+	}
+
+	return c.ctx.GetKey(), nil
+}

--- a/spnego/negotiate_client.go
+++ b/spnego/negotiate_client.go
@@ -152,7 +152,7 @@ func (c *NegotiateClient) handleInitialChallenge(req *http.Request) (*http.Respo
 		flagsUint |= uint32(f)
 	}
 
-	c.ctx = NewClientContext(sessionKey, flagsUint)
+	c.ctx = NewClientContext(sessionKey, flagsUint, negTokenInit.InitialSeqNum())
 
 	// Store the raw MechTypes DER for MIC computation.
 	c.ctx.SetMechTypeListDER(negTokenInit.RawMechTypesDER())

--- a/spnego/negotiate_client.go
+++ b/spnego/negotiate_client.go
@@ -598,8 +598,9 @@ func (c *NegotiateClient) Wrap(payload []byte) (*gssapi.WrapToken, error) {
 	return c.ctx.Wrap(payload)
 }
 
-// Unwrap decrypts and verifies a wrapped payload.
+// Unwrap verifies a sign-only wrapped payload and returns the plaintext.
 // Returns an error if the context is not established.
+// For encrypted (sealed) tokens, use UnwrapSealed or UnwrapAuto instead.
 func (c *NegotiateClient) Unwrap(token *gssapi.WrapToken) ([]byte, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -609,6 +610,47 @@ func (c *NegotiateClient) Unwrap(token *gssapi.WrapToken) ([]byte, error) {
 	}
 
 	return c.ctx.Unwrap(token)
+}
+
+// WrapSealed creates an encrypted (sealed) wrap token for the given payload.
+// This provides confidentiality in addition to integrity per RFC 4121.
+// Returns an error if the context is not established.
+func (c *NegotiateClient) WrapSealed(payload []byte) ([]byte, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.ctx == nil {
+		return nil, errors.New("no security context")
+	}
+
+	return c.ctx.WrapSealed(payload)
+}
+
+// UnwrapSealed decrypts a sealed wrap token and returns the plaintext.
+// Returns an error if the context is not established.
+func (c *NegotiateClient) UnwrapSealed(tokenBytes []byte) ([]byte, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.ctx == nil {
+		return nil, errors.New("no security context")
+	}
+
+	return c.ctx.UnwrapSealed(tokenBytes)
+}
+
+// UnwrapAuto automatically detects whether a token is sealed or sign-only and processes it.
+// This provides a unified API similar to SSPI's DecryptMessage.
+// Returns an error if the context is not established.
+func (c *NegotiateClient) UnwrapAuto(tokenBytes []byte) (*gssapi.UnwrapResult, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.ctx == nil {
+		return nil, errors.New("no security context")
+	}
+
+	return c.ctx.UnwrapAuto(tokenBytes)
 }
 
 // SessionKey returns the session key from the security context.

--- a/spnego/negotiate_client.go
+++ b/spnego/negotiate_client.go
@@ -89,9 +89,10 @@ func (c *NegotiateClient) RoundTrip(req *http.Request) (*http.Response, error) {
 		return resp, nil
 	}
 
-	// Check for WWW-Authenticate: Negotiate header.
-	authHeader := resp.Header.Get(HTTPHeaderAuthResponse)
-	if !strings.HasPrefix(authHeader, HTTPHeaderAuthResponseValueKey) {
+	// Check for WWW-Authenticate: Negotiate header(s).
+	// HTTP allows multiple WWW-Authenticate headers (e.g., Negotiate and Kerberos).
+	challenge := findNegotiateChallenge(resp.Header)
+	if challenge == nil {
 		return resp, nil
 	}
 
@@ -99,17 +100,13 @@ func (c *NegotiateClient) RoundTrip(req *http.Request) (*http.Response, error) {
 	_, _ = io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 
-	// Step 1: Handle bare "Negotiate" - send initial token.
-	authValue := strings.TrimPrefix(authHeader, HTTPHeaderAuthResponseValueKey)
-	authValue = strings.TrimSpace(authValue)
-
-	if authValue == "" {
+	if !challenge.hasToken {
 		// Bare Negotiate header - start authentication.
 		return c.handleInitialChallenge(req)
 	}
 
-	// Step 2: Handle "Negotiate <token>" - process server response.
-	return c.handleServerToken(req, authValue)
+	// Handle "Negotiate <token>" - process server response.
+	return c.handleServerToken(req, challenge.token)
 }
 
 // handleInitialChallenge processes the initial 401 with bare "Negotiate" header.
@@ -187,19 +184,15 @@ func (c *NegotiateClient) handleInitialChallenge(req *http.Request) (*http.Respo
 
 	// Check if we got a success (2xx) or another challenge (401).
 	if resp.StatusCode == http.StatusUnauthorized {
-		// Check for another Negotiate challenge.
-		authHeader := resp.Header.Get(HTTPHeaderAuthResponse)
-		if authValue, found := strings.CutPrefix(authHeader, HTTPHeaderAuthResponseValueKey); found {
-			authValue = strings.TrimSpace(authValue)
+		// Check for another Negotiate challenge with a token.
+		challenge := findNegotiateChallenge(resp.Header)
+		if challenge != nil && challenge.hasToken {
+			// Drain and close response body.
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
 
-			if authValue != "" {
-				// Drain and close response body.
-				_, _ = io.Copy(io.Discard, resp.Body)
-				resp.Body.Close()
-
-				// Process server's response token.
-				return c.handleServerToken(newReq, authValue)
-			}
+			// Process server's response token.
+			return c.handleServerToken(newReq, challenge.token)
 		}
 	}
 
@@ -222,11 +215,12 @@ func (c *NegotiateClient) handleServerToken(req *http.Request, tokenB64 string) 
 		return nil, err
 	}
 
-	if err := c.processNegTokenResp(negResp); err != nil {
+	responseToken, err := c.processNegTokenResp(negResp)
+	if err != nil {
 		return nil, err
 	}
 
-	return c.sendFinalRequest(req)
+	return c.sendFinalRequest(req, responseToken)
 }
 
 // decodeNegTokenResp decodes a base64 token and returns the NegTokenResp.
@@ -252,34 +246,72 @@ func (c *NegotiateClient) decodeNegTokenResp(tokenB64 string) (*NegTokenResp, er
 }
 
 // processNegTokenResp processes the negotiation response state and tokens.
-func (c *NegotiateClient) processNegTokenResp(negResp *NegTokenResp) error {
+// Returns a client response token (may be nil) to send back to the server.
+func (c *NegotiateClient) processNegTokenResp(negResp *NegTokenResp) ([]byte, error) {
 	switch negResp.State() {
 	case NegStateReject:
 		c.ctx.SetFailed()
-		return errors.New("server rejected authentication")
+		return nil, errors.New("server rejected authentication")
 
 	case NegStateAcceptCompleted, NegStateAcceptIncomplete:
 		if err := c.verifyResponseToken(negResp); err != nil {
-			return err
+			return nil, err
 		}
 
 		if err := c.verifyMechListMIC(negResp); err != nil {
-			return err
+			return nil, err
 		}
 
 		if negResp.State() == NegStateAcceptCompleted {
 			if err := c.ctx.SetEstablished(); err != nil {
 				c.ctx.SetFailed()
-				return fmt.Errorf("failed to establish context: %w", err)
+				return nil, fmt.Errorf("failed to establish context: %w", err)
 			}
 		}
 
 	case NegStateRequestMIC:
-		c.ctx.SetFailed()
-		return errors.New("server requested MIC - not supported")
+		// Server requested mechListMIC - generate and return a response token.
+		if err := c.verifyResponseToken(negResp); err != nil {
+			return nil, err
+		}
+
+		responseToken, err := c.buildMICResponseToken()
+		if err != nil {
+			c.ctx.SetFailed()
+			return nil, fmt.Errorf("failed to build MIC response: %w", err)
+		}
+
+		return responseToken, nil
 	}
 
-	return nil
+	return nil, nil
+}
+
+// buildMICResponseToken creates a NegTokenResp containing only the mechListMIC.
+// This is sent in response to NegStateRequestMIC from the server.
+func (c *NegotiateClient) buildMICResponseToken() ([]byte, error) {
+	mic, err := c.ctx.MechListMIC()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate mechListMIC: %w", err)
+	}
+
+	// Build a NegTokenResp with just the mechListMIC.
+	clientResp := NegTokenResp{
+		MechListMIC: mic,
+	}
+
+	// Wrap in SPNEGOToken for marshaling.
+	spnegoToken := &SPNEGOToken{
+		Resp:         true,
+		NegTokenResp: clientResp,
+	}
+
+	tokenBytes, err := spnegoToken.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal response token: %w", err)
+	}
+
+	return tokenBytes, nil
 }
 
 // verifyResponseToken verifies the KRB5 token in the response.
@@ -332,8 +364,14 @@ func (c *NegotiateClient) verifyMechListMIC(negResp *NegTokenResp) error {
 }
 
 // sendFinalRequest sends the final request after processing the server token.
-func (c *NegotiateClient) sendFinalRequest(req *http.Request) (*http.Response, error) {
+// If responseToken is non-nil, it is included in the Authorization header.
+func (c *NegotiateClient) sendFinalRequest(req *http.Request, responseToken []byte) (*http.Response, error) {
 	newReq := cloneRequest(req)
+
+	// Include response token in Authorization header if provided.
+	if len(responseToken) > 0 {
+		newReq.Header.Set(HTTPHeaderAuthRequest, HTTPHeaderAuthResponseValueKey+" "+base64.StdEncoding.EncodeToString(responseToken))
+	}
 
 	resp, err := c.transport.RoundTrip(newReq)
 	if err != nil {
@@ -367,19 +405,16 @@ func (c *NegotiateClient) handleSuccessResponse(resp *http.Response) (*http.Resp
 
 // processFinalAuthToken processes a final Negotiate token in the response header.
 func (c *NegotiateClient) processFinalAuthToken(resp *http.Response) error {
-	authHeader := resp.Header.Get(HTTPHeaderAuthResponse)
-
-	authValue, found := strings.CutPrefix(authHeader, HTTPHeaderAuthResponseValueKey)
-	if !found {
+	challenge := findNegotiateChallenge(resp.Header)
+	if challenge == nil || !challenge.hasToken {
 		return nil
 	}
 
-	authValue = strings.TrimSpace(authValue)
-	if authValue == "" || c.ctx == nil || c.ctx.State() != ContextStateInProgress {
+	if c.ctx == nil || c.ctx.State() != ContextStateInProgress {
 		return nil
 	}
 
-	tokenBytes, err := base64.StdEncoding.DecodeString(authValue)
+	tokenBytes, err := base64.StdEncoding.DecodeString(challenge.token)
 	if err != nil {
 		c.ctx.SetFailed()
 		return fmt.Errorf("failed to decode final token: %w", err)
@@ -471,6 +506,47 @@ func cloneRequest(req *http.Request) *http.Request {
 	}
 
 	return newReq
+}
+
+// negotiateChallenge represents a parsed Negotiate challenge from WWW-Authenticate.
+type negotiateChallenge struct {
+	// hasToken indicates whether the challenge includes a token.
+	hasToken bool
+	// token is the base64-encoded token (empty if hasToken is false).
+	token string
+}
+
+// findNegotiateChallenge searches through all WWW-Authenticate headers to find
+// the best Negotiate challenge. It prefers "Negotiate <token>" over bare "Negotiate".
+// Returns nil if no Negotiate challenge is found.
+func findNegotiateChallenge(headers http.Header) *negotiateChallenge {
+	values := headers.Values(HTTPHeaderAuthResponse)
+	if len(values) == 0 {
+		return nil
+	}
+
+	var bareNegotiate *negotiateChallenge
+
+	for _, value := range values {
+		if !strings.HasPrefix(value, HTTPHeaderAuthResponseValueKey) {
+			continue
+		}
+
+		token := strings.TrimPrefix(value, HTTPHeaderAuthResponseValueKey)
+		token = strings.TrimSpace(token)
+
+		if token != "" {
+			// Prefer "Negotiate <token>" - return immediately.
+			return &negotiateChallenge{hasToken: true, token: token}
+		}
+
+		// Remember bare "Negotiate" in case we don't find one with a token.
+		if bareNegotiate == nil {
+			bareNegotiate = &negotiateChallenge{hasToken: false, token: ""}
+		}
+	}
+
+	return bareNegotiate
 }
 
 // NegotiatingRoundTripper is an http.RoundTripper that handles SPNEGO authentication.

--- a/spnego/negotiate_client_test.go
+++ b/spnego/negotiate_client_test.go
@@ -76,7 +76,7 @@ func TestContextStateTransitions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := NewClientContext(dummySessionKey(), 0)
+			ctx := NewClientContext(dummySessionKey(), 0, 0)
 			tt.setup(ctx)
 
 			err := tt.action(ctx)
@@ -140,7 +140,7 @@ func TestContextGating(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := NewClientContext(dummySessionKey(), 0)
+			ctx := NewClientContext(dummySessionKey(), 0, 0)
 
 			// Set up state.
 			switch tt.state {
@@ -429,7 +429,7 @@ func TestContextStateString(t *testing.T) {
 // TestMechTypeListDERPreservation tests that the raw DER is correctly preserved.
 func TestMechTypeListDERPreservation(t *testing.T) {
 	// Create a context with a known MechTypeList DER.
-	ctx := NewClientContext(dummySessionKey(), 0)
+	ctx := NewClientContext(dummySessionKey(), 0, 0)
 
 	originalDER := []byte{0x30, 0x0D, 0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x12, 0x01, 0x02, 0x02}
 	ctx.SetMechTypeListDER(originalDER)
@@ -511,7 +511,7 @@ func TestNegotiateClientReset(t *testing.T) {
 	client := NewNegotiateClient(nil, "HTTP/test")
 
 	// Simulate having a context.
-	client.ctx = NewClientContext(dummySessionKey(), 0)
+	client.ctx = NewClientContext(dummySessionKey(), 0, 0)
 	_ = client.ctx.SetInProgress()
 
 	assert.NotNil(t, client.ctx)
@@ -531,7 +531,7 @@ func TestNegotiateClientIsEstablished(t *testing.T) {
 	assert.False(t, client.IsEstablished())
 
 	// Context not established.
-	client.ctx = NewClientContext(dummySessionKey(), 0)
+	client.ctx = NewClientContext(dummySessionKey(), 0, 0)
 	assert.False(t, client.IsEstablished())
 
 	// Context in progress.
@@ -575,7 +575,7 @@ func TestExtractRawMechTypesDER(t *testing.T) {
 
 // TestClientContextSetFailed tests the SetFailed method.
 func TestClientContextSetFailed(t *testing.T) {
-	ctx := NewClientContext(dummySessionKey(), 0)
+	ctx := NewClientContext(dummySessionKey(), 0, 0)
 	_ = ctx.SetInProgress()
 
 	assert.Equal(t, ContextStateInProgress, ctx.State())
@@ -588,7 +588,7 @@ func TestClientContextSetFailed(t *testing.T) {
 // TestClientContextGetKey tests the GetKey method with and without subkey.
 func TestClientContextGetKey(t *testing.T) {
 	sessionKey := dummySessionKey()
-	ctx := NewClientContext(sessionKey, 0)
+	ctx := NewClientContext(sessionKey, 0, 0)
 
 	// Without subkey, should return session key.
 	key := ctx.GetKey()
@@ -610,7 +610,7 @@ func TestClientContextGetKey(t *testing.T) {
 
 // TestClientContextHasAcceptorSubkey tests the HasAcceptorSubkey method.
 func TestClientContextHasAcceptorSubkey(t *testing.T) {
-	ctx := NewClientContext(dummySessionKey(), 0)
+	ctx := NewClientContext(dummySessionKey(), 0, 0)
 
 	assert.False(t, ctx.HasAcceptorSubkey())
 
@@ -626,23 +626,39 @@ func TestClientContextHasAcceptorSubkey(t *testing.T) {
 
 // TestClientContextSequenceNumbers tests the sequence number methods.
 func TestClientContextSequenceNumbers(t *testing.T) {
-	ctx := NewClientContext(dummySessionKey(), 0)
+	t.Run("starts at zero by default", func(t *testing.T) {
+		ctx := NewClientContext(dummySessionKey(), 0, 0)
 
-	// Test send sequence numbers.
-	assert.Equal(t, uint64(0), ctx.NextSendSeqNum())
-	assert.Equal(t, uint64(1), ctx.NextSendSeqNum())
-	assert.Equal(t, uint64(2), ctx.NextSendSeqNum())
+		// Test send sequence numbers start at 0.
+		assert.Equal(t, uint64(0), ctx.NextSendSeqNum())
+		assert.Equal(t, uint64(1), ctx.NextSendSeqNum())
+		assert.Equal(t, uint64(2), ctx.NextSendSeqNum())
 
-	// Test receive sequence numbers.
-	assert.Equal(t, uint64(0), ctx.NextRecvSeqNum())
-	assert.Equal(t, uint64(1), ctx.NextRecvSeqNum())
-	assert.Equal(t, uint64(2), ctx.NextRecvSeqNum())
+		// Test receive sequence numbers start at 0.
+		assert.Equal(t, uint64(0), ctx.NextRecvSeqNum())
+		assert.Equal(t, uint64(1), ctx.NextRecvSeqNum())
+		assert.Equal(t, uint64(2), ctx.NextRecvSeqNum())
+	})
+
+	t.Run("respects initial sequence number", func(t *testing.T) {
+		// Simulate a sequence number from the Authenticator (30-bit masked).
+		initialSeqNum := int64(0x12345678)
+		ctx := NewClientContext(dummySessionKey(), 0, initialSeqNum)
+
+		// Send sequence numbers should start at the initial value.
+		assert.Equal(t, uint64(initialSeqNum), ctx.NextSendSeqNum())
+		assert.Equal(t, uint64(initialSeqNum+1), ctx.NextSendSeqNum())
+		assert.Equal(t, uint64(initialSeqNum+2), ctx.NextSendSeqNum())
+
+		// Receive sequence numbers still start at 0 (set later from AP-REP).
+		assert.Equal(t, uint64(0), ctx.NextRecvSeqNum())
+	})
 }
 
 // TestClientContextFlags tests the Flags method.
 func TestClientContextFlags(t *testing.T) {
 	flags := uint32(0x1234)
-	ctx := NewClientContext(dummySessionKey(), flags)
+	ctx := NewClientContext(dummySessionKey(), flags, 0)
 
 	assert.Equal(t, flags, ctx.Flags())
 }
@@ -665,7 +681,7 @@ func TestMarshalMechTypeList(t *testing.T) {
 
 // TestMechListMICWithoutDER tests MechListMIC when DER bytes are not set.
 func TestMechListMICWithoutDER(t *testing.T) {
-	ctx := NewClientContext(dummySessionKey(), 0)
+	ctx := NewClientContext(dummySessionKey(), 0, 0)
 	_ = ctx.SetInProgress()
 	_ = ctx.SetEstablished()
 
@@ -677,7 +693,7 @@ func TestMechListMICWithoutDER(t *testing.T) {
 
 // TestVerifyMechListMICWithoutDER tests VerifyMechListMIC when DER bytes are not set.
 func TestVerifyMechListMICWithoutDER(t *testing.T) {
-	ctx := NewClientContext(dummySessionKey(), 0)
+	ctx := NewClientContext(dummySessionKey(), 0, 0)
 	_ = ctx.SetInProgress()
 	_ = ctx.SetEstablished()
 
@@ -689,7 +705,7 @@ func TestVerifyMechListMICWithoutDER(t *testing.T) {
 
 // TestVerifyMICNotEstablished tests VerifyMIC when context is not established.
 func TestVerifyMICNotEstablished(t *testing.T) {
-	ctx := NewClientContext(dummySessionKey(), 0)
+	ctx := NewClientContext(dummySessionKey(), 0, 0)
 
 	// VerifyMIC should fail when not established.
 	_, err := ctx.VerifyMIC(&gssapi.MICToken{}, []byte("payload"))
@@ -699,7 +715,7 @@ func TestVerifyMICNotEstablished(t *testing.T) {
 
 // TestUnwrapNotEstablished tests Unwrap when context is not established.
 func TestUnwrapNotEstablished(t *testing.T) {
-	ctx := NewClientContext(dummySessionKey(), 0)
+	ctx := NewClientContext(dummySessionKey(), 0, 0)
 
 	// Unwrap should fail when not established.
 	_, err := ctx.Unwrap(&gssapi.WrapToken{})
@@ -734,7 +750,7 @@ func TestKRB5TokenVerifyAPRepNotAPRep(t *testing.T) {
 	token := &KRB5Token{}
 	token.tokID, _ = decodeHex(TOK_ID_KRB_AP_REQ)
 
-	ctx := NewClientContext(dummySessionKey(), 0)
+	ctx := NewClientContext(dummySessionKey(), 0, 0)
 	_ = ctx.SetInProgress()
 
 	ok, status := token.VerifyAPRep(ctx)
@@ -786,7 +802,7 @@ func TestNegotiateClientContext(t *testing.T) {
 	assert.Nil(t, client.Context())
 
 	// Set a context.
-	client.ctx = NewClientContext(dummySessionKey(), 0)
+	client.ctx = NewClientContext(dummySessionKey(), 0, 0)
 	assert.NotNil(t, client.Context())
 }
 
@@ -810,7 +826,7 @@ func TestNegotiateClientSessionKey(t *testing.T) {
 
 	// With context.
 	sessionKey := dummySessionKey()
-	client.ctx = NewClientContext(sessionKey, 0)
+	client.ctx = NewClientContext(sessionKey, 0, 0)
 	key, err := client.SessionKey()
 	require.NoError(t, err)
 	assert.Equal(t, sessionKey.KeyType, key.KeyType)
@@ -827,7 +843,7 @@ func TestNegotiateClientGetMIC(t *testing.T) {
 	assert.Contains(t, err.Error(), "no security context")
 
 	// With context but not established.
-	client.ctx = NewClientContext(dummySessionKey(), 0)
+	client.ctx = NewClientContext(dummySessionKey(), 0, 0)
 	_, err = client.GetMIC([]byte("test"))
 	assert.Error(t, err)
 }

--- a/spnego/negotiate_client_test.go
+++ b/spnego/negotiate_client_test.go
@@ -1,0 +1,938 @@
+package spnego
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/x/encoding/asn1"
+
+	"github.com/go-krb5/krb5/gssapi"
+	"github.com/go-krb5/krb5/types"
+)
+
+// TestContextStateTransitions tests the state machine transitions.
+func TestContextStateTransitions(t *testing.T) {
+	tests := []struct {
+		name          string
+		setup         func(*ClientContext)
+		action        func(*ClientContext) error
+		expectedState ContextState
+		expectError   bool
+	}{
+		{
+			name:          "Initial to InProgress",
+			setup:         func(c *ClientContext) {},
+			action:        func(c *ClientContext) error { return c.SetInProgress() },
+			expectedState: ContextStateInProgress,
+			expectError:   false,
+		},
+		{
+			name: "InProgress to Established (no mutual auth)",
+			setup: func(c *ClientContext) {
+				_ = c.SetInProgress()
+			},
+			action:        func(c *ClientContext) error { return c.SetEstablished() },
+			expectedState: ContextStateEstablished,
+			expectError:   false,
+		},
+		{
+			name: "InProgress to Established fails when mutual auth required but not done",
+			setup: func(c *ClientContext) {
+				c.SetMutualAuthRequired(true)
+				_ = c.SetInProgress()
+			},
+			action:        func(c *ClientContext) error { return c.SetEstablished() },
+			expectedState: ContextStateInProgress,
+			expectError:   true,
+		},
+		{
+			name: "Cannot SetInProgress from Established",
+			setup: func(c *ClientContext) {
+				_ = c.SetInProgress()
+				_ = c.SetEstablished()
+			},
+			action:        func(c *ClientContext) error { return c.SetInProgress() },
+			expectedState: ContextStateEstablished,
+			expectError:   true,
+		},
+		{
+			name: "Cannot SetEstablished from Initial",
+			setup: func(c *ClientContext) {
+				// Don't transition to InProgress.
+			},
+			action:        func(c *ClientContext) error { return c.SetEstablished() },
+			expectedState: ContextStateInitial,
+			expectError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := NewClientContext(dummySessionKey(), 0)
+			tt.setup(ctx)
+
+			err := tt.action(ctx)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.expectedState, ctx.State())
+		})
+	}
+}
+
+// TestContextGating tests that Wrap/GetMIC operations are gated on establishment.
+func TestContextGating(t *testing.T) {
+	tests := []struct {
+		name        string
+		state       ContextState
+		operation   string
+		expectError bool
+	}{
+		{
+			name:        "Wrap fails when Initial",
+			state:       ContextStateInitial,
+			operation:   "wrap",
+			expectError: true,
+		},
+		{
+			name:        "Wrap fails when InProgress",
+			state:       ContextStateInProgress,
+			operation:   "wrap",
+			expectError: true,
+		},
+		{
+			name:        "Wrap succeeds when Established",
+			state:       ContextStateEstablished,
+			operation:   "wrap",
+			expectError: false,
+		},
+		{
+			name:        "GetMIC fails when Initial",
+			state:       ContextStateInitial,
+			operation:   "getmic",
+			expectError: true,
+		},
+		{
+			name:        "GetMIC fails when InProgress",
+			state:       ContextStateInProgress,
+			operation:   "getmic",
+			expectError: true,
+		},
+		{
+			name:        "GetMIC succeeds when Established",
+			state:       ContextStateEstablished,
+			operation:   "getmic",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := NewClientContext(dummySessionKey(), 0)
+
+			// Set up state.
+			switch tt.state {
+			case ContextStateInProgress:
+				_ = ctx.SetInProgress()
+			case ContextStateEstablished:
+				_ = ctx.SetInProgress()
+				_ = ctx.SetEstablished()
+			}
+
+			var err error
+
+			switch tt.operation {
+			case "wrap":
+				_, err = ctx.Wrap([]byte("test payload"))
+			case "getmic":
+				_, err = ctx.GetMIC([]byte("test payload"))
+			}
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "not established")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestNegTokenInitRawMechTypesDER tests that raw MechTypes DER is preserved.
+func TestNegTokenInitRawMechTypesDER(t *testing.T) {
+	// Create a NegTokenInit with MechTypes.
+	mechTypes := []asn1.ObjectIdentifier{gssapi.OIDKRB5.OID()}
+
+	// Marshal MechTypes to get expected DER.
+	expectedDER, err := asn1.Marshal(mechTypes, asn1.WithMarshalSlicePreserveTypes(true))
+	require.NoError(t, err)
+
+	// Create a NegTokenInit.
+	negTokenInit := NegTokenInit{
+		MechTypes:      mechTypes,
+		MechTokenBytes: []byte{0x01, 0x02, 0x03}, // Dummy token.
+	}
+
+	// Set the raw DER.
+	negTokenInit.SetRawMechTypesDER(expectedDER)
+
+	// Verify it's preserved.
+	assert.Equal(t, expectedDER, negTokenInit.RawMechTypesDER())
+
+	// Marshal and unmarshal to verify preservation through the cycle.
+	marshaled, err := negTokenInit.Marshal()
+	require.NoError(t, err)
+
+	var unmarshaled NegTokenInit
+
+	err = unmarshaled.Unmarshal(marshaled)
+	require.NoError(t, err)
+
+	// The raw DER should be extracted during unmarshal.
+	assert.NotEmpty(t, unmarshaled.RawMechTypesDER())
+}
+
+// TestNegotiateServerFlow tests the multi-leg SPNEGO flow with a mock server.
+func TestNegotiateServerFlow(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverBehavior []serverResponse
+		expectSuccess  bool
+		expectError    bool
+	}{
+		{
+			name: "Single leg - 401 then 200",
+			serverBehavior: []serverResponse{
+				{statusCode: 401, header: "Negotiate"},
+				{statusCode: 200, header: ""},
+			},
+			expectSuccess: true,
+			expectError:   false,
+		},
+		{
+			name: "Single leg - 401 then 200 with final token",
+			serverBehavior: []serverResponse{
+				{statusCode: 401, header: "Negotiate"},
+				{statusCode: 200, header: "Negotiate " + dummyNegTokenRespAcceptCompleted()},
+			},
+			expectSuccess: true,
+			expectError:   false,
+		},
+		{
+			name: "Multi leg - 401, 401 with token, then 200",
+			serverBehavior: []serverResponse{
+				{statusCode: 401, header: "Negotiate"},
+				{statusCode: 401, header: "Negotiate " + dummyNegTokenRespAcceptIncomplete()},
+				{statusCode: 200, header: ""},
+			},
+			expectSuccess: true,
+			expectError:   false,
+		},
+		{
+			name: "Server rejects",
+			serverBehavior: []serverResponse{
+				{statusCode: 401, header: "Negotiate"},
+				{statusCode: 401, header: "Negotiate " + dummyNegTokenRespReject()},
+			},
+			expectSuccess: false,
+			expectError:   true,
+		},
+		{
+			name: "No Negotiate header - pass through",
+			serverBehavior: []serverResponse{
+				{statusCode: 401, header: "Basic realm=\"test\""},
+			},
+			expectSuccess: false,
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock server.
+			requestCount := 0
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if requestCount >= len(tt.serverBehavior) {
+					t.Errorf("unexpected request %d", requestCount)
+					w.WriteHeader(http.StatusInternalServerError)
+
+					return
+				}
+
+				resp := tt.serverBehavior[requestCount]
+				requestCount++
+
+				if resp.header != "" {
+					w.Header().Set(HTTPHeaderAuthResponse, resp.header)
+				}
+
+				w.WriteHeader(resp.statusCode)
+				_, _ = w.Write([]byte("OK"))
+			}))
+			defer server.Close()
+
+			// Create a mock transport that doesn't actually do SPNEGO.
+			// This tests the state machine flow without real Kerberos.
+			mockTransport := &mockSPNEGOTransport{
+				underlying: server.Client().Transport,
+				serverURL:  server.URL,
+			}
+
+			// Test the flow by directly testing the state machine.
+			// Since we don't have a real KRB5 client, we test the token parsing.
+			req, err := http.NewRequest("GET", server.URL, nil)
+			require.NoError(t, err)
+
+			resp, err := mockTransport.RoundTrip(req)
+
+			if tt.expectError {
+				// For error cases, we simulate by checking response.
+				if err == nil && resp != nil {
+					resp.Body.Close()
+				}
+			} else {
+				require.NoError(t, err)
+
+				if resp != nil {
+					_, _ = io.ReadAll(resp.Body)
+					resp.Body.Close()
+				}
+			}
+		})
+	}
+}
+
+// TestNegTokenRespParsing tests parsing of various NegTokenResp formats.
+func TestNegTokenRespParsing(t *testing.T) {
+	tests := []struct {
+		name        string
+		tokenB64    string
+		expectState NegState
+		expectError bool
+	}{
+		{
+			name:        "Accept Completed",
+			tokenB64:    dummyNegTokenRespAcceptCompleted(),
+			expectState: NegStateAcceptCompleted,
+			expectError: false,
+		},
+		{
+			name:        "Accept Incomplete",
+			tokenB64:    dummyNegTokenRespAcceptIncomplete(),
+			expectState: NegStateAcceptIncomplete,
+			expectError: false,
+		},
+		{
+			name:        "Reject",
+			tokenB64:    dummyNegTokenRespReject(),
+			expectState: NegStateReject,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokenBytes, err := base64.StdEncoding.DecodeString(tt.tokenB64)
+			require.NoError(t, err)
+
+			var spnegoToken SPNEGOToken
+
+			err = spnegoToken.Unmarshal(tokenBytes)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.True(t, spnegoToken.Resp)
+				assert.Equal(t, tt.expectState, spnegoToken.NegTokenResp.State())
+			}
+		})
+	}
+}
+
+// TestKRB5TokenTypeDetection tests detection of KRB5 token types.
+func TestKRB5TokenTypeDetection(t *testing.T) {
+	tests := []struct {
+		name     string
+		tokIDHex string
+		isAPReq  bool
+		isAPRep  bool
+		isKRBErr bool
+	}{
+		{
+			name:     "AP-REQ token",
+			tokIDHex: TOK_ID_KRB_AP_REQ,
+			isAPReq:  true,
+			isAPRep:  false,
+			isKRBErr: false,
+		},
+		{
+			name:     "AP-REP token",
+			tokIDHex: TOK_ID_KRB_AP_REP,
+			isAPReq:  false,
+			isAPRep:  true,
+			isKRBErr: false,
+		},
+		{
+			name:     "KRB-ERROR token",
+			tokIDHex: TOK_ID_KRB_ERROR,
+			isAPReq:  false,
+			isAPRep:  false,
+			isKRBErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token := &KRB5Token{}
+			token.tokID, _ = decodeHex(tt.tokIDHex)
+
+			assert.Equal(t, tt.isAPReq, token.IsAPReq())
+			assert.Equal(t, tt.isAPRep, token.IsAPRep())
+			assert.Equal(t, tt.isKRBErr, token.IsKRBError())
+		})
+	}
+}
+
+// TestContextStateString tests the String method of ContextState.
+func TestContextStateString(t *testing.T) {
+	tests := []struct {
+		state    ContextState
+		expected string
+	}{
+		{ContextStateInitial, "Initial"},
+		{ContextStateInProgress, "InProgress"},
+		{ContextStateEstablished, "Established"},
+		{ContextStateFailed, "Failed"},
+		{ContextState(99), "Unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.state.String())
+		})
+	}
+}
+
+// TestMechTypeListDERPreservation tests that the raw DER is correctly preserved.
+func TestMechTypeListDERPreservation(t *testing.T) {
+	// Create a context with a known MechTypeList DER.
+	ctx := NewClientContext(dummySessionKey(), 0)
+
+	originalDER := []byte{0x30, 0x0D, 0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x12, 0x01, 0x02, 0x02}
+	ctx.SetMechTypeListDER(originalDER)
+
+	// Verify the DER is stored.
+	storedDER := ctx.MechTypeListDER()
+	assert.Equal(t, originalDER, storedDER)
+
+	// Verify it's a copy (modifying original shouldn't affect stored).
+	originalDER[0] = 0xFF
+	assert.NotEqual(t, originalDER[0], storedDER[0])
+}
+
+// Helper types and functions for testing.
+
+type serverResponse struct {
+	statusCode int
+	header     string
+}
+
+type mockSPNEGOTransport struct {
+	underlying http.RoundTripper
+	serverURL  string
+}
+
+func (t *mockSPNEGOTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.underlying.RoundTrip(req)
+}
+
+// dummySessionKey creates a dummy session key for testing.
+func dummySessionKey() types.EncryptionKey {
+	return types.EncryptionKey{
+		KeyType:  17, // AES128-CTS-HMAC-SHA1-96.
+		KeyValue: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+	}
+}
+
+// dummyNegTokenRespAcceptCompleted returns a base64-encoded NegTokenResp with AcceptCompleted.
+func dummyNegTokenRespAcceptCompleted() string {
+	// This is a pre-computed NegTokenResp with state=accept-completed and KRB5 mech.
+	return "oRQwEqADCgEAoQsGCSqGSIb3EgECAg=="
+}
+
+// dummyNegTokenRespAcceptIncomplete returns a base64-encoded NegTokenResp with AcceptIncomplete.
+func dummyNegTokenRespAcceptIncomplete() string {
+	// This is a pre-computed NegTokenResp with state=accept-incomplete and KRB5 mech.
+	return "oRQwEqADCgEBoQsGCSqGSIb3EgECAg=="
+}
+
+// dummyNegTokenRespReject returns a base64-encoded NegTokenResp with Reject.
+func dummyNegTokenRespReject() string {
+	// This is a pre-computed NegTokenResp with state=reject.
+	return "oQcwBaADCgEC"
+}
+
+func decodeHex(s string) ([]byte, error) {
+	return hex.DecodeString(s)
+}
+
+// TestNegotiateClientOptions tests the option functions.
+func TestNegotiateClientOptions(t *testing.T) {
+	t.Run("WithMutualAuth", func(t *testing.T) {
+		client := NewNegotiateClient(nil, "HTTP/test", WithMutualAuth(false))
+		assert.False(t, client.mutualAuth)
+
+		client2 := NewNegotiateClient(nil, "HTTP/test", WithMutualAuth(true))
+		assert.True(t, client2.mutualAuth)
+	})
+
+	t.Run("WithTransport", func(t *testing.T) {
+		customTransport := &http.Transport{}
+		client := NewNegotiateClient(nil, "HTTP/test", WithTransport(customTransport))
+		assert.Equal(t, customTransport, client.transport)
+	})
+}
+
+// TestNegotiateClientReset tests that Reset clears the context.
+func TestNegotiateClientReset(t *testing.T) {
+	client := NewNegotiateClient(nil, "HTTP/test")
+
+	// Simulate having a context.
+	client.ctx = NewClientContext(dummySessionKey(), 0)
+	_ = client.ctx.SetInProgress()
+
+	assert.NotNil(t, client.ctx)
+
+	// Reset.
+	client.Reset()
+
+	assert.Nil(t, client.ctx)
+	assert.Nil(t, client.negTokenInit)
+}
+
+// TestNegotiateClientIsEstablished tests the IsEstablished method.
+func TestNegotiateClientIsEstablished(t *testing.T) {
+	client := NewNegotiateClient(nil, "HTTP/test")
+
+	// No context.
+	assert.False(t, client.IsEstablished())
+
+	// Context not established.
+	client.ctx = NewClientContext(dummySessionKey(), 0)
+	assert.False(t, client.IsEstablished())
+
+	// Context in progress.
+	_ = client.ctx.SetInProgress()
+	assert.False(t, client.IsEstablished())
+
+	// Context established.
+	_ = client.ctx.SetEstablished()
+	assert.True(t, client.IsEstablished())
+}
+
+// TestExtractRawMechTypesDER tests the DER extraction function.
+func TestExtractRawMechTypesDER(t *testing.T) {
+	// Create a valid NegTokenInit and marshal it.
+	mechTypes := []asn1.ObjectIdentifier{gssapi.OIDKRB5.OID()}
+	negTokenInit := NegTokenInit{
+		MechTypes:      mechTypes,
+		MechTokenBytes: []byte{0x01, 0x02, 0x03},
+	}
+
+	// Marshal.
+	marshaled, err := negTokenInit.Marshal()
+	require.NoError(t, err)
+
+	// Unmarshal to trigger DER extraction.
+	var unmarshaled NegTokenInit
+
+	err = unmarshaled.Unmarshal(marshaled)
+	require.NoError(t, err)
+
+	// Verify the raw DER was extracted.
+	assert.NotEmpty(t, unmarshaled.RawMechTypesDER())
+
+	// The DER should be a valid SEQUENCE OF OID.
+	var oids []asn1.ObjectIdentifier
+
+	_, err = asn1.Unmarshal(unmarshaled.RawMechTypesDER(), &oids)
+	require.NoError(t, err)
+	assert.Equal(t, mechTypes, oids)
+}
+
+// TestClientContextSetFailed tests the SetFailed method.
+func TestClientContextSetFailed(t *testing.T) {
+	ctx := NewClientContext(dummySessionKey(), 0)
+	_ = ctx.SetInProgress()
+
+	assert.Equal(t, ContextStateInProgress, ctx.State())
+
+	ctx.SetFailed()
+
+	assert.Equal(t, ContextStateFailed, ctx.State())
+}
+
+// TestClientContextGetKey tests the GetKey method with and without subkey.
+func TestClientContextGetKey(t *testing.T) {
+	sessionKey := dummySessionKey()
+	ctx := NewClientContext(sessionKey, 0)
+
+	// Without subkey, should return session key.
+	key := ctx.GetKey()
+	assert.Equal(t, sessionKey.KeyType, key.KeyType)
+	assert.Equal(t, sessionKey.KeyValue, key.KeyValue)
+
+	// Simulate having a subkey by directly setting it.
+	subkey := types.EncryptionKey{
+		KeyType:  18, // AES256-CTS-HMAC-SHA1-96.
+		KeyValue: []byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30},
+	}
+	ctx.subkey = &subkey
+
+	// With subkey, should return subkey.
+	key = ctx.GetKey()
+	assert.Equal(t, subkey.KeyType, key.KeyType)
+	assert.Equal(t, subkey.KeyValue, key.KeyValue)
+}
+
+// TestClientContextHasAcceptorSubkey tests the HasAcceptorSubkey method.
+func TestClientContextHasAcceptorSubkey(t *testing.T) {
+	ctx := NewClientContext(dummySessionKey(), 0)
+
+	assert.False(t, ctx.HasAcceptorSubkey())
+
+	// Set a subkey.
+	subkey := types.EncryptionKey{
+		KeyType:  18,
+		KeyValue: []byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30},
+	}
+	ctx.subkey = &subkey
+
+	assert.True(t, ctx.HasAcceptorSubkey())
+}
+
+// TestClientContextSequenceNumbers tests the sequence number methods.
+func TestClientContextSequenceNumbers(t *testing.T) {
+	ctx := NewClientContext(dummySessionKey(), 0)
+
+	// Test send sequence numbers.
+	assert.Equal(t, uint64(0), ctx.NextSendSeqNum())
+	assert.Equal(t, uint64(1), ctx.NextSendSeqNum())
+	assert.Equal(t, uint64(2), ctx.NextSendSeqNum())
+
+	// Test receive sequence numbers.
+	assert.Equal(t, uint64(0), ctx.NextRecvSeqNum())
+	assert.Equal(t, uint64(1), ctx.NextRecvSeqNum())
+	assert.Equal(t, uint64(2), ctx.NextRecvSeqNum())
+}
+
+// TestClientContextFlags tests the Flags method.
+func TestClientContextFlags(t *testing.T) {
+	flags := uint32(0x1234)
+	ctx := NewClientContext(dummySessionKey(), flags)
+
+	assert.Equal(t, flags, ctx.Flags())
+}
+
+// TestMarshalMechTypeList tests the MarshalMechTypeList function.
+func TestMarshalMechTypeList(t *testing.T) {
+	mechTypes := []asn1.ObjectIdentifier{gssapi.OIDKRB5.OID()}
+
+	der, err := MarshalMechTypeList(mechTypes)
+	require.NoError(t, err)
+	assert.NotEmpty(t, der)
+
+	// Verify we can unmarshal it back.
+	var decoded []asn1.ObjectIdentifier
+
+	_, err = asn1.Unmarshal(der, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, mechTypes, decoded)
+}
+
+// TestMechListMICWithoutDER tests MechListMIC when DER bytes are not set.
+func TestMechListMICWithoutDER(t *testing.T) {
+	ctx := NewClientContext(dummySessionKey(), 0)
+	_ = ctx.SetInProgress()
+	_ = ctx.SetEstablished()
+
+	// MechListMIC should fail without DER bytes set.
+	_, err := ctx.MechListMIC()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "mechTypeList DER bytes not set")
+}
+
+// TestVerifyMechListMICWithoutDER tests VerifyMechListMIC when DER bytes are not set.
+func TestVerifyMechListMICWithoutDER(t *testing.T) {
+	ctx := NewClientContext(dummySessionKey(), 0)
+	_ = ctx.SetInProgress()
+	_ = ctx.SetEstablished()
+
+	// VerifyMechListMIC should fail without DER bytes set.
+	_, err := ctx.VerifyMechListMIC([]byte{0x01, 0x02, 0x03})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "mechTypeList DER bytes not set")
+}
+
+// TestVerifyMICNotEstablished tests VerifyMIC when context is not established.
+func TestVerifyMICNotEstablished(t *testing.T) {
+	ctx := NewClientContext(dummySessionKey(), 0)
+
+	// VerifyMIC should fail when not established.
+	_, err := ctx.VerifyMIC(&gssapi.MICToken{}, []byte("payload"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not established")
+}
+
+// TestUnwrapNotEstablished tests Unwrap when context is not established.
+func TestUnwrapNotEstablished(t *testing.T) {
+	ctx := NewClientContext(dummySessionKey(), 0)
+
+	// Unwrap should fail when not established.
+	_, err := ctx.Unwrap(&gssapi.WrapToken{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not established")
+}
+
+// TestKRB5TokenGetKRBError tests the GetKRBError method.
+func TestKRB5TokenGetKRBError(t *testing.T) {
+	t.Run("Not a KRB_ERROR", func(t *testing.T) {
+		token := &KRB5Token{}
+		token.tokID, _ = decodeHex(TOK_ID_KRB_AP_REQ)
+
+		_, err := token.GetKRBError()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not a KRB_ERROR")
+	})
+
+	t.Run("Is a KRB_ERROR", func(t *testing.T) {
+		token := &KRB5Token{}
+		token.tokID, _ = decodeHex(TOK_ID_KRB_ERROR)
+		token.KRBError.EText = "test error"
+
+		krbErr, err := token.GetKRBError()
+		require.NoError(t, err)
+		assert.Equal(t, "test error", krbErr.EText)
+	})
+}
+
+// TestKRB5TokenVerifyAPRepNotAPRep tests VerifyAPRep when token is not AP_REP.
+func TestKRB5TokenVerifyAPRepNotAPRep(t *testing.T) {
+	token := &KRB5Token{}
+	token.tokID, _ = decodeHex(TOK_ID_KRB_AP_REQ)
+
+	ctx := NewClientContext(dummySessionKey(), 0)
+	_ = ctx.SetInProgress()
+
+	ok, status := token.VerifyAPRep(ctx)
+	assert.False(t, ok)
+	assert.Equal(t, gssapi.StatusDefectiveToken, status.Code)
+	assert.Contains(t, status.Message, "not an AP_REP")
+}
+
+// TestNegTokenRespGetKRB5Token tests the GetKRB5Token method.
+func TestNegTokenRespGetKRB5Token(t *testing.T) {
+	t.Run("No response token", func(t *testing.T) {
+		resp := &NegTokenResp{}
+
+		_, err := resp.GetKRB5Token()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no response token present")
+	})
+
+	t.Run("Invalid response token", func(t *testing.T) {
+		resp := &NegTokenResp{
+			ResponseToken: []byte{0x01, 0x02, 0x03}, // Invalid token.
+		}
+
+		_, err := resp.GetKRB5Token()
+		assert.Error(t, err)
+	})
+}
+
+// TestNegTokenRespHasMechListMIC tests the HasMechListMIC method.
+func TestNegTokenRespHasMechListMIC(t *testing.T) {
+	t.Run("No MIC", func(t *testing.T) {
+		resp := &NegTokenResp{}
+		assert.False(t, resp.HasMechListMIC())
+	})
+
+	t.Run("Has MIC", func(t *testing.T) {
+		resp := &NegTokenResp{
+			MechListMIC: []byte{0x01, 0x02, 0x03},
+		}
+		assert.True(t, resp.HasMechListMIC())
+	})
+}
+
+// TestNegotiateClientContext tests the Context method.
+func TestNegotiateClientContext(t *testing.T) {
+	client := NewNegotiateClient(nil, "HTTP/test")
+
+	// No context initially.
+	assert.Nil(t, client.Context())
+
+	// Set a context.
+	client.ctx = NewClientContext(dummySessionKey(), 0)
+	assert.NotNil(t, client.Context())
+}
+
+// TestNegotiatingRoundTripper tests the NegotiatingRoundTripper constructor.
+func TestNegotiatingRoundTripper(t *testing.T) {
+	customTransport := &http.Transport{}
+	rt := NewNegotiatingRoundTripper(nil, "HTTP/test", WithTransport(customTransport))
+
+	assert.NotNil(t, rt)
+	assert.Equal(t, "HTTP/test", rt.spn)
+	assert.Equal(t, customTransport, rt.transport)
+}
+
+// TestNegotiateClientSessionKey tests the SessionKey method.
+func TestNegotiateClientSessionKey(t *testing.T) {
+	client := NewNegotiateClient(nil, "HTTP/test")
+
+	// No context - should return error.
+	_, err := client.SessionKey()
+	assert.Error(t, err)
+
+	// With context.
+	sessionKey := dummySessionKey()
+	client.ctx = NewClientContext(sessionKey, 0)
+	key, err := client.SessionKey()
+	require.NoError(t, err)
+	assert.Equal(t, sessionKey.KeyType, key.KeyType)
+	assert.Equal(t, sessionKey.KeyValue, key.KeyValue)
+}
+
+// TestNegotiateClientGetMIC tests the GetMIC wrapper method.
+func TestNegotiateClientGetMIC(t *testing.T) {
+	client := NewNegotiateClient(nil, "HTTP/test")
+
+	// No context - should return error.
+	_, err := client.GetMIC([]byte("test"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no security context")
+
+	// With context but not established.
+	client.ctx = NewClientContext(dummySessionKey(), 0)
+	_, err = client.GetMIC([]byte("test"))
+	assert.Error(t, err)
+}
+
+// TestNegotiateClientVerifyMIC tests the VerifyMIC wrapper method.
+func TestNegotiateClientVerifyMIC(t *testing.T) {
+	client := NewNegotiateClient(nil, "HTTP/test")
+
+	// No context - should return error.
+	_, err := client.VerifyMIC(&gssapi.MICToken{}, []byte("test"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no security context")
+}
+
+// TestNegotiateClientWrap tests the Wrap wrapper method.
+func TestNegotiateClientWrap(t *testing.T) {
+	client := NewNegotiateClient(nil, "HTTP/test")
+
+	// No context - should return error.
+	_, err := client.Wrap([]byte("test"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no security context")
+}
+
+// TestNegotiateClientUnwrap tests the Unwrap wrapper method.
+func TestNegotiateClientUnwrap(t *testing.T) {
+	client := NewNegotiateClient(nil, "HTTP/test")
+
+	// No context - should return error.
+	_, err := client.Unwrap(&gssapi.WrapToken{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no security context")
+}
+
+// TestCloneRequest tests the cloneRequest helper function.
+func TestCloneRequest(t *testing.T) {
+	original, err := http.NewRequest("GET", "http://example.com/path", nil)
+	require.NoError(t, err)
+	original.Header.Set("X-Custom", "value")
+
+	cloned := cloneRequest(original)
+
+	// Should have same URL and method.
+	assert.Equal(t, original.URL.String(), cloned.URL.String())
+	assert.Equal(t, original.Method, cloned.Method)
+
+	// Should have copied headers.
+	assert.Equal(t, "value", cloned.Header.Get("X-Custom"))
+
+	// Modifying clone shouldn't affect original.
+	cloned.Header.Set("X-New", "newvalue")
+	assert.Empty(t, original.Header.Get("X-New"))
+}
+
+// TestHTTPAuthHeaderParsing tests parsing of various WWW-Authenticate header formats.
+func TestHTTPAuthHeaderParsing(t *testing.T) {
+	tests := []struct {
+		name        string
+		header      string
+		isNegotiate bool
+		hasToken    bool
+	}{
+		{
+			name:        "Bare Negotiate",
+			header:      "Negotiate",
+			isNegotiate: true,
+			hasToken:    false,
+		},
+		{
+			name:        "Negotiate with token",
+			header:      "Negotiate oRQwEqADCgEAoQsGCSqGSIb3EgECAg==",
+			isNegotiate: true,
+			hasToken:    true,
+		},
+		{
+			name:        "Negotiate with extra whitespace",
+			header:      "Negotiate  oRQwEqADCgEAoQsGCSqGSIb3EgECAg==",
+			isNegotiate: true,
+			hasToken:    true,
+		},
+		{
+			name:        "Basic auth",
+			header:      "Basic realm=\"test\"",
+			isNegotiate: false,
+			hasToken:    false,
+		},
+		{
+			name:        "Empty",
+			header:      "",
+			isNegotiate: false,
+			hasToken:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isNegotiate := strings.HasPrefix(tt.header, HTTPHeaderAuthResponseValueKey)
+			assert.Equal(t, tt.isNegotiate, isNegotiate)
+
+			if isNegotiate {
+				tokenPart := strings.TrimPrefix(tt.header, HTTPHeaderAuthResponseValueKey)
+				tokenPart = strings.TrimSpace(tokenPart)
+				hasToken := tokenPart != ""
+				assert.Equal(t, tt.hasToken, hasToken)
+			}
+		})
+	}
+}

--- a/spnego/negotiate_client_test.go
+++ b/spnego/negotiate_client_test.go
@@ -952,3 +952,183 @@ func TestHTTPAuthHeaderParsing(t *testing.T) {
 		})
 	}
 }
+
+// TestFindNegotiateChallenge tests the findNegotiateChallenge helper function.
+func TestFindNegotiateChallenge(t *testing.T) {
+	tests := []struct {
+		name           string
+		headers        []string
+		expectNil      bool
+		expectHasToken bool
+		expectToken    string
+	}{
+		{
+			name:      "No headers",
+			headers:   nil,
+			expectNil: true,
+		},
+		{
+			name:      "No WWW-Authenticate header",
+			headers:   []string{},
+			expectNil: true,
+		},
+		{
+			name:           "Single bare Negotiate",
+			headers:        []string{"Negotiate"},
+			expectNil:      false,
+			expectHasToken: false,
+		},
+		{
+			name:           "Single Negotiate with token",
+			headers:        []string{"Negotiate dGVzdHRva2Vu"},
+			expectNil:      false,
+			expectHasToken: true,
+			expectToken:    "dGVzdHRva2Vu",
+		},
+		{
+			name:           "Multiple headers - Kerberos first, then Negotiate",
+			headers:        []string{"Kerberos", "Negotiate"},
+			expectNil:      false,
+			expectHasToken: false,
+		},
+		{
+			name:           "Multiple headers - bare Negotiate first, then Kerberos",
+			headers:        []string{"Negotiate", "Kerberos"},
+			expectNil:      false,
+			expectHasToken: false,
+		},
+		{
+			name:           "Multiple headers - Negotiate with token preferred over bare",
+			headers:        []string{"Negotiate", "Negotiate dGVzdHRva2Vu"},
+			expectNil:      false,
+			expectHasToken: true,
+			expectToken:    "dGVzdHRva2Vu",
+		},
+		{
+			name:           "Multiple headers - token first (returns immediately)",
+			headers:        []string{"Negotiate dGVzdHRva2Vu", "Negotiate"},
+			expectNil:      false,
+			expectHasToken: true,
+			expectToken:    "dGVzdHRva2Vu",
+		},
+		{
+			name:           "WinRM-style - Negotiate and Kerberos both present",
+			headers:        []string{"Negotiate", "Kerberos"},
+			expectNil:      false,
+			expectHasToken: false,
+		},
+		{
+			name:           "WinRM-style with token - prefer Negotiate with token",
+			headers:        []string{"Kerberos", "Negotiate dGVzdHRva2Vu"},
+			expectNil:      false,
+			expectHasToken: true,
+			expectToken:    "dGVzdHRva2Vu",
+		},
+		{
+			name:      "Only Basic auth",
+			headers:   []string{"Basic realm=\"test\""},
+			expectNil: true,
+		},
+		{
+			name:           "Mixed - Basic and Negotiate",
+			headers:        []string{"Basic realm=\"test\"", "Negotiate"},
+			expectNil:      false,
+			expectHasToken: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := make(http.Header)
+			for _, h := range tt.headers {
+				header.Add("WWW-Authenticate", h)
+			}
+
+			challenge := findNegotiateChallenge(header)
+
+			if tt.expectNil {
+				assert.Nil(t, challenge)
+			} else {
+				require.NotNil(t, challenge)
+				assert.Equal(t, tt.expectHasToken, challenge.hasToken)
+
+				if tt.expectHasToken {
+					assert.Equal(t, tt.expectToken, challenge.token)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildMICResponseToken tests the buildMICResponseToken method.
+func TestBuildMICResponseToken(t *testing.T) {
+	t.Run("fails without MechTypeListDER", func(t *testing.T) {
+		client := NewNegotiateClient(nil, "HTTP/test")
+		client.ctx = NewClientContext(dummySessionKey(), 0, 0)
+		_ = client.ctx.SetInProgress()
+		_ = client.ctx.SetEstablished()
+
+		// No MechTypeListDER set - should fail.
+		_, err := client.buildMICResponseToken()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "mechListMIC")
+	})
+
+	t.Run("succeeds with MechTypeListDER", func(t *testing.T) {
+		client := NewNegotiateClient(nil, "HTTP/test")
+		client.ctx = NewClientContext(dummySessionKey(), 0, 0)
+		_ = client.ctx.SetInProgress()
+		_ = client.ctx.SetEstablished()
+
+		// Set up MechTypeListDER.
+		mechTypes := []asn1.ObjectIdentifier{gssapi.OIDKRB5.OID()}
+		der, err := MarshalMechTypeList(mechTypes)
+		require.NoError(t, err)
+		client.ctx.SetMechTypeListDER(der)
+
+		// Should succeed now.
+		tokenBytes, err := client.buildMICResponseToken()
+		require.NoError(t, err)
+		assert.NotEmpty(t, tokenBytes)
+
+		// Verify it's a valid SPNEGO token.
+		var spnegoToken SPNEGOToken
+
+		err = spnegoToken.Unmarshal(tokenBytes)
+		require.NoError(t, err)
+		assert.True(t, spnegoToken.Resp)
+		assert.NotEmpty(t, spnegoToken.NegTokenResp.MechListMIC)
+	})
+}
+
+// TestProcessNegTokenRespRequestMIC tests handling of NegStateRequestMIC.
+func TestProcessNegTokenRespRequestMIC(t *testing.T) {
+	client := NewNegotiateClient(nil, "HTTP/test")
+	client.ctx = NewClientContext(dummySessionKey(), 0, 0)
+	_ = client.ctx.SetInProgress()
+
+	// Set up MechTypeListDER for MIC generation.
+	mechTypes := []asn1.ObjectIdentifier{gssapi.OIDKRB5.OID()}
+	der, err := MarshalMechTypeList(mechTypes)
+	require.NoError(t, err)
+	client.ctx.SetMechTypeListDER(der)
+
+	// Create a NegTokenResp with RequestMIC state.
+	negResp := &NegTokenResp{
+		NegState: asn1.Enumerated(NegStateRequestMIC),
+	}
+
+	// Process should return a response token.
+	responseToken, err := client.processNegTokenResp(negResp)
+	require.NoError(t, err)
+	assert.NotNil(t, responseToken)
+	assert.NotEmpty(t, responseToken)
+
+	// Verify the response token is a valid SPNEGO NegTokenResp with MechListMIC.
+	var spnegoToken SPNEGOToken
+
+	err = spnegoToken.Unmarshal(responseToken)
+	require.NoError(t, err)
+	assert.True(t, spnegoToken.Resp)
+	assert.NotEmpty(t, spnegoToken.NegTokenResp.MechListMIC)
+}

--- a/spnego/negotiation_token.go
+++ b/spnego/negotiation_token.go
@@ -35,6 +35,10 @@ type NegTokenInit struct {
 	MechListMIC    []byte
 	mechToken      gssapi.ContextToken
 	settings       *service.Settings
+	// rawMechTypesDER stores the exact DER encoding of the MechTypes SEQUENCE.
+	// This is critical for mechListMIC computation per RFC 4178 - the MIC
+	// must be computed over the exact bytes, not a re-encoded version.
+	rawMechTypesDER []byte
 }
 
 type marshalNegTokenInit struct {
@@ -118,8 +122,23 @@ func (n *NegTokenInit) Unmarshal(b []byte) error {
 	n.MechListMIC = nInit.MechListMIC
 	n.MechTypes = nInit.MechTypes
 	n.ReqFlags = nInit.ReqFlags
+	n.rawMechTypesDER = nInit.rawMechTypesDER
 
 	return nil
+}
+
+// RawMechTypesDER returns the raw DER encoding of the MechTypes SEQUENCE.
+// This is needed for mechListMIC computation per RFC 4178.
+func (n *NegTokenInit) RawMechTypesDER() []byte {
+	return n.rawMechTypesDER
+}
+
+// SetRawMechTypesDER sets the raw DER encoding of the MechTypes SEQUENCE.
+// This should be called when creating a NegTokenInit to ensure proper
+// mechListMIC computation.
+func (n *NegTokenInit) SetRawMechTypesDER(der []byte) {
+	n.rawMechTypesDER = make([]byte, len(der))
+	copy(n.rawMechTypesDER, der)
 }
 
 // Verify an Init negotiation token.
@@ -282,6 +301,35 @@ func (n *NegTokenResp) Context() context.Context {
 	return nil
 }
 
+// GetKRB5Token returns the KRB5Token from the ResponseToken field.
+// This is useful for client-side processing of AP-REP tokens.
+func (n *NegTokenResp) GetKRB5Token() (*KRB5Token, error) {
+	if n.ResponseToken == nil {
+		return nil, errors.New("no response token present")
+	}
+
+	if n.mechToken != nil {
+		mt, ok := n.mechToken.(*KRB5Token)
+		if ok {
+			return mt, nil
+		}
+	}
+
+	mt := new(KRB5Token)
+	if err := mt.Unmarshal(n.ResponseToken); err != nil {
+		return nil, fmt.Errorf("error unmarshalling response token: %w", err)
+	}
+
+	n.mechToken = mt
+
+	return mt, nil
+}
+
+// HasMechListMIC returns true if the NegTokenResp contains a mechListMIC.
+func (n *NegTokenResp) HasMechListMIC() bool {
+	return len(n.MechListMIC) > 0
+}
+
 // UnmarshalNegToken umarshals and returns either a NegTokenInit or a NegTokenResp.
 //
 // The boolean indicates if the response is a NegTokenInit.
@@ -303,11 +351,19 @@ func UnmarshalNegToken(b []byte) (bool, any, error) {
 			return false, nil, fmt.Errorf("error unmarshalling NegotiationToken type %d (Init): %w", a.Tag, err)
 		}
 
+		// Extract raw MechTypes DER bytes for mechListMIC computation.
+		// Per RFC 4178, the MIC must be computed over the exact DER bytes.
+		rawMechTypesDER, err := extractRawMechTypesDER(a.Bytes)
+		if err != nil {
+			return false, nil, fmt.Errorf("error extracting raw MechTypes DER: %w", err)
+		}
+
 		nt := NegTokenInit{
-			MechTypes:      n.MechTypes,
-			ReqFlags:       n.ReqFlags,
-			MechTokenBytes: n.MechTokenBytes,
-			MechListMIC:    n.MechListMIC,
+			MechTypes:       n.MechTypes,
+			ReqFlags:        n.ReqFlags,
+			MechTokenBytes:  n.MechTokenBytes,
+			MechListMIC:     n.MechListMIC,
+			rawMechTypesDER: rawMechTypesDER,
 		}
 
 		return true, nt, nil
@@ -332,9 +388,45 @@ func UnmarshalNegToken(b []byte) (bool, any, error) {
 	}
 }
 
+// extractRawMechTypesDER extracts the raw DER bytes of the MechTypes field from a NegTokenInit.
+// The input is the inner bytes of the NegTokenInit (after the context tag).
+// The MechTypes field is at context tag [0] and contains a SEQUENCE OF OID.
+func extractRawMechTypesDER(b []byte) ([]byte, error) {
+	// Parse the SEQUENCE containing the NegTokenInit fields.
+	var seq asn1.RawValue
+
+	rest, err := asn1.Unmarshal(b, &seq)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing NegTokenInit SEQUENCE: %w", err)
+	}
+
+	if len(rest) > 0 {
+		return nil, errors.New("trailing data after NegTokenInit SEQUENCE")
+	}
+
+	// Parse the first field which should be the context-tagged [0] MechTypes.
+	var mechTypesField asn1.RawValue
+
+	_, err = asn1.Unmarshal(seq.Bytes, &mechTypesField)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing MechTypes field: %w", err)
+	}
+
+	// The mechTypesField.Bytes contains the SEQUENCE OF OID.
+	// We need to return just the SEQUENCE OF OID, not the context tag wrapper.
+	// The mechTypesField.FullBytes would include the context tag, but we need
+	// the inner SEQUENCE for MIC computation per RFC 4178.
+	return mechTypesField.Bytes, nil
+}
+
 // NewNegTokenInitKRB5 creates new Init negotiation token for Kerberos 5.
 func NewNegTokenInitKRB5(cl *client.Client, tkt messages.Ticket, sessionKey types.EncryptionKey) (NegTokenInit, error) {
-	mt, err := NewKRB5TokenAPREQ(cl, tkt, sessionKey, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, []int{})
+	return NewNegTokenInitKRB5WithFlags(cl, tkt, sessionKey, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, []int{})
+}
+
+// NewNegTokenInitKRB5WithFlags creates new Init negotiation token for Kerberos 5 with custom flags.
+func NewNegTokenInitKRB5WithFlags(cl *client.Client, tkt messages.Ticket, sessionKey types.EncryptionKey, flagsGSSAPI []int, optionsAP []int) (NegTokenInit, error) {
+	mt, err := NewKRB5TokenAPREQ(cl, tkt, sessionKey, flagsGSSAPI, optionsAP)
 	if err != nil {
 		return NegTokenInit{}, fmt.Errorf("error getting KRB5 token; %w", err)
 	}
@@ -344,8 +436,17 @@ func NewNegTokenInitKRB5(cl *client.Client, tkt messages.Ticket, sessionKey type
 		return NegTokenInit{}, fmt.Errorf("error marshalling KRB5 token; %w", err)
 	}
 
+	mechTypes := []asn1.ObjectIdentifier{gssapi.OIDKRB5.OID()}
+
+	// Marshal the MechTypes to get the raw DER bytes for MIC computation.
+	rawMechTypesDER, err := asn1.Marshal(mechTypes, asn1.WithMarshalSlicePreserveTypes(true))
+	if err != nil {
+		return NegTokenInit{}, fmt.Errorf("error marshalling MechTypes for MIC; %w", err)
+	}
+
 	return NegTokenInit{
-		MechTypes:      []asn1.ObjectIdentifier{gssapi.OIDKRB5.OID()},
-		MechTokenBytes: mtb,
+		MechTypes:       mechTypes,
+		MechTokenBytes:  mtb,
+		rawMechTypesDER: rawMechTypesDER,
 	}, nil
 }

--- a/spnego/negotiation_token.go
+++ b/spnego/negotiation_token.go
@@ -39,6 +39,10 @@ type NegTokenInit struct {
 	// This is critical for mechListMIC computation per RFC 4178 - the MIC
 	// must be computed over the exact bytes, not a re-encoded version.
 	rawMechTypesDER []byte
+	// initialSeqNum stores the Authenticator's sequence number from the AP-REQ.
+	// This should be used to initialize the client's send sequence number
+	// per RFC 4121.
+	initialSeqNum int64
 }
 
 type marshalNegTokenInit struct {
@@ -139,6 +143,12 @@ func (n *NegTokenInit) RawMechTypesDER() []byte {
 func (n *NegTokenInit) SetRawMechTypesDER(der []byte) {
 	n.rawMechTypesDER = make([]byte, len(der))
 	copy(n.rawMechTypesDER, der)
+}
+
+// InitialSeqNum returns the Authenticator's sequence number from the AP-REQ.
+// This should be used to initialize the client's send sequence number.
+func (n *NegTokenInit) InitialSeqNum() int64 {
+	return n.initialSeqNum
 }
 
 // Verify an Init negotiation token.
@@ -426,12 +436,12 @@ func NewNegTokenInitKRB5(cl *client.Client, tkt messages.Ticket, sessionKey type
 
 // NewNegTokenInitKRB5WithFlags creates new Init negotiation token for Kerberos 5 with custom flags.
 func NewNegTokenInitKRB5WithFlags(cl *client.Client, tkt messages.Ticket, sessionKey types.EncryptionKey, flagsGSSAPI []int, optionsAP []int) (NegTokenInit, error) {
-	mt, err := NewKRB5TokenAPREQ(cl, tkt, sessionKey, flagsGSSAPI, optionsAP)
+	result, err := NewKRB5TokenAPREQ(cl, tkt, sessionKey, flagsGSSAPI, optionsAP)
 	if err != nil {
 		return NegTokenInit{}, fmt.Errorf("error getting KRB5 token; %w", err)
 	}
 
-	mtb, err := mt.Marshal()
+	mtb, err := result.Token.Marshal()
 	if err != nil {
 		return NegTokenInit{}, fmt.Errorf("error marshalling KRB5 token; %w", err)
 	}
@@ -448,5 +458,6 @@ func NewNegTokenInitKRB5WithFlags(cl *client.Client, tkt messages.Ticket, sessio
 		MechTypes:       mechTypes,
 		MechTokenBytes:  mtb,
 		rawMechTypesDER: rawMechTypesDER,
+		initialSeqNum:   result.SeqNum,
 	}, nil
 }


### PR DESCRIPTION
## Summary
- Add a stateful SPNEGO HTTP Negotiate client that handles multi-leg RFC 4178 flows, including multiple `WWW-Authenticate` headers and server token processing.
- Introduce a client-side security context for per-message operations, with sequence number tracking, mutual-auth handling, and mechListMIC support.
- Implement GSS-API wrap tokens with confidentiality (sealed) support, plus auto-detect unwrap and DCE-style ciphertext rotation for WSMan/PSRP.
- Expand tests across SPNEGO negotiation, context sequencing, and wrap token seal/unwrap behaviors.

## Why
Some SPNEGO servers (notably Windows/WinRM) require multi‑leg RFC 4178 negotiation and only complete the context after a follow‑on token. They also use RFC 4121 sealed wrap tokens with DCE‑style rotation for per‑message security. The existing flow handled only the simplest case, which breaks against those stacks. This update adds the missing negotiation and wrap/unwarp behavior needed for compatibility.
