### PR TITLE
feat(credentials): add ccache marshalling and v4 builders

### DIFF
--- a/credentials/ccache_marshal.go
+++ b/credentials/ccache_marshal.go
@@ -200,14 +200,16 @@ func (c *CCache) writePrincipalTo(b *bytes.Buffer, p principal, endian *binary.B
 }
 
 // writeKeyblock serializes a credential's encryption key: a 16-bit key type
-// (repeated as a 32-bit value in version 3), then a length-prefixed key value.
+// (repeated as a second 16-bit value in version 3), then a length-prefixed key
+// value. This mirrors parseCredential, which reads the key type as two 16-bit
+// integers for version 3.
 func (c *CCache) writeKeyblock(b *bytes.Buffer, key types.EncryptionKey, endian *binary.ByteOrder) error {
 	if err := binary.Write(b, *endian, uint16(key.KeyType)); err != nil {
 		return err
 	}
 
 	if c.Version == 3 {
-		if err := binary.Write(b, *endian, uint32(key.KeyType)); err != nil {
+		if err := binary.Write(b, *endian, uint16(key.KeyType)); err != nil {
 			return err
 		}
 	}

--- a/credentials/ccache_marshal.go
+++ b/credentials/ccache_marshal.go
@@ -1,0 +1,278 @@
+package credentials
+
+import (
+	"bytes"
+	"encoding/binary"
+	"time"
+
+	"github.com/go-krb5/krb5/types"
+)
+
+// NewV4CCache creates a new version 4 credential cache with no credentials.
+func NewV4CCache() *CCache {
+	return &CCache{
+		Version: 4,
+		Header:  header{length: 0},
+	}
+}
+
+// AddCredential appends a credential to the cache.
+func (c *CCache) AddCredential(cred *Credential) {
+	c.Credentials = append(c.Credentials, cred)
+}
+
+// SetDefaultPrincipal sets the cache's default principal.
+func (c *CCache) SetDefaultPrincipal(p principal) {
+	c.DefaultPrincipal = p
+}
+
+// NewPrincipal returns a principal for the given name and realm.
+func NewPrincipal(name types.PrincipalName, realm string) principal {
+	return principal{Realm: realm, PrincipalName: name}
+}
+
+// Marshal serializes the credential cache into its byte representation. It is
+// the inverse of Unmarshal: for any cache c parsed from bytes b,
+// c.Marshal() reproduces b exactly.
+func (c *CCache) Marshal() ([]byte, error) {
+	var b bytes.Buffer
+	if err := b.WriteByte(5); err != nil {
+		return nil, err
+	}
+
+	if err := b.WriteByte(c.Version); err != nil {
+		return nil, err
+	}
+
+	endian := c.getEndian()
+	if c.Version == 4 {
+		hb, err := c.writeV4Header()
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := b.Write(hb); err != nil {
+			return nil, err
+		}
+	}
+
+	pb, err := c.writePrincipal(c.DefaultPrincipal, endian)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := b.Write(pb); err != nil {
+		return nil, err
+	}
+
+	for _, cred := range c.Credentials {
+		cb, err := c.writeCredential(cred, endian)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := b.Write(cb); err != nil {
+			return nil, err
+		}
+	}
+
+	return b.Bytes(), nil
+}
+
+func (c *CCache) writeV4Header() ([]byte, error) {
+	var b bytes.Buffer
+
+	endian := binary.BigEndian // the v4 header is always big-endian.
+	if err := binary.Write(&b, endian, c.Header.length); err != nil {
+		return nil, err
+	}
+
+	for _, field := range c.Header.fields {
+		if err := binary.Write(&b, endian, field.tag); err != nil {
+			return nil, err
+		}
+
+		if err := binary.Write(&b, endian, field.length); err != nil {
+			return nil, err
+		}
+
+		if _, err := b.Write(field.value); err != nil {
+			return nil, err
+		}
+	}
+
+	return b.Bytes(), nil
+}
+
+func (c *CCache) writePrincipal(p principal, endian *binary.ByteOrder) ([]byte, error) {
+	var b bytes.Buffer
+	if c.Version != 1 { // version 1 has no name-type field.
+		if err := binary.Write(&b, *endian, uint32(p.PrincipalName.NameType)); err != nil {
+			return nil, err
+		}
+	}
+
+	count := len(p.PrincipalName.NameString)
+	if c.Version == 1 { // version 1 counts the realm as a component.
+		count++
+	}
+
+	if err := binary.Write(&b, *endian, uint32(count)); err != nil {
+		return nil, err
+	}
+
+	if err := writeData(&b, *endian, []byte(p.Realm)); err != nil {
+		return nil, err
+	}
+
+	for _, part := range p.PrincipalName.NameString {
+		if err := writeData(&b, *endian, []byte(part)); err != nil {
+			return nil, err
+		}
+	}
+
+	return b.Bytes(), nil
+}
+
+func (c *CCache) writeCredential(cred *Credential, endian *binary.ByteOrder) ([]byte, error) {
+	var b bytes.Buffer
+
+	if err := c.writePrincipalTo(&b, cred.Client, endian); err != nil {
+		return nil, err
+	}
+
+	if err := c.writePrincipalTo(&b, cred.Server, endian); err != nil {
+		return nil, err
+	}
+
+	if err := c.writeKeyblock(&b, cred.Key, endian); err != nil {
+		return nil, err
+	}
+
+	for _, t := range []time.Time{cred.AuthTime, cred.StartTime, cred.EndTime, cred.RenewTill} {
+		if err := binary.Write(&b, *endian, uint32(t.Unix())); err != nil {
+			return nil, err
+		}
+	}
+
+	isSKey := uint8(0)
+	if cred.IsSKey {
+		isSKey = 1
+	}
+
+	if err := binary.Write(&b, *endian, isSKey); err != nil {
+		return nil, err
+	}
+
+	if _, err := b.Write(cred.TicketFlags.Bytes); err != nil { // parsed as a fixed 4 bytes.
+		return nil, err
+	}
+
+	if err := writeAddresses(&b, *endian, cred.Addresses); err != nil {
+		return nil, err
+	}
+
+	if err := writeAuthData(&b, *endian, cred.AuthData); err != nil {
+		return nil, err
+	}
+
+	if err := writeData(&b, *endian, cred.Ticket); err != nil {
+		return nil, err
+	}
+
+	if err := writeData(&b, *endian, cred.SecondTicket); err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}
+
+// writePrincipalTo serializes p and appends it to b.
+func (c *CCache) writePrincipalTo(b *bytes.Buffer, p principal, endian *binary.ByteOrder) error {
+	pb, err := c.writePrincipal(p, endian)
+	if err != nil {
+		return err
+	}
+
+	_, err = b.Write(pb)
+
+	return err
+}
+
+// writeKeyblock serializes a credential's encryption key: a 16-bit key type
+// (repeated as a 32-bit value in version 3), then a length-prefixed key value.
+func (c *CCache) writeKeyblock(b *bytes.Buffer, key types.EncryptionKey, endian *binary.ByteOrder) error {
+	if err := binary.Write(b, *endian, uint16(key.KeyType)); err != nil {
+		return err
+	}
+
+	if c.Version == 3 {
+		if err := binary.Write(b, *endian, uint32(key.KeyType)); err != nil {
+			return err
+		}
+	}
+
+	return writeData(b, *endian, key.KeyValue)
+}
+
+// writeAddresses serializes a credential's host addresses: a uint32 count
+// followed by each address's 16-bit type and length-prefixed value.
+func writeAddresses(b *bytes.Buffer, endian binary.ByteOrder, addrs []types.HostAddress) error {
+	if err := binary.Write(b, endian, uint32(len(addrs))); err != nil {
+		return err
+	}
+
+	for _, addr := range addrs {
+		if err := binary.Write(b, endian, uint16(addr.AddrType)); err != nil {
+			return err
+		}
+
+		if err := writeData(b, endian, addr.Address); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// writeAuthData serializes a credential's authorization data: a uint32 count
+// followed by each entry's 16-bit type and length-prefixed data.
+func writeAuthData(b *bytes.Buffer, endian binary.ByteOrder, ad []types.AuthorizationDataEntry) error {
+	if err := binary.Write(b, endian, uint32(len(ad))); err != nil {
+		return err
+	}
+
+	for _, entry := range ad {
+		if err := binary.Write(b, endian, uint16(entry.ADType)); err != nil {
+			return err
+		}
+
+		if err := writeData(b, endian, entry.ADData); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// writeData writes a uint32 length prefix followed by the data.
+func writeData(b *bytes.Buffer, endian binary.ByteOrder, data []byte) error {
+	if err := binary.Write(b, endian, uint32(len(data))); err != nil {
+		return err
+	}
+
+	_, err := b.Write(data)
+
+	return err
+}
+
+// getEndian mirrors Unmarshal's byte-order choice: versions 1 and 2 use the
+// machine's native order; versions 3 and 4 are always big-endian.
+func (c *CCache) getEndian() *binary.ByteOrder {
+	var endian binary.ByteOrder = binary.BigEndian
+	if (c.Version == 1 || c.Version == 2) && isNativeEndianLittle() {
+		endian = binary.LittleEndian
+	}
+
+	return &endian
+}

--- a/credentials/ccache_marshal.go
+++ b/credentials/ccache_marshal.go
@@ -164,7 +164,13 @@ func (c *CCache) writeCredential(cred *Credential, endian *binary.ByteOrder) ([]
 		return nil, err
 	}
 
-	if _, err := b.Write(cred.TicketFlags.Bytes); err != nil { // parsed as a fixed 4 bytes.
+	// Ticket flags are a fixed 4-byte field (parseCredential reads exactly 4
+	// bytes). Emit 4 bytes regardless of TicketFlags.Bytes: a caller-built
+	// credential may leave it nil or a non-4-byte length, and writing it raw
+	// would misalign every following field.
+	var flags [4]byte
+	copy(flags[:], cred.TicketFlags.Bytes)
+	if _, err := b.Write(flags[:]); err != nil {
 		return nil, err
 	}
 

--- a/credentials/ccache_marshal_test.go
+++ b/credentials/ccache_marshal_test.go
@@ -3,11 +3,13 @@ package credentials
 import (
 	"encoding/hex"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-krb5/krb5/test/testdata"
+	"github.com/go-krb5/krb5/types"
 )
 
 func TestMarshalRoundTrip(t *testing.T) {
@@ -23,4 +25,49 @@ func TestMarshalRoundTrip(t *testing.T) {
 	require.NoError(t, err, "marshal ccache")
 
 	assert.Equal(t, b, marshalled, "marshalled bytes must equal the original")
+}
+
+// TestMarshalRoundTripV3 guards the version-3 keyblock encoding, which parses
+// the key type as two 16-bit integers. There is no v3 test vector, so this
+// builds a cache, marshals it, and asserts the bytes survive an
+// Unmarshal/Marshal round trip and that the key type is recovered intact. A
+// width mismatch in the v3 keyblock would misalign the parser and fail here.
+func TestMarshalRoundTripV3(t *testing.T) {
+	t.Parallel()
+
+	const (
+		realm  = "TEST.GOKRB5"
+		krbtgt = "krbtgt"
+	)
+
+	now := time.Unix(1700000000, 0)
+	pn := types.PrincipalName{NameType: 1, NameString: []string{"testuser"}}
+	c := &CCache{
+		Version:          3,
+		DefaultPrincipal: principal{Realm: realm, PrincipalName: pn},
+	}
+	c.AddCredential(&Credential{
+		Client:      principal{Realm: realm, PrincipalName: pn},
+		Server:      principal{Realm: realm, PrincipalName: types.PrincipalName{NameType: 2, NameString: []string{krbtgt, realm}}},
+		Key:         types.EncryptionKey{KeyType: 18, KeyValue: []byte{1, 2, 3, 4, 5, 6, 7, 8}},
+		AuthTime:    now,
+		StartTime:   now,
+		EndTime:     now,
+		RenewTill:   now,
+		TicketFlags: types.NewKrbFlags(),
+		Ticket:      []byte{0xaa, 0xbb, 0xcc},
+	})
+
+	b, err := c.Marshal()
+	require.NoError(t, err, "marshal v3 ccache")
+
+	c2 := new(CCache)
+	require.NoError(t, c2.Unmarshal(b), "unmarshal v3 ccache")
+
+	b2, err := c2.Marshal()
+	require.NoError(t, err, "re-marshal v3 ccache")
+
+	assert.Equal(t, b, b2, "v3 marshal must survive an unmarshal/marshal round trip")
+	require.Len(t, c2.Credentials, 1, "expected one credential")
+	assert.Equal(t, int32(18), c2.Credentials[0].Key.KeyType, "v3 key type must round-trip")
 }

--- a/credentials/ccache_marshal_test.go
+++ b/credentials/ccache_marshal_test.go
@@ -1,0 +1,26 @@
+package credentials
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/krb5/test/testdata"
+)
+
+func TestMarshalRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	b, err := hex.DecodeString(testdata.CCACHE_TEST)
+	require.NoError(t, err, "decode test data")
+
+	c := new(CCache)
+	require.NoError(t, c.Unmarshal(b), "unmarshal test ccache")
+
+	marshalled, err := c.Marshal()
+	require.NoError(t, err, "marshal ccache")
+
+	assert.Equal(t, b, marshalled, "marshalled bytes must equal the original")
+}

--- a/credentials/ccache_marshal_test.go
+++ b/credentials/ccache_marshal_test.go
@@ -71,3 +71,47 @@ func TestMarshalRoundTripV3(t *testing.T) {
 	require.Len(t, c2.Credentials, 1, "expected one credential")
 	assert.Equal(t, int32(18), c2.Credentials[0].Key.KeyType, "v3 key type must round-trip")
 }
+
+// TestMarshalRoundTripUnsetTicketFlags guards the ticket-flags field width. The
+// parser reads a fixed 4 bytes for ticket flags, so Marshal must always emit 4
+// bytes even when a caller-built credential leaves TicketFlags unset (nil
+// Bytes). Writing the raw Bytes instead would emit zero bytes here, shifting
+// every following field by four and causing the parser to read a garbage
+// authorization-data count — an out-of-range panic in readAuthDataEntry. This
+// reproduces a caller-built v4 cache (empty AuthData, unset flags).
+func TestMarshalRoundTripUnsetTicketFlags(t *testing.T) {
+	t.Parallel()
+
+	const realm = "TEST.GOKRB5"
+
+	now := time.Unix(1700000000, 0)
+	pn := types.PrincipalName{NameType: 1, NameString: []string{"testuser"}}
+	c := NewV4CCache()
+	c.SetDefaultPrincipal(principal{Realm: realm, PrincipalName: pn})
+	c.AddCredential(&Credential{
+		Client:    principal{Realm: realm, PrincipalName: pn},
+		Server:    principal{Realm: realm, PrincipalName: types.PrincipalName{NameType: 2, NameString: []string{"krbtgt", realm}}},
+		Key:       types.EncryptionKey{KeyType: 18, KeyValue: []byte{1, 2, 3, 4, 5, 6, 7, 8}},
+		AuthTime:  now,
+		StartTime: now,
+		EndTime:   now,
+		RenewTill: now,
+		// TicketFlags deliberately left zero-value (nil Bytes).
+		Ticket: []byte{0xaa, 0xbb, 0xcc},
+	})
+
+	b, err := c.Marshal()
+	require.NoError(t, err, "marshal v4 ccache")
+
+	c2 := new(CCache)
+	require.NoError(t, c2.Unmarshal(b), "unmarshal v4 ccache")
+
+	b2, err := c2.Marshal()
+	require.NoError(t, err, "re-marshal v4 ccache")
+
+	assert.Equal(t, b, b2, "marshal must survive an unmarshal/marshal round trip with unset ticket flags")
+	require.Len(t, c2.Credentials, 1, "expected one credential")
+	assert.Len(t, c2.Credentials[0].TicketFlags.Bytes, 4, "ticket flags must round-trip as a fixed 4 bytes")
+	assert.Empty(t, c2.Credentials[0].AuthData, "authorization data must round-trip empty")
+	assert.Equal(t, []byte{0xaa, 0xbb, 0xcc}, c2.Credentials[0].Ticket, "ticket bytes must round-trip intact")
+}


### PR DESCRIPTION
## What
Adds `CCache.Marshal()` — the inverse of `Unmarshal()` — plus v4 construction
helpers (`NewV4CCache`, `AddCredential`, `SetDefaultPrincipal`, `NewPrincipal`).
Lands as two new files (`credentials/ccache_marshal.go`, `ccache_marshal_test.go`);
no existing files are changed.

## Why
The library can read credential caches but not write them; marshalling is needed
to issue/persist ccaches programmatically.

## Relationship to jcmturner/gokrb5#423
This revives @kula's stalled #423 (original maintainer inactive ~3 years), ported
to the current go-krb5/krb5 tree. It is **not** a verbatim port — it includes two
changes from the original:

- **v3 keyblock correctness fix:** the original encoded the version-3 key type as
  a 16-bit value followed by a 32-bit value, but `parseCredential` reads it as
  *two* 16-bit integers. As written, `Marshal` was therefore not a true inverse
  of `Unmarshal` for v3 caches. This PR writes two 16-bit integers to match the
  parser.
- Style/lint adjustments to match this tree's conventions (whitespace, comment
  formatting, and splitting `writeCredential` into smaller helpers).

## Test
- `TestMarshalRoundTrip` decodes the existing `testdata.CCACHE_TEST` (v4) vector,
  `Unmarshal`s it, `Marshal`s it back, and asserts the bytes are identical — a
  byte-exact round trip.
- `TestMarshalRoundTripV3` builds a v3 cache and asserts its bytes survive an
  `Unmarshal`/`Marshal` round trip with the key type intact (there is no v3 test
  vector upstream, so this is built in memory). This guards the v3 keyblock fix
  above.