### PR TITLE
export: NewAuthenticatorChksum + gssapi.ChannelBindings for RFC 4121 tokens

### DIFF
--- a/gssapi/channel_bindings.go
+++ b/gssapi/channel_bindings.go
@@ -1,0 +1,52 @@
+package gssapi
+
+import (
+	"crypto/md5"
+	"encoding/binary"
+)
+
+// ChannelBindings holds GSS-API channel binding information, mirroring the
+// gss_channel_bindings_struct of RFC 2744. Its MD5 hash forms the 16-byte Bnd
+// field of the RFC 4121 §4.1.1 authenticator checksum, binding the security
+// context to the underlying transport (e.g. tls-server-end-point per
+// RFC 5929).
+//
+// A nil *ChannelBindings represents GSS_C_NO_CHANNEL_BINDINGS and is handled by
+// callers as a zero Bnd field; a non-nil value with empty fields is distinct
+// and still contributes to the hash.
+type ChannelBindings struct {
+	InitiatorAddrType uint32
+	InitiatorAddress  []byte
+	AcceptorAddrType  uint32
+	AcceptorAddress   []byte
+	ApplicationData   []byte
+}
+
+// Bytes marshals the channel bindings per RFC 4121 §4.1.1.2 and returns their
+// 16-byte MD5 hash, suitable for the Bnd field of the authenticator checksum.
+//
+// The marshaling emits, in order, the little-endian initiator address type and
+// address, the little-endian acceptor address type and address, and the
+// application data; each address and the application data is prefixed by its
+// little-endian 4-byte length.
+func (c *ChannelBindings) Bytes() []byte {
+	var b []byte
+
+	putUint32 := func(v uint32) {
+		b = binary.LittleEndian.AppendUint32(b, v)
+	}
+	putBuffer := func(v []byte) {
+		putUint32(uint32(len(v)))
+		b = append(b, v...)
+	}
+
+	putUint32(c.InitiatorAddrType)
+	putBuffer(c.InitiatorAddress)
+	putUint32(c.AcceptorAddrType)
+	putBuffer(c.AcceptorAddress)
+	putBuffer(c.ApplicationData)
+
+	sum := md5.Sum(b)
+
+	return sum[:]
+}

--- a/gssapi/channel_bindings_test.go
+++ b/gssapi/channel_bindings_test.go
@@ -1,0 +1,70 @@
+package gssapi
+
+import (
+	"crypto/md5"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChannelBindings_Bytes_ApplicationDataOnly(t *testing.T) {
+	t.Parallel()
+
+	cb := &ChannelBindings{ApplicationData: []byte("test")}
+
+	// RFC 4121 §4.1.1.2 marshaling: little-endian 4-byte fields, each
+	// gss_buffer prefixed by its 4-byte length. Address types and empty
+	// addresses contribute their length words (all zero here); only the
+	// application data carries bytes.
+	want := []byte{
+		0x00, 0x00, 0x00, 0x00, // initiator addrtype
+		0x00, 0x00, 0x00, 0x00, // initiator address length (0)
+		0x00, 0x00, 0x00, 0x00, // acceptor addrtype
+		0x00, 0x00, 0x00, 0x00, // acceptor address length (0)
+		0x04, 0x00, 0x00, 0x00, // application data length (4)
+		't', 'e', 's', 't',
+	}
+	sum := md5.Sum(want)
+
+	assert.Equal(t, sum[:], cb.Bytes())
+	assert.Len(t, cb.Bytes(), 16)
+}
+
+func TestChannelBindings_Bytes_WithAddresses(t *testing.T) {
+	t.Parallel()
+
+	cb := &ChannelBindings{
+		InitiatorAddrType: 2,
+		InitiatorAddress:  []byte{127, 0, 0, 1},
+		AcceptorAddrType:  2,
+		AcceptorAddress:   []byte{10, 0, 0, 5},
+		ApplicationData:   []byte("app"),
+	}
+
+	want := []byte{
+		0x02, 0x00, 0x00, 0x00, // initiator addrtype (2)
+		0x04, 0x00, 0x00, 0x00, // initiator address length (4)
+		127, 0, 0, 1,
+		0x02, 0x00, 0x00, 0x00, // acceptor addrtype (2)
+		0x04, 0x00, 0x00, 0x00, // acceptor address length (4)
+		10, 0, 0, 5,
+		0x03, 0x00, 0x00, 0x00, // application data length (3)
+		'a', 'p', 'p',
+	}
+	sum := md5.Sum(want)
+
+	assert.Equal(t, sum[:], cb.Bytes())
+}
+
+// An all-empty but non-nil binding still hashes its five length words, which
+// is distinct from GSS_C_NO_CHANNEL_BINDINGS (a nil *ChannelBindings, handled
+// by callers as a zero Bnd field).
+func TestChannelBindings_Bytes_Empty(t *testing.T) {
+	t.Parallel()
+
+	cb := &ChannelBindings{}
+
+	sum := md5.Sum(make([]byte, 20))
+
+	assert.Equal(t, sum[:], cb.Bytes())
+}

--- a/spnego/krb5_token.go
+++ b/spnego/krb5_token.go
@@ -218,14 +218,15 @@ func krb5TokenAuthenticator(creds *credentials.Credentials, flags []int) (types.
 
 	auth.Cksum = types.Checksum{
 		CksumType: chksumtype.GSSAPI,
-		Checksum:  newAuthenticatorChksum(flags),
+		Checksum:  NewAuthenticatorChksum(flags),
 	}
 
 	return auth, nil
 }
 
-// Create new authenticator checksum for kerberos MechToken.
-func newAuthenticatorChksum(flags []int) []byte {
+// NewAuthenticatorChksum creates a new authenticator checksum for kerberos MechToken, per RFC 4121 Section 4.1.1.
+// The checksum is used in the Authenticator's Cksum field and encodes GSS-API context flags.
+func NewAuthenticatorChksum(flags []int) []byte {
 	a := make([]byte, 24)
 	binary.LittleEndian.PutUint32(a[:4], 16)
 

--- a/spnego/krb5_token.go
+++ b/spnego/krb5_token.go
@@ -218,7 +218,7 @@ func krb5TokenAuthenticator(creds *credentials.Credentials, flags []int) (types.
 
 	auth.Cksum = types.Checksum{
 		CksumType: chksumtype.GSSAPI,
-		Checksum:  NewAuthenticatorChksum(flags),
+		Checksum:  NewAuthenticatorChksum(flags, nil),
 	}
 
 	return auth, nil
@@ -226,9 +226,17 @@ func krb5TokenAuthenticator(creds *credentials.Credentials, flags []int) (types.
 
 // NewAuthenticatorChksum creates a new authenticator checksum for kerberos MechToken, per RFC 4121 Section 4.1.1.
 // The checksum is used in the Authenticator's Cksum field and encodes GSS-API context flags.
-func NewAuthenticatorChksum(flags []int) []byte {
+//
+// cb carries optional GSS-API channel bindings whose MD5 hash forms the 16-byte
+// Bnd field (RFC 4121 §4.1.1.2). A nil cb represents GSS_C_NO_CHANNEL_BINDINGS
+// and leaves the Bnd field zero.
+func NewAuthenticatorChksum(flags []int, cb *gssapi.ChannelBindings) []byte {
 	a := make([]byte, 24)
 	binary.LittleEndian.PutUint32(a[:4], 16)
+
+	if cb != nil {
+		copy(a[4:20], cb.Bytes())
+	}
 
 	for _, i := range flags {
 		if i == gssapi.ContextFlagDeleg {

--- a/spnego/krb5_token_test.go
+++ b/spnego/krb5_token_test.go
@@ -1,6 +1,7 @@
 package spnego
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"math"
 	"testing"
@@ -47,8 +48,25 @@ func TestKRB5Token_NewAuthenticatorChksum(t *testing.T) {
 	b, err := hex.DecodeString(AuthChksum)
 	require.NoError(t, err)
 
-	cb := NewAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf})
-	assert.Equal(t, b, cb)
+	chksum := NewAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, nil)
+	assert.Equal(t, b, chksum)
+}
+
+func TestKRB5Token_NewAuthenticatorChksum_ChannelBindings(t *testing.T) {
+	t.Parallel()
+
+	cb := &gssapi.ChannelBindings{ApplicationData: []byte("tls-server-end-point:abc")}
+	chksum := NewAuthenticatorChksum([]int{gssapi.ContextFlagInteg}, cb)
+
+	// Length prefix (16) and flags are unchanged; the Bnd field now carries the
+	// channel-binding hash instead of zeros.
+	assert.Equal(t, []byte{16, 0, 0, 0}, chksum[:4])
+	assert.Equal(t, cb.Bytes(), chksum[4:20])
+	assert.Equal(t, uint32(gssapi.ContextFlagInteg), binary.LittleEndian.Uint32(chksum[20:24]))
+
+	// A nil binding leaves the Bnd field zero.
+	zero := NewAuthenticatorChksum([]int{gssapi.ContextFlagInteg}, nil)
+	assert.Equal(t, make([]byte, 16), zero[4:20])
 }
 
 // Test with explicit subkey generation.

--- a/spnego/krb5_token_test.go
+++ b/spnego/krb5_token_test.go
@@ -41,13 +41,13 @@ func TestKRB5Token_Unmarshal(t *testing.T) {
 	assert.Equal(t, int32(18), mt.APReq.EncryptedAuthenticator.EType)
 }
 
-func TestKRB5Token_newAuthenticatorChksum(t *testing.T) {
+func TestKRB5Token_NewAuthenticatorChksum(t *testing.T) {
 	t.Parallel()
 
 	b, err := hex.DecodeString(AuthChksum)
 	require.NoError(t, err)
 
-	cb := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf})
+	cb := NewAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf})
 	assert.Equal(t, b, cb)
 }
 


### PR DESCRIPTION
Export and generalize the RFC 4121 §4.1.1 authenticator-checksum builder so external packages can construct GSS-API initial-context tokens — including channel-bound ones — without going through the full SPNEGO flow or reaching into `spnego` internals.

## Summary

- **Export** `newAuthenticatorChksum` → `NewAuthenticatorChksum` and document it against RFC 4121 §4.1.1.
- **Add** a mechanism-agnostic `gssapi.ChannelBindings` type (mirroring RFC 2744's `gss_channel_bindings_struct`) whose `Bytes()` method marshals per RFC 4121 §4.1.1.2 and returns the 16-byte MD5 Bnd hash.
- **Plumb** channel bindings through `NewAuthenticatorChksum`, which now takes a `*gssapi.ChannelBindings`.

## Motivation

Packages implementing SASL GSSAPI (RFC 4752) and GS2-KRB5 (RFC 5801) need to build their own AP-REQ messages directly from cached credentials. Two pieces were locked inside `spnego`:

1. The checksum construction itself (now exported).
2. Channel-binding support — the checksum's 16-byte `Bnd` field was always zero, so no consumer could bind a context to the transport (e.g. `tls-server-end-point`, RFC 5929). This is required for GS2-KRB5-PLUS.

## Changes

- `spnego/krb5_token.go` — export + document `NewAuthenticatorChksum`; add optional `*gssapi.ChannelBindings` parameter that fills the `Bnd` field.
- `gssapi/channel_bindings.go` (new) — `ChannelBindings` type + `Bytes()` (RFC 4121 §4.1.1.2 marshaling → MD5).
- Tests in both packages.

## Compatibility & semantics

- The sole internal caller (`krb5TokenAuthenticator`, the SPNEGO path) passes `nil`, preserving existing behavior and the existing checksum test vector — no behavioral change to SPNEGO.
- `nil *gssapi.ChannelBindings` = `GSS_C_NO_CHANNEL_BINDINGS` → `Bnd` left zero. A non-nil value with empty fields is distinct and still hashes its length words, matching GSS semantics (MIT `kg_checksum_channel`).

## Marshaling detail (RFC 4121 §4.1.1.2)

Little-endian throughout: initiator addrtype, initiator address (len-prefixed), acceptor addrtype, acceptor address (len-prefixed), application data (len-prefixed) — then MD5. Verified against the canonical MIT layout.

## Out of scope

Full `GSS_C_DELEG_FLAG` delegation (embedding a KRB_CRED) remains the pre-existing placeholder; no current consumer needs it.
