### PR TITLE
feat(kadmin): change password and set password

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -58,3 +58,17 @@ change will be elaborated on in time):
   | `crypto.ChecksumETypeIDs`                | List the registered checksum type IDs in ascending order.   |
   | `crypto.RegisterDeprecatedRC4HMAC`       | Opt back in to `rc4-hmac` and `kerb-checksum-hmac-md5`.     |
   | `crypto.RegisterDeprecatedDes3CbcSha1Kd` | Opt back in to `des3-cbc-sha1-kd` and `hmac-sha1-des3-kd`.  |
+- `client.Client.ChangePasswd` and `kadmin.ChangePasswdMsg` now emit the original Kerberos change password protocol,
+  protocol version `0x0001`, whose KRB_PRIV user data is the new password in the clear. They previously emitted the
+  RFC 3244 set password protocol, protocol version `0xff80`, with the requestor's own principal name and realm in the
+  `targname` and `targrealm` fields of the `ChangePasswdData`. Setting a password is an administrative operation, so on
+  Active Directory the old message was rejected with `KRB5_KPASSWD_ACCESSDENIED` unless the requestor held the Reset
+  Password extended right, which meant a principal could not change its own password. Their signatures are unchanged.
+  This closes [jcmturner/gokrb5#387](https://github.com/jcmturner/gokrb5/issues/387) and
+  [go-krb5/krb5#69](https://github.com/go-krb5/krb5/issues/69).
+- Setting another principal's password is still available, now as an explicit operation rather than as the only thing
+  `ChangePasswd` could do: `client.Client.SetPasswd` and `kadmin.SetPasswdMsg` send the RFC 3244 set password message
+  naming a target principal. `kadmin.Request` has gained a `Version` field, set by `kadmin.ChangePasswdMsg` and
+  `kadmin.SetPasswdMsg`, which selects which of the two protocols `kadmin.Request.Marshal` writes. A `kadmin.Request`
+  constructed directly must set it to `kadmin.VersionChangePassword` or `kadmin.VersionSetPassword`; `Marshal` returns
+  an error for any other value rather than writing a version number the KDC will reject.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1,6 +1,7 @@
 # References
 
 * [RFC 3244 Microsoft Windows 2000 Kerberos Change Password and Set Password Protocols](https://tools.ietf.org/html/rfc3244)
+* [draft-ietf-cat-kerb-chg-password-02 Kerberos Change Password Protocol](https://datatracker.ietf.org/doc/html/draft-ietf-cat-kerb-chg-password-02)
 * [RFC 4120 The Kerberos Network Authentication Service (V5)](https://tools.ietf.org/html/rfc4120)
 * [RFC 3961 Encryption and Checksum Specifications for Kerberos 5](https://tools.ietf.org/html/rfc3961)
 * [RFC 3962 Advanced Encryption Standard (AES) Encryption for Kerberos 5](https://tools.ietf.org/html/rfc3962)

--- a/client/passwd.go
+++ b/client/passwd.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-krb5/krb5/kadmin"
 	"github.com/go-krb5/krb5/messages"
+	"github.com/go-krb5/krb5/types"
 )
 
 // Kpasswd server response codes.
@@ -20,13 +21,12 @@ const (
 )
 
 // ChangePasswd changes the password of the client to the value provided.
+//
+// This uses the original Kerberos change password protocol, which asks the KDC to change the password of the principal
+// the client authenticated as. It requires no administrative privilege. To set the password of another principal use
+// SetPasswd.
 func (cl *Client) ChangePasswd(newPasswd string) (bool, error) {
-	ASReq, err := messages.NewASReqForChgPasswd(cl.Credentials.Domain(), cl.Config, cl.Credentials.CName())
-	if err != nil {
-		return false, err
-	}
-
-	ASRep, err := cl.ASExchange(cl.Credentials.Domain(), ASReq, 0)
+	ASRep, err := cl.kpasswdASExchange()
 	if err != nil {
 		return false, err
 	}
@@ -36,23 +36,72 @@ func (cl *Client) ChangePasswd(newPasswd string) (bool, error) {
 		return false, err
 	}
 
-	r, err := cl.sendToKPasswd(msg)
-	if err != nil {
+	if err = cl.exchangeWithKPasswd(msg, key); err != nil {
 		return false, err
-	}
-
-	err = r.Decrypt(key)
-	if err != nil {
-		return false, err
-	}
-
-	if r.ResultCode != KRB5_KPASSWD_SUCCESS {
-		return false, fmt.Errorf("error response from kadmin: code: %d; result: %s; krberror: %w", r.ResultCode, r.Result, r.KRBError)
 	}
 
 	cl.Credentials.WithPassword(newPasswd)
 
 	return true, nil
+}
+
+// SetPasswd sets the password of the principal named by targName in targRealm to the value provided. If targRealm is
+// empty the client's own realm is used.
+//
+// This uses the set password protocol defined by RFC 3244, which asks the KDC to set the target principal's password
+// administratively. The client must be authorized to administer the target principal; on Active Directory that is the
+// Reset Password extended right. A client changing its own password should use ChangePasswd instead, which needs no
+// such privilege. The client's stored credentials are not updated by this call.
+func (cl *Client) SetPasswd(targName types.PrincipalName, targRealm, newPasswd string) (bool, error) {
+	if targRealm == "" {
+		targRealm = cl.Credentials.Domain()
+	}
+
+	ASRep, err := cl.kpasswdASExchange()
+	if err != nil {
+		return false, err
+	}
+
+	msg, key, err := kadmin.SetPasswdMsg(cl.Credentials.CName(), cl.Credentials.Domain(), targName, targRealm, newPasswd, ASRep.Ticket, ASRep.DecryptedEncPart.Key)
+	if err != nil {
+		return false, err
+	}
+
+	if err = cl.exchangeWithKPasswd(msg, key); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// kpasswdASExchange obtains an initial ticket for the kadmin/changepw service.
+func (cl *Client) kpasswdASExchange() (messages.ASRep, error) {
+	ASReq, err := messages.NewASReqForChgPasswd(cl.Credentials.Domain(), cl.Config, cl.Credentials.CName())
+	if err != nil {
+		return messages.ASRep{}, err
+	}
+
+	return cl.ASExchange(cl.Credentials.Domain(), ASReq, 0)
+}
+
+// exchangeWithKPasswd sends the request to the kpasswd server and checks the result code of the reply, which is
+// decrypted with key.
+func (cl *Client) exchangeWithKPasswd(msg kadmin.Request, key types.EncryptionKey) error {
+	r, err := cl.sendToKPasswd(msg)
+	if err != nil {
+		return err
+	}
+
+	err = r.Decrypt(key)
+	if err != nil {
+		return err
+	}
+
+	if r.ResultCode != KRB5_KPASSWD_SUCCESS {
+		return fmt.Errorf("error response from kadmin: code: %d; result: %s; krberror: %w", r.ResultCode, r.Result, r.KRBError)
+	}
+
+	return nil
 }
 
 func (cl *Client) sendToKPasswd(msg kadmin.Request) (r kadmin.Reply, err error) {

--- a/kadmin/change_passwd_data.go
+++ b/kadmin/change_passwd_data.go
@@ -22,3 +22,10 @@ func (c *ChangePasswdData) Marshal() ([]byte, error) {
 
 	return b, nil
 }
+
+// Unmarshal bytes b into the ChangePasswdData struct.
+func (c *ChangePasswdData) Unmarshal(b []byte) error {
+	_, err := asn1.Unmarshal(b, c)
+
+	return err
+}

--- a/kadmin/message.go
+++ b/kadmin/message.go
@@ -11,8 +11,24 @@ import (
 	"github.com/go-krb5/krb5/types"
 )
 
-// Request message for changing password.
+// Protocol version numbers for the kpasswd request message.
+const (
+	// VersionChangePassword is the protocol version number of the original Kerberos change password protocol. The
+	// KRB_PRIV user data of such a request is the new password in the clear and the KDC changes the password of the
+	// principal that the AP_REQ ticket was issued to.
+	VersionChangePassword uint16 = 0x0001
+
+	// VersionSetPassword is the protocol version number of the set password protocol defined by RFC 3244. The
+	// KRB_PRIV user data of such a request is a marshaled ChangePasswdData and the KDC sets the password of the
+	// principal named by its targname, which requires the requestor to be authorized to administer that principal.
+	VersionSetPassword uint16 = 0xff80
+)
+
+// Request message for changing or setting a password.
 type Request struct {
+	// Version is the protocol version number of the request, which selects the operation the KDC performs. It must
+	// be VersionChangePassword or VersionSetPassword.
+	Version uint16
 	APREQ   messages.APReq
 	KRBPriv messages.KRBPriv
 }
@@ -32,7 +48,12 @@ type Reply struct {
 
 // Marshal a Request into a byte slice.
 func (m *Request) Marshal() (b []byte, err error) {
-	b = []byte{255, 128}
+	if m.Version != VersionChangePassword && m.Version != VersionSetPassword {
+		return nil, fmt.Errorf("invalid kadmin request protocol version number: %#04x", m.Version)
+	}
+
+	b = make([]byte, 2)
+	binary.BigEndian.PutUint16(b, m.Version)
 
 	ab, e := m.APREQ.Marshal()
 	if e != nil {

--- a/kadmin/passwd.go
+++ b/kadmin/passwd.go
@@ -8,37 +8,61 @@ import (
 	"github.com/go-krb5/krb5/types"
 )
 
-// ChangePasswdMsg generate a change password request and also return the key needed to decrypt the reply.
+// ChangePasswdMsg generates a change password request for the principal the ticket was issued to and also returns the
+// key needed to decrypt the reply.
+//
+// This is the original Kerberos change password protocol, in which the KDC changes the password of the principal named
+// in the ticket. It requires nothing of the requestor beyond an initial ticket, so it is the operation to use for a
+// principal changing its own password. To set another principal's password use SetPasswdMsg.
 func ChangePasswdMsg(cname types.PrincipalName, realm, password string, tkt messages.Ticket, sessionKey types.EncryptionKey) (r Request, k types.EncryptionKey, err error) {
-	// Create change password data struct and marshal to bytes.
+	return newRequest(VersionChangePassword, cname, realm, []byte(password), tkt, sessionKey)
+}
+
+// SetPasswdMsg generates a set password request for the principal named by targname and targrealm and also returns the
+// key needed to decrypt the reply.
+//
+// This is the set password protocol defined by RFC 3244, in which the KDC sets the password of the target principal
+// administratively. The requestor must be authorized to administer the target principal; on Active Directory that is
+// the Reset Password extended right. A principal changing its own password should use ChangePasswdMsg instead.
+func SetPasswdMsg(cname types.PrincipalName, realm string, targname types.PrincipalName, targrealm, password string, tkt messages.Ticket, sessionKey types.EncryptionKey) (r Request, k types.EncryptionKey, err error) {
 	chgpasswd := ChangePasswdData{
 		NewPasswd: []byte(password),
-		TargName:  cname,
-		TargRealm: realm,
+		TargName:  targname,
+		TargRealm: targrealm,
 	}
 
-	chpwdb, err := chgpasswd.Marshal()
+	userData, err := chgpasswd.Marshal()
 	if err != nil {
 		err = krberror.Errorf(err, krberror.KRBMsgError, "error marshaling change passwd data")
+
 		return
 	}
 
+	return newRequest(VersionSetPassword, cname, realm, userData, tkt, sessionKey)
+}
+
+// newRequest builds a kpasswd request of the given protocol version carrying userData in its KRB_PRIV and returns the
+// subkey the reply will be encrypted with.
+func newRequest(version uint16, cname types.PrincipalName, realm string, userData []byte, tkt messages.Ticket, sessionKey types.EncryptionKey) (r Request, k types.EncryptionKey, err error) {
 	// Generate authenticator.
 	auth, err := types.NewAuthenticator(realm, cname)
 	if err != nil {
 		err = krberror.Errorf(err, krberror.KRBMsgError, "error generating new authenticator")
+
 		return
 	}
 
 	etype, err := crypto.GetEType(sessionKey.KeyType)
 	if err != nil {
 		err = krberror.Errorf(err, krberror.KRBMsgError, "error generating subkey etype")
+
 		return
 	}
 
 	err = auth.GenerateSeqNumberAndSubKey(etype.GetETypeID(), etype.GetKeyByteSize())
 	if err != nil {
 		err = krberror.Errorf(err, krberror.KRBMsgError, "error generating subkey")
+
 		return
 	}
 
@@ -52,7 +76,7 @@ func ChangePasswdMsg(cname types.PrincipalName, realm, password string, tkt mess
 
 	// Form the KRBPriv encpart data.
 	kp := messages.EncKrbPrivPart{
-		UserData:       chpwdb,
+		UserData:       userData,
 		Timestamp:      auth.CTime,
 		Usec:           auth.Cusec,
 		SequenceNumber: auth.SeqNumber,
@@ -61,11 +85,13 @@ func ChangePasswdMsg(cname types.PrincipalName, realm, password string, tkt mess
 
 	err = kpriv.EncryptEncPart(k)
 	if err != nil {
-		err = krberror.Errorf(err, krberror.EncryptingError, "error encrypting change passwd data")
+		err = krberror.Errorf(err, krberror.EncryptingError, "error encrypting kpasswd request data")
+
 		return
 	}
 
 	r = Request{
+		Version: version,
 		APREQ:   APreq,
 		KRBPriv: kpriv,
 	}

--- a/kadmin/passwd_test.go
+++ b/kadmin/passwd_test.go
@@ -1,0 +1,81 @@
+package kadmin
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/krb5/iana/etypeID"
+	"github.com/go-krb5/krb5/iana/nametype"
+	"github.com/go-krb5/krb5/messages"
+	"github.com/go-krb5/krb5/types"
+)
+
+// testTicket returns a ticket and session key usable for building a kpasswd request. The ticket's encrypted part is
+// never decrypted when building a request so it does not need to be populated.
+func testTicket(t *testing.T) (messages.Ticket, types.EncryptionKey) {
+	t.Helper()
+
+	kb := make([]byte, 32)
+
+	_, err := rand.Read(kb)
+	require.NoError(t, err)
+
+	return messages.Ticket{
+			TktVNO: 5,
+			Realm:  "TEST.GOKRB5",
+			SName:  types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, "kadmin/changepw"),
+		}, types.EncryptionKey{
+			KeyType:  etypeID.AES256_CTS_HMAC_SHA1_96,
+			KeyValue: kb,
+		}
+}
+
+func TestChangePasswdMsg(t *testing.T) {
+	t.Parallel()
+
+	tkt, sk := testTicket(t)
+	cname := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, "testuser1")
+
+	r, k, err := ChangePasswdMsg(cname, "TEST.GOKRB5", "newpassword", tkt, sk)
+	require.NoError(t, err)
+
+	b, err := r.Marshal()
+	require.NoError(t, err)
+
+	// The original change password protocol is version 0x0001. Version 0xff80 is RFC 3244 set password, which asks
+	// the KDC to set a principal's password administratively rather than change the requestor's own.
+	assert.Equal(t, []byte{0x00, 0x01}, b[2:4], "change password must use protocol version 0x0001")
+
+	// For version 0x0001 the KRB_PRIV user data is the cleartext password with no ASN.1 wrapping.
+	require.NoError(t, r.KRBPriv.DecryptEncPart(k))
+	assert.Equal(t, []byte("newpassword"), r.KRBPriv.DecryptedEncPart.UserData)
+}
+
+func TestSetPasswdMsg(t *testing.T) {
+	t.Parallel()
+
+	tkt, sk := testTicket(t)
+	cname := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, "adminuser")
+	targ := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, "testuser1")
+
+	r, k, err := SetPasswdMsg(cname, "TEST.GOKRB5", targ, "TEST.GOKRB5", "newpassword", tkt, sk)
+	require.NoError(t, err)
+
+	b, err := r.Marshal()
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte{0xff, 0x80}, b[2:4], "set password must use protocol version 0xff80")
+
+	// For version 0xff80 the KRB_PRIV user data is a marshaled ChangePasswdData naming the target principal.
+	require.NoError(t, r.KRBPriv.DecryptEncPart(k))
+
+	var d ChangePasswdData
+
+	require.NoError(t, d.Unmarshal(r.KRBPriv.DecryptedEncPart.UserData))
+	assert.Equal(t, []byte("newpassword"), d.NewPasswd)
+	assert.Equal(t, targ, d.TargName)
+	assert.Equal(t, "TEST.GOKRB5", d.TargRealm)
+}


### PR DESCRIPTION
This separates the change password implementation from set password. It now requires the implementer to be specific, but allows the expected outcome.

Fixes #69.