### PR TITLE
feat: channel binding

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -72,3 +72,11 @@ change will be elaborated on in time):
   `kadmin.SetPasswdMsg`, which selects which of the two protocols `kadmin.Request.Marshal` writes. A `kadmin.Request`
   constructed directly must set it to `kadmin.VersionChangePassword` or `kadmin.VersionSetPassword`; `Marshal` returns
   an error for any other value rather than writing a version number the KDC will reject.
+- `spnego.NewKRB5TokenAPREQ` now returns an error, `spnego.ErrDelegationUnimplemented`, when `flagsGSSAPI` contains
+  `gssapi.ContextFlagDeleg`, where previously it returned a token. RFC 4121 §4.1.1 requires an initiator that sets the
+  delegation flag to populate the `DlgOpt`, `Dlgth` and `Deleg` fields that follow the context flags with the
+  delegation option identifier and a `KRB_CRED`; this library emitted the flag with all three zeroed. MIT rejects that
+  token with `GSS_S_FAILURE` once it reads `DlgOpt` as `0`, so no working deployment loses functionality — the change
+  converts an opaque remote failure into a local one that names the cause. Credential delegation is not implemented;
+  nothing in this library requests the flag, so only a caller passing `flagsGSSAPI` to `NewKRB5TokenAPREQ` directly is
+  affected.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ The following section contains some implementation specific information.
 |         des-cbc-md5          | No (deprecated, insecure)  |       3       |      8      | [RFC3961], [RFC6649] |
 |         des3-cbc-md5         | No (deprecated, insecure)  |       5       |      8      | [RFC3961], [RFC8429] |
 |        des3-cbc-sha1         | No (deprecated, insecure)  |       7       |     13      | [RFC3961], [RFC8429] |
-|        des3-cbc-sha1         |             No             |       8       |     13      |      [RFC3961]       |
 |      dsaWithSHA1-CmsOID      |             No             |       9       |     10      |      [RFC3961]       |
 | md5WithRSAEncryption-CmsOID  |             No             |      10       |      7      |      [RFC3961]       |
 | sha1WithRSAEncryption-CmsOID |             No             |      11       |     14      |      [RFC3961]       |

--- a/credentials/ccache_marshal_test.go
+++ b/credentials/ccache_marshal_test.go
@@ -77,7 +77,7 @@ func TestMarshalRoundTripV3(t *testing.T) {
 // bytes even when a caller-built credential leaves TicketFlags unset (nil
 // Bytes). Writing the raw Bytes instead would emit zero bytes here, shifting
 // every following field by four and causing the parser to read a garbage
-// authorization-data count — an out-of-range panic in readAuthDataEntry. This
+// authorization-data count; an out-of-range panic in readAuthDataEntry. This
 // reproduces a caller-built v4 cache (empty AuthData, unset flags).
 func TestMarshalRoundTripUnsetTicketFlags(t *testing.T) {
 	t.Parallel()

--- a/crypto/rfc4757/msgtype.go
+++ b/crypto/rfc4757/msgtype.go
@@ -17,7 +17,7 @@ func UsageToMSMsgType(usage uint32) []byte {
 	// Now convert to bytes.
 	tb := make([]byte, 4)
 
-	binary.PutUvarint(tb, uint64(usage))
+	binary.LittleEndian.PutUint32(tb, usage)
 
 	return tb
 }

--- a/crypto/rfc4757/msgtype_test.go
+++ b/crypto/rfc4757/msgtype_test.go
@@ -1,0 +1,115 @@
+package rfc4757
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/krb5/iana/keyusage"
+)
+
+// TestUsageToMSMsgTypeShouldFollowRFC4757Table asserts the key usage to message type mapping enumerated by RFC 4757
+// Section 3, which lists a T value for each of the fifteen key usages it covers. Most usages carry their own number
+// through unchanged; the two that do not are items 3 and 9, both of which RFC 4757 gives T=8.
+//
+// T is the value HMACed into the key derivation of every RC4-HMAC operation (see Encrypt, Checksum and DeriveKey), so
+// a wrong value here does not fail loudly. It produces a key both peers compute differently, and the only symptom is
+// an integrity check failure with nothing pointing at the cause.
+func TestUsageToMSMsgTypeShouldFollowRFC4757Table(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		usage uint32
+		want  uint32
+	}{
+		{"AsReqPaEncTimestamp", 1, 1},
+		{"AsRepTicket", 2, 2},
+		{"AsRepEncPartClientKey", 3, 8},
+		{"TgsReqAuthorizationDataSessionKey", 4, 4},
+		{"TgsReqAuthorizationDataSubkey", 5, 5},
+		{"TgsReqAuthenticatorCksum", 6, 6},
+		{"TgsReqAuthenticator", 7, 7},
+		{"TgsRepEncPartSessionKey", 8, 8},
+		{"TgsRepEncPartSubkey", 9, 8},
+		{"ApReqAuthenticatorCksum", 10, 10},
+		{"ApReqAuthenticator", 11, 11},
+		{"ApRepEncPart", 12, 12},
+		{"KrbPrivEncPart", 13, 13},
+		{"KrbCredEncPart", 14, 14},
+		{"KrbSafeCksum", 15, 15},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tb := UsageToMSMsgType(tc.usage)
+
+			require.Len(t, tb, 4, "T is a four octet field")
+			assert.Equal(t, tc.want, binary.LittleEndian.Uint32(tb))
+		})
+	}
+}
+
+// TestUsageToMSMsgTypeShouldEncodeLittleEndianNotVarint pins the encoding itself. RFC 4757 Sections 3, 4 and 5 each
+// state that T is "encoded as a little-endian four-byte integer", and this was implemented with binary.PutUvarint
+// until it was corrected.
+//
+// The two encodings agree for every value below 128, which is why the varint implementation interoperated: the
+// largest T that RFC 4757 assigns is 15. They diverge from 128 upwards, so this asserts the divergence directly. No
+// real key usage reaches that value today, which is exactly why the encoding needs a test rather than a caller to
+// catch a regression.
+func TestUsageToMSMsgTypeShouldEncodeLittleEndianNotVarint(t *testing.T) {
+	t.Parallel()
+
+	// Below the varint continuation-bit boundary the two encodings coincide, so a T in RFC 4757's range cannot
+	// distinguish them.
+	for _, usage := range []uint32{1, 15, 127} {
+		varint := make([]byte, 4)
+		binary.PutUvarint(varint, uint64(usage))
+
+		assert.Equal(t, varint, UsageToMSMsgType(usage),
+			"below 128 the little-endian and varint encodings agree, so real T values cannot detect the difference")
+	}
+
+	// At and above 128 a varint sets the continuation bit and spills into the second octet, which is not a
+	// little-endian uint32 any longer.
+	varint := make([]byte, 4)
+	binary.PutUvarint(varint, 128)
+	require.Equal(t, []byte{0x80, 0x01, 0x00, 0x00}, varint, "a varint of 128 spills into the second octet")
+
+	assert.Equal(t, []byte{0x80, 0x00, 0x00, 0x00}, UsageToMSMsgType(128),
+		"T must be a little-endian four octet integer, never a varint")
+}
+
+// TestUsageToMSMsgTypeGSSAPIUsages documents the mapping for the GSS-API per-message key usages of RFC 4121, which
+// fall outside the fifteen items RFC 4757 Section 3 enumerates.
+//
+// This records current behaviour rather than asserting it is right. RFC 4757 item 13 covers "data encrypted with GSS
+// Wrap" (T=13) and item 15 covers "data signed in GSS MIC" (T=15), yet GSSAPI_ACCEPTOR_SIGN is mapped to 13 here, the
+// wrap value, while the three other GSS-API usages pass through unchanged as 22, 24 and 25; none of which appears in
+// RFC 4757 at all. Whether that is a bug or an undocumented match for what Windows actually does has not been
+// established; do not change it without testing against a real Windows KDC. RC4-HMAC is deprecated and no longer
+// registered by default (see BREAKING.md), so this path is unreachable unless an application opts back in with
+// crypto.RegisterDeprecatedRC4HMAC.
+func TestUsageToMSMsgTypeGSSAPIUsages(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		usage uint32
+		want  uint32
+	}{
+		{"AcceptorSeal", keyusage.GSSAPI_ACCEPTOR_SEAL, 22},
+		{"AcceptorSign", keyusage.GSSAPI_ACCEPTOR_SIGN, 13},
+		{"InitiatorSeal", keyusage.GSSAPI_INITIATOR_SEAL, 24},
+		{"InitiatorSign", keyusage.GSSAPI_INITIATOR_SIGN, 25},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, binary.LittleEndian.Uint32(UsageToMSMsgType(tc.usage)))
+		})
+	}
+}

--- a/gssapi/channel_binding.go
+++ b/gssapi/channel_binding.go
@@ -1,0 +1,78 @@
+package gssapi
+
+import (
+	"crypto/md5" //nolint:gosec // RFC 1964 §1.1.1 fixes MD5 as the channel bindings digest. It is a protocol constant, not a collision resistance claim, and cannot be substituted without breaking interoperability.
+	"encoding/binary"
+)
+
+// Channel binding address types as assigned by RFC 2744 Section 3.11.
+const (
+	AddressTypeUnspecified uint32 = 0
+	AddressTypeLocal       uint32 = 1
+	AddressTypeIPv4        uint32 = 2
+	AddressTypeDECnet      uint32 = 12
+	AddressTypeIPv6        uint32 = 24
+)
+
+// channelBindingFieldLen is the width of each address type and length field in the marshalled structure.
+const channelBindingFieldLen = 4
+
+// channelBindingFields is the number of fixed width fields in the marshalled structure: two address types and three
+// lengths.
+const channelBindingFields = 5
+
+// ChannelBinding is the GSS-API channel bindings structure of RFC 2744 Section 3.11. It binds a security context to
+// the transport channel underneath it so that a credential captured on one channel cannot be replayed on another.
+//
+// For the TLS binding types of RFC 5929 and RFC 9266 the address fields are left unset and everything is carried in
+// ApplicationData. Use NewChannelBindingTLSServerEndPoint, NewChannelBindingTLSExporter or
+// NewChannelBindingTLSUnique rather than populating this struct directly.
+//
+// A nil *ChannelBinding means "no channel bindings" and is safe to use with either method.
+type ChannelBinding struct {
+	InitiatorAddrType uint32
+	InitiatorAddress  []byte
+	AcceptorAddrType  uint32
+	AcceptorAddress   []byte
+	ApplicationData   []byte
+}
+
+// Bytes returns the channel bindings marshalled as described by RFC 1964 Section 1.1.1, with every integer in
+// little-endian order. The length prefix of a field is written even when that field is empty.
+//
+// It returns nil if the receiver is nil.
+func (c *ChannelBinding) Bytes() []byte {
+	if c == nil {
+		return nil
+	}
+
+	b := make([]byte, 0, channelBindingFields*channelBindingFieldLen+
+		len(c.InitiatorAddress)+len(c.AcceptorAddress)+len(c.ApplicationData))
+
+	b = binary.LittleEndian.AppendUint32(b, c.InitiatorAddrType)
+	b = appendChannelBindingField(b, c.InitiatorAddress)
+	b = binary.LittleEndian.AppendUint32(b, c.AcceptorAddrType)
+	b = appendChannelBindingField(b, c.AcceptorAddress)
+	b = appendChannelBindingField(b, c.ApplicationData)
+
+	return b
+}
+
+// Bnd returns the MD5 hash of the marshalled channel bindings. This is the Bnd field of the GSS-API authenticator
+// checksum described by RFC 4121 Section 4.1.1, which occupies bytes 4 to 19 of that checksum.
+//
+// It returns the zero value if the receiver is nil, which is how RFC 4121 encodes the absence of channel bindings.
+func (c *ChannelBinding) Bnd() [16]byte {
+	if c == nil {
+		return [16]byte{}
+	}
+
+	return md5.Sum(c.Bytes()) //nolint:gosec // See the package level rationale on the md5 import.
+}
+
+// appendChannelBindingField appends a little-endian length prefix followed by the field itself.
+func appendChannelBindingField(b, field []byte) []byte {
+	b = binary.LittleEndian.AppendUint32(b, uint32(len(field)))
+
+	return append(b, field...)
+}

--- a/gssapi/channel_binding.go
+++ b/gssapi/channel_binding.go
@@ -5,13 +5,26 @@ import (
 	"encoding/binary"
 )
 
-// Channel binding address types as assigned by RFC 2744 Section 3.11.
+// Channel binding address types for the InitiatorAddrType and AcceptorAddrType fields. RFC 2744 Section 3.11 names
+// the address families those fields may carry; the numeric values are assigned by the gssapi.h header RFC 2744
+// publishes in Appendix A, which is also where the GSS_C_AF_ prefixed names these mirror come from. The set below is
+// the RFC 2744 families this library declares for callers building their own, non-TLS channel bindings, plus the
+// MIT/Heimdal IPv6 value described below; this library itself only ever references AddressTypeUnspecified and
+// AddressTypeIPv4.
+//
+// AddressTypeIPv6 is the exception: RFC 2744 predates IPv6 and assigns no value for it anywhere. 24 is the value MIT
+// Kerberos and Heimdal both give GSS_C_AF_INET6, and is declared for interoperability with them rather than on the
+// authority of the RFC.
+//
+// The TLS binding types of RFC 5929 and RFC 9266 use only AddressTypeUnspecified: they leave both address fields
+// unset and carry everything in ApplicationData.
 const (
 	AddressTypeUnspecified uint32 = 0
 	AddressTypeLocal       uint32 = 1
 	AddressTypeIPv4        uint32 = 2
 	AddressTypeDECnet      uint32 = 12
 	AddressTypeIPv6        uint32 = 24
+	AddressTypeNullAddr    uint32 = 255
 )
 
 // channelBindingFieldLen is the width of each address type and length field in the marshalled structure.
@@ -39,6 +52,10 @@ type ChannelBinding struct {
 
 // Bytes returns the channel bindings marshalled as described by RFC 1964 Section 1.1.1, with every integer in
 // little-endian order. The length prefix of a field is written even when that field is empty.
+//
+// Each field must be no longer than 4294967295 octets, the limit RFC 4121 Section 4.1.1.2 places on interoperable
+// channel binding buffers, because the length prefix is four octets wide. No TLS binding type comes close: the
+// longest is tls-server-end-point over a SHA-512 signed certificate, at 85 octets.
 //
 // It returns nil if the receiver is nil.
 func (c *ChannelBinding) Bytes() []byte {
@@ -71,7 +88,16 @@ func (c *ChannelBinding) Bnd() [16]byte {
 }
 
 // appendChannelBindingField appends a little-endian length prefix followed by the field itself.
+//
+// The length prefix is four octets wide because RFC 1964 Section 1.1.1 fixes it there, which is also why RFC 4121
+// Section 4.1.1.2 limits interoperable channel binding buffers to 4294967295 octets. A field longer than that cannot
+// be represented and is not rejected here: Bytes has no error to return, and returning a short or empty marshalling
+// instead would yield a Bnd that collides with a legitimate one, which is worse than a length that cannot occur. See
+// the documented limit on Bytes.
 func appendChannelBindingField(b, field []byte) []byte {
+	//nolint:gosec // G115: len cannot exceed math.MaxUint32 here for any channel binding that RFC 4121 Section
+	// 4.1.1.2 considers interoperable, and on a 32 bit platform int cannot exceed it at all. Reaching this would
+	// require a single field over 4GiB; the longest TLS binding type is 85 octets.
 	b = binary.LittleEndian.AppendUint32(b, uint32(len(field)))
 
 	return append(b, field...)

--- a/gssapi/channel_binding_test.go
+++ b/gssapi/channel_binding_test.go
@@ -1,0 +1,70 @@
+package gssapi
+
+import (
+	"crypto/md5" //nolint:gosec // Asserts the RFC 1964 mandated digest.
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChannelBindingBytesShouldMarshalRFC1964Layout(t *testing.T) {
+	t.Parallel()
+
+	cb := &ChannelBinding{
+		InitiatorAddrType: AddressTypeIPv4,
+		InitiatorAddress:  []byte{10, 0, 0, 1},
+		AcceptorAddrType:  AddressTypeIPv4,
+		AcceptorAddress:   []byte{10, 0, 0, 2},
+		ApplicationData:   []byte("tls-server-end-point:xyz"),
+	}
+
+	expected := make([]byte, 0, 52)
+	expected = append(expected,
+		0x02, 0x00, 0x00, 0x00, // initiator address type.
+		0x04, 0x00, 0x00, 0x00, // initiator address length.
+		10, 0, 0, 1,
+		0x02, 0x00, 0x00, 0x00, // acceptor address type.
+		0x04, 0x00, 0x00, 0x00, // acceptor address length.
+		10, 0, 0, 2,
+		0x18, 0x00, 0x00, 0x00, // application data length (24).
+	)
+	expected = append(expected, []byte("tls-server-end-point:xyz")...)
+
+	assert.Equal(t, expected, cb.Bytes())
+}
+
+// TestChannelBindingBytesShouldWriteLengthsForEmptyFields asserts the length prefix of an unset field is still
+// emitted. MIT's kg_checksum_channel_bindings does this and interoperability depends on matching it.
+func TestChannelBindingBytesShouldWriteLengthsForEmptyFields(t *testing.T) {
+	t.Parallel()
+
+	cb := &ChannelBinding{ApplicationData: []byte("ab")}
+
+	assert.Equal(t, []byte{
+		0, 0, 0, 0, // initiator address type.
+		0, 0, 0, 0, // initiator address length.
+		0, 0, 0, 0, // acceptor address type.
+		0, 0, 0, 0, // acceptor address length.
+		2, 0, 0, 0, // application data length.
+		'a', 'b',
+	}, cb.Bytes())
+}
+
+func TestChannelBindingBndShouldHashTheMarshalledStructure(t *testing.T) {
+	t.Parallel()
+
+	cb := &ChannelBinding{ApplicationData: []byte("ab")}
+
+	assert.Equal(t, md5.Sum(cb.Bytes()), cb.Bnd()) //nolint:gosec
+}
+
+// TestChannelBindingShouldBeNilSafe asserts a nil binding means "no channel bindings" and yields the 16 zero bytes
+// RFC 4121 expects, which is what keeps the default behaviour unchanged.
+func TestChannelBindingShouldBeNilSafe(t *testing.T) {
+	t.Parallel()
+
+	var cb *ChannelBinding
+
+	assert.Nil(t, cb.Bytes())
+	assert.Equal(t, [16]byte{}, cb.Bnd())
+}

--- a/gssapi/channel_binding_tls.go
+++ b/gssapi/channel_binding_tls.go
@@ -1,0 +1,151 @@
+package gssapi
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"hash"
+)
+
+// Channel binding type names as registered by RFC 5929 and RFC 9266. Each appears in the application data followed
+// by a colon and the binding data itself.
+const (
+	ChannelBindingTypeTLSServerEndPoint = "tls-server-end-point"
+	ChannelBindingTypeTLSUnique         = "tls-unique"
+	ChannelBindingTypeTLSExporter       = "tls-exporter"
+)
+
+// ErrChannelBindingUndefined is returned when a channel binding cannot be derived from the connection. The binding
+// is not merely unavailable: deriving one anyway would produce a value the peer computes differently, so
+// authentication would fail with nothing to point at. Callers should either fall back to no channel binding or
+// treat the connection as unusable, rather than substituting another value.
+var ErrChannelBindingUndefined = errors.New("channel binding is undefined for this connection")
+
+// NewChannelBindingTLSServerEndPoint returns the tls-server-end-point channel binding of RFC 5929 Section 4 for the
+// server certificate provided. This is the binding type Microsoft's Extended Protection for Authentication uses and
+// it applies to both TLS 1.2 and TLS 1.3.
+//
+// The hash is selected from the certificate's own signature algorithm per RFC 5929 Section 4.1. Certificates whose
+// signature algorithm uses no single hash function, such as Ed25519, produce ErrChannelBindingUndefined.
+func NewChannelBindingTLSServerEndPoint(cert *x509.Certificate) (*ChannelBinding, error) {
+	if cert == nil {
+		return nil, errors.New("no certificate provided")
+	}
+
+	h, err := tlsServerEndPointHash(cert.SignatureAlgorithm)
+	if err != nil {
+		return nil, err
+	}
+
+	h.Write(cert.Raw)
+
+	return newChannelBindingApplicationData(ChannelBindingTypeTLSServerEndPoint, h.Sum(nil)), nil
+}
+
+// NewChannelBindingTLSServerEndPointFromState returns the tls-server-end-point channel binding derived from the
+// leaf certificate the peer presented in the TLS connection state provided.
+//
+// This is for initiator (client) use only: on a client connection, PeerCertificates holds the chain the server
+// presented, which is exactly what tls-server-end-point requires. On a server connection, PeerCertificates instead
+// holds the client's chain (only present at all when mTLS is in use), so calling this from acceptor code either
+// errors out or, worse, computes a binding over the wrong certificate that every legitimate client will then fail
+// to match. Acceptor-side callers must instead derive the binding from their own configured server certificate,
+// via NewChannelBindingTLSServerEndPoint, and pass the result to service.RequireChannelBinding.
+func NewChannelBindingTLSServerEndPointFromState(cs *tls.ConnectionState) (*ChannelBinding, error) {
+	if cs == nil {
+		return nil, errors.New("no TLS connection state provided")
+	}
+
+	if len(cs.PeerCertificates) == 0 {
+		return nil, errors.New("TLS connection state contains no peer certificates")
+	}
+
+	return NewChannelBindingTLSServerEndPoint(cs.PeerCertificates[0])
+}
+
+// tlsServerEndPointHash returns the hash to digest the certificate with, per RFC 5929 Section 4.1: a signature
+// algorithm based on MD5 or SHA-1 is upgraded to SHA-256, any other single hash function is used as is, and an
+// algorithm using no single hash function leaves the binding undefined.
+func tlsServerEndPointHash(alg x509.SignatureAlgorithm) (hash.Hash, error) {
+	switch alg {
+	case x509.MD5WithRSA, x509.SHA1WithRSA, x509.DSAWithSHA1, x509.ECDSAWithSHA1,
+		x509.SHA256WithRSA, x509.DSAWithSHA256, x509.ECDSAWithSHA256, x509.SHA256WithRSAPSS:
+		return sha256.New(), nil
+	case x509.SHA384WithRSA, x509.ECDSAWithSHA384, x509.SHA384WithRSAPSS:
+		return sha512.New384(), nil
+	case x509.SHA512WithRSA, x509.ECDSAWithSHA512, x509.SHA512WithRSAPSS:
+		return sha512.New(), nil
+	case x509.MD2WithRSA:
+		return nil, fmt.Errorf("%w: certificate signature algorithm %s uses a hash function Go does not implement", ErrChannelBindingUndefined, alg)
+	default:
+		return nil, fmt.Errorf("%w: certificate signature algorithm %s does not use a single hash function", ErrChannelBindingUndefined, alg)
+	}
+}
+
+// newChannelBindingApplicationData builds a ChannelBinding whose application data is the binding type, a colon and
+// the binding data, with the address fields left unset as is standard for the TLS binding types.
+func newChannelBindingApplicationData(cbType string, data []byte) *ChannelBinding {
+	d := make([]byte, 0, len(cbType)+1+len(data))
+	d = append(d, cbType...)
+	d = append(d, ':')
+	d = append(d, data...)
+
+	return &ChannelBinding{
+		InitiatorAddrType: AddressTypeUnspecified,
+		AcceptorAddrType:  AddressTypeUnspecified,
+		ApplicationData:   d,
+	}
+}
+
+// RFC 9266 Section 3 defines the tls-exporter binding as a TLS exporter run with this label and output length.
+const (
+	channelBindingExporterLabel  = "EXPORTER-Channel-Binding"
+	channelBindingExporterLength = 32
+)
+
+// channelBindingExporterContext is the context RFC 9266 Section 3 specifies for the tls-exporter binding: "Context
+// value: Zero-length string." That is a context that is present but empty, not an absent one. Go's
+// ExportKeyingMaterial treats a nil context as omitted from the exporter seed entirely, which RFC 5705 (TLS 1.2)
+// distinguishes from an explicit zero-length context; the two happen to coincide on TLS 1.3, whose exporter always
+// hashes the context, but diverge on TLS 1.2. Keep this a non-nil, zero-length slice; do not simplify it to nil.
+var channelBindingExporterContext = []byte{}
+
+// NewChannelBindingTLSExporter returns the tls-exporter channel binding of RFC 9266 for the TLS connection state
+// provided.
+//
+// RFC 9266 requires either TLS 1.3 or the extended master secret extension of RFC 7627. Go enforces exactly that
+// precondition in ExportKeyingMaterial, and also refuses when renegotiation is enabled, so its error is wrapped in
+// ErrChannelBindingUndefined and returned unchanged.
+func NewChannelBindingTLSExporter(cs *tls.ConnectionState) (*ChannelBinding, error) {
+	if cs == nil {
+		return nil, errors.New("no TLS connection state provided")
+	}
+
+	b, err := cs.ExportKeyingMaterial(channelBindingExporterLabel, channelBindingExporterContext, channelBindingExporterLength)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrChannelBindingUndefined, err)
+	}
+
+	return newChannelBindingApplicationData(ChannelBindingTypeTLSExporter, b), nil
+}
+
+// NewChannelBindingTLSUnique returns the tls-unique channel binding of RFC 5929 Section 3 for the TLS connection
+// state provided.
+//
+// Go does not populate TLSUnique for TLS 1.3 connections, nor for resumed connections without the extended master
+// secret extension of RFC 7627, and this returns ErrChannelBindingUndefined in those cases. Prefer
+// NewChannelBindingTLSExporter on TLS 1.3, or NewChannelBindingTLSServerEndPoint which works on both versions.
+func NewChannelBindingTLSUnique(cs *tls.ConnectionState) (*ChannelBinding, error) {
+	if cs == nil {
+		return nil, errors.New("no TLS connection state provided")
+	}
+
+	if len(cs.TLSUnique) == 0 {
+		return nil, fmt.Errorf("%w: tls-unique is not available for TLS 1.3 or for a resumed connection without extended master secret", ErrChannelBindingUndefined)
+	}
+
+	return newChannelBindingApplicationData(ChannelBindingTypeTLSUnique, cs.TLSUnique), nil
+}

--- a/gssapi/channel_binding_tls_test.go
+++ b/gssapi/channel_binding_tls_test.go
@@ -1,0 +1,277 @@
+package gssapi
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTLSServerEndPointHashShouldFollowRFC5929 asserts the hash selection rules of RFC 5929 Section 4.1, including
+// the mandatory upgrade of MD5 and SHA-1 to SHA-256.
+func TestTLSServerEndPointHashShouldFollowRFC5929(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		alg  x509.SignatureAlgorithm
+		size int
+	}{
+		{"MD5WithRSAUpgradesToSHA256", x509.MD5WithRSA, sha256.Size},
+		{"SHA1WithRSAUpgradesToSHA256", x509.SHA1WithRSA, sha256.Size},
+		{"ECDSAWithSHA1UpgradesToSHA256", x509.ECDSAWithSHA1, sha256.Size},
+		{"DSAWithSHA1UpgradesToSHA256", x509.DSAWithSHA1, sha256.Size},
+		{"SHA256WithRSA", x509.SHA256WithRSA, sha256.Size},
+		{"SHA256WithRSAPSS", x509.SHA256WithRSAPSS, sha256.Size},
+		{"ECDSAWithSHA256", x509.ECDSAWithSHA256, sha256.Size},
+		{"SHA384WithRSA", x509.SHA384WithRSA, sha512.Size384},
+		{"ECDSAWithSHA384", x509.ECDSAWithSHA384, sha512.Size384},
+		{"SHA512WithRSA", x509.SHA512WithRSA, sha512.Size},
+		{"ECDSAWithSHA512", x509.ECDSAWithSHA512, sha512.Size},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, err := tlsServerEndPointHash(tc.alg)
+			require.NoError(t, err)
+			assert.Equal(t, tc.size, h.Size())
+		})
+	}
+}
+
+// TestTLSServerEndPointHashShouldRejectAlgorithmsWithoutASingleHash asserts the case upstream PR #572 got wrong.
+// RFC 5929 Section 4.1 leaves the binding undefined when the signature algorithm uses no single hash function, so
+// guessing SHA-256 would produce a binding the peer computes differently and fail authentication silently.
+func TestTLSServerEndPointHashShouldRejectAlgorithmsWithoutASingleHash(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		alg  x509.SignatureAlgorithm
+	}{
+		{"PureEd25519", x509.PureEd25519},
+		{"MD2WithRSA", x509.MD2WithRSA},
+		{"Unknown", x509.UnknownSignatureAlgorithm},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := tlsServerEndPointHash(tc.alg)
+			require.ErrorIs(t, err, ErrChannelBindingUndefined)
+		})
+	}
+}
+
+func TestNewChannelBindingTLSServerEndPointShouldPrefixAndHashTheCertificate(t *testing.T) {
+	t.Parallel()
+
+	cert := testChannelBindingCertificate(t, x509.SHA256WithRSA)
+
+	cb, err := NewChannelBindingTLSServerEndPoint(cert)
+	require.NoError(t, err)
+
+	sum := sha256.Sum256(cert.Raw)
+	expected := append([]byte("tls-server-end-point:"), sum[:]...)
+
+	assert.Equal(t, expected, cb.ApplicationData)
+	assert.Equal(t, AddressTypeUnspecified, cb.InitiatorAddrType)
+	assert.Equal(t, AddressTypeUnspecified, cb.AcceptorAddrType)
+	assert.Nil(t, cb.InitiatorAddress)
+	assert.Nil(t, cb.AcceptorAddress)
+}
+
+func TestNewChannelBindingTLSServerEndPointShouldUseSHA384ForSHA384Certificates(t *testing.T) {
+	t.Parallel()
+
+	cert := testChannelBindingCertificate(t, x509.SHA384WithRSA)
+
+	cb, err := NewChannelBindingTLSServerEndPoint(cert)
+	require.NoError(t, err)
+
+	sum := sha512.Sum384(cert.Raw)
+
+	assert.True(t, bytes.HasSuffix(cb.ApplicationData, sum[:]))
+}
+
+func TestNewChannelBindingTLSServerEndPointShouldRejectNilCertificate(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewChannelBindingTLSServerEndPoint(nil)
+	require.EqualError(t, err, "no certificate provided")
+}
+
+func TestNewChannelBindingTLSServerEndPointFromStateShouldRejectMissingInput(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewChannelBindingTLSServerEndPointFromState(nil)
+	require.EqualError(t, err, "no TLS connection state provided")
+
+	_, err = NewChannelBindingTLSServerEndPointFromState(&tls.ConnectionState{})
+	require.EqualError(t, err, "TLS connection state contains no peer certificates")
+}
+
+// testChannelBindingCertificate builds a self signed certificate carrying the requested signature algorithm.
+func testChannelBindingCertificate(t *testing.T, alg x509.SignatureAlgorithm) *x509.Certificate {
+	t.Helper()
+
+	der, _ := testChannelBindingSelfSignedCertificate(t, alg)
+
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return cert
+}
+
+// testChannelBindingSelfSignedCertificate generates a self signed RSA certificate carrying the requested signature
+// algorithm, returning both the DER encoding and the private key. testChannelBindingCertificate parses the DER for
+// callers that only need the certificate; testChannelBindingTLSStates uses both to build a tls.Certificate for a
+// real handshake.
+func testChannelBindingSelfSignedCertificate(t *testing.T, alg x509.SignatureAlgorithm) ([]byte, *rsa.PrivateKey) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:       big.NewInt(1),
+		Subject:            pkix.Name{CommonName: "channel-binding-test"},
+		DNSNames:           []string{"localhost"},
+		NotBefore:          time.Now().Add(-time.Hour),
+		NotAfter:           time.Now().Add(time.Hour),
+		SignatureAlgorithm: alg,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return der, key
+}
+
+// TestNewChannelBindingTLSExporterShouldAgreeAcrossPeers asserts the property that actually matters for a channel
+// binding: both ends of the same connection derive identical bytes.
+func TestNewChannelBindingTLSExporterShouldAgreeAcrossPeers(t *testing.T) {
+	t.Parallel()
+
+	cs, ss := testChannelBindingTLSStates(t, tls.VersionTLS13)
+
+	c, err := NewChannelBindingTLSExporter(&cs)
+	require.NoError(t, err)
+
+	s, err := NewChannelBindingTLSExporter(&ss)
+	require.NoError(t, err)
+
+	assert.Equal(t, c.ApplicationData, s.ApplicationData)
+	assert.True(t, bytes.HasPrefix(c.ApplicationData, []byte("tls-exporter:")))
+	assert.Len(t, c.ApplicationData, len("tls-exporter:")+32)
+}
+
+// TestNewChannelBindingTLSExporterShouldUseZeroLengthContextPerRFC9266 pins the choice of exporter context. The
+// cross-peer agreement tests cannot catch a regression here because both peers run the same code and would agree on
+// a wrong value just as happily. RFC 9266 Section 3 specifies a zero-length context, which Go's ExportKeyingMaterial
+// treats differently from an absent (nil) one on TLS 1.2; see channelBindingExporterContext. This asserts the
+// binding matches the zero-length-context computation and does not match the nil-context one, so the test fails if
+// the implementation is ever reverted to nil.
+func TestNewChannelBindingTLSExporterShouldUseZeroLengthContextPerRFC9266(t *testing.T) {
+	t.Parallel()
+
+	cs, _ := testChannelBindingTLSStates(t, tls.VersionTLS12)
+
+	c, err := NewChannelBindingTLSExporter(&cs)
+	require.NoError(t, err)
+
+	wantZeroLength, err := cs.ExportKeyingMaterial(channelBindingExporterLabel, []byte{}, channelBindingExporterLength)
+	require.NoError(t, err)
+
+	nilContext, err := cs.ExportKeyingMaterial(channelBindingExporterLabel, nil, channelBindingExporterLength)
+	require.NoError(t, err)
+
+	require.NotEqual(t, nilContext, wantZeroLength,
+		"TLS 1.2 exporter output is expected to differ between a nil and a zero-length context; if this fails, "+
+			"Go's ExportKeyingMaterial behaviour changed and the regression guard below no longer proves anything")
+
+	assert.Equal(t, append([]byte("tls-exporter:"), wantZeroLength...), c.ApplicationData)
+	assert.NotEqual(t, append([]byte("tls-exporter:"), nilContext...), c.ApplicationData)
+}
+
+func TestNewChannelBindingTLSUniqueShouldAgreeAcrossPeersOnTLS12(t *testing.T) {
+	t.Parallel()
+
+	cs, ss := testChannelBindingTLSStates(t, tls.VersionTLS12)
+
+	c, err := NewChannelBindingTLSUnique(&cs)
+	require.NoError(t, err)
+
+	s, err := NewChannelBindingTLSUnique(&ss)
+	require.NoError(t, err)
+
+	assert.Equal(t, c.ApplicationData, s.ApplicationData)
+	assert.True(t, bytes.HasPrefix(c.ApplicationData, []byte("tls-unique:")))
+}
+
+// TestNewChannelBindingTLSUniqueShouldRejectTLS13 asserts the documented limitation: Go leaves TLSUnique nil on
+// TLS 1.3, and binding to nothing must be an error rather than a silent empty binding.
+func TestNewChannelBindingTLSUniqueShouldRejectTLS13(t *testing.T) {
+	t.Parallel()
+
+	cs, _ := testChannelBindingTLSStates(t, tls.VersionTLS13)
+
+	_, err := NewChannelBindingTLSUnique(&cs)
+	require.ErrorIs(t, err, ErrChannelBindingUndefined)
+}
+
+func TestChannelBindingTLSConstructorsShouldRejectNilState(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewChannelBindingTLSExporter(nil)
+	require.EqualError(t, err, "no TLS connection state provided")
+
+	_, err = NewChannelBindingTLSUnique(nil)
+	require.EqualError(t, err, "no TLS connection state provided")
+}
+
+// testChannelBindingTLSStates performs a real handshake over an in-memory pipe and returns the client and server
+// connection states for it.
+func testChannelBindingTLSStates(t *testing.T, version uint16) (client, server tls.ConnectionState) {
+	t.Helper()
+
+	der, key := testChannelBindingSelfSignedCertificate(t, x509.SHA256WithRSA)
+
+	cp, sp := net.Pipe()
+
+	t.Cleanup(func() {
+		_ = cp.Close()
+		_ = sp.Close()
+	})
+
+	serverConn := tls.Server(sp, &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: key}},
+		MinVersion:   version,
+		MaxVersion:   version,
+	})
+
+	clientConn := tls.Client(cp, &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec // Self signed fixture certificate in a test.
+		MinVersion:         version,
+		MaxVersion:         version,
+	})
+
+	errCh := make(chan error, 1)
+
+	go func() { errCh <- serverConn.Handshake() }()
+
+	require.NoError(t, clientConn.Handshake())
+	require.NoError(t, <-errCh)
+
+	return clientConn.ConnectionState(), serverConn.ConnectionState()
+}

--- a/service/ap_exchange.go
+++ b/service/ap_exchange.go
@@ -2,6 +2,9 @@ package service
 
 import (
 	"crypto/hmac"
+	"encoding/binary"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/go-krb5/krb5/credentials"
@@ -72,19 +75,73 @@ func VerifyAPREQ(APReq *messages.APReq, s *Settings) (bool, *credentials.Credent
 	return true, creds, nil
 }
 
+// ErrBadChannelBinding identifies a channel binding verification failure. RFC 2743 Section 2.2.2 gives this failure
+// its own GSS-API major status, GSS_S_BAD_BINDINGS, which is deliberately distinct from a defective token: it tells
+// the initiator that its credential was sound but was presented over a channel the acceptor is not bound to, which
+// is the difference between "retry" and "you may be talking to a man in the middle". Callers translating an AP_REQ
+// failure into a GSS-API status match against this with errors.Is.
+var ErrBadChannelBinding = errors.New("bad channel binding")
+
+// badChannelBindingError joins ErrBadChannelBinding to the KRB_ERROR describing the failure. Both are exposed
+// through Unwrap so that a caller can classify the failure with errors.Is and still recover the KRB_ERROR to send on
+// the wire with errors.As. KRB_AP_ERR_BADMATCH is reused for the wire error because RFC 4120 defines no code for bad
+// channel bindings; the distinction that matters to the initiator is carried by the GSS-API status.
+type badChannelBindingError struct {
+	krberr messages.KRBError
+}
+
+// Error returns the description of the underlying KRB_ERROR.
+func (e badChannelBindingError) Error() string {
+	return e.krberr.Error()
+}
+
+// Unwrap exposes the sentinel and the KRB_ERROR so that errors.Is(err, ErrBadChannelBinding) and
+// errors.As(err, &messages.KRBError{}) both succeed.
+func (e badChannelBindingError) Unwrap() []error {
+	return []error{ErrBadChannelBinding, e.krberr}
+}
+
+// newBadChannelBindingError builds the error returned when channel binding verification fails.
+func newBadChannelBindingError(APReq *messages.APReq, etext string) error {
+	return badChannelBindingError{
+		krberr: messages.NewKRBError(APReq.Ticket.SName, APReq.Ticket.Realm, errorcode.KRB_AP_ERR_BADMATCH, etext),
+	}
+}
+
+// authenticatorChksumBndLgth is the value RFC 4121 Section 4.1.1 fixes in the four octet little-endian Lgth field at
+// the start of the GSS-API authenticator checksum: the width of the Bnd field that follows it.
+const authenticatorChksumBndLgth = 16
+
+// authenticatorChksumMinLen is the smallest GSS-API authenticator checksum RFC 4121 Section 4.1.1 describes, holding
+// Lgth, Bnd and Flags. The delegation and extension fields beyond it are optional.
+const authenticatorChksumMinLen = 24
+
 // verifyChannelBinding compares the Bnd field of the AP_REQ authenticator's GSS-API checksum against the channel
 // binding the service requires, as described by RFC 4121 Section 4.1.1. The comparison is constant time.
+//
+// Lgth is checked rather than assumed. RFC 4121 Section 4.1.1 fixes it at 16, so a checksum declaring anything else
+// is not a layout whose octets 4 to 19 can be read as Bnd; comparing them anyway would report a binding mismatch for
+// what is really a malformed checksum, sending whoever has to diagnose it after the wrong problem.
+//
+// Every failure is reported as ErrBadChannelBinding, including an authenticator that carries no usable Bnd at all:
+// once the acceptor has supplied bindings, an initiator that supplied none has bindings that do not match, which
+// RFC 2743 Section 2.2.2 classifies as bad bindings rather than as a defective token.
 func verifyChannelBinding(APReq *messages.APReq, cb *gssapi.ChannelBinding) error {
-	if APReq.Authenticator.Cksum.CksumType != chksumtype.GSSAPI || len(APReq.Authenticator.Cksum.Checksum) < 24 {
-		return messages.NewKRBError(APReq.Ticket.SName, APReq.Ticket.Realm, errorcode.KRB_AP_ERR_BADMATCH,
-			"authenticator does not contain a GSSAPI checksum carrying channel bindings")
+	cksum := APReq.Authenticator.Cksum.Checksum
+
+	if APReq.Authenticator.Cksum.CksumType != chksumtype.GSSAPI || len(cksum) < authenticatorChksumMinLen {
+		return newBadChannelBindingError(APReq, "authenticator does not contain a GSSAPI checksum carrying channel bindings")
+	}
+
+	if lgth := binary.LittleEndian.Uint32(cksum[:4]); lgth != authenticatorChksumBndLgth {
+		return newBadChannelBindingError(APReq, fmt.Sprintf(
+			"authenticator GSSAPI checksum declares a Bnd length of %d rather than %d", lgth, authenticatorChksumBndLgth))
 	}
 
 	expected := cb.Bnd()
 
-	if !hmac.Equal(APReq.Authenticator.Cksum.Checksum[4:20], expected[:]) {
-		return messages.NewKRBError(APReq.Ticket.SName, APReq.Ticket.Realm, errorcode.KRB_AP_ERR_BADMATCH,
-			"channel binding mismatch")
+	if !hmac.Equal(cksum[4:20], expected[:]) {
+		return newBadChannelBindingError(APReq, "channel binding mismatch")
 	}
 
 	return nil

--- a/service/ap_exchange.go
+++ b/service/ap_exchange.go
@@ -1,9 +1,12 @@
 package service
 
 import (
+	"crypto/hmac"
 	"time"
 
 	"github.com/go-krb5/krb5/credentials"
+	"github.com/go-krb5/krb5/gssapi"
+	"github.com/go-krb5/krb5/iana/chksumtype"
 	"github.com/go-krb5/krb5/iana/errorcode"
 	"github.com/go-krb5/krb5/messages"
 )
@@ -20,6 +23,12 @@ func VerifyAPREQ(APReq *messages.APReq, s *Settings) (bool, *credentials.Credent
 	if s.RequireHostAddr() && len(APReq.Ticket.DecryptedEncPart.CAddr) < 1 {
 		return false, creds,
 			messages.NewKRBError(APReq.Ticket.SName, APReq.Ticket.Realm, errorcode.KRB_AP_ERR_BADADDR, "ticket does not contain HostAddress values required")
+	}
+
+	if cb := s.RequireChannelBinding(); cb != nil {
+		if err = verifyChannelBinding(APReq, cb); err != nil {
+			return false, creds, err
+		}
 	}
 
 	// Check for replay.
@@ -61,4 +70,22 @@ func VerifyAPREQ(APReq *messages.APReq, s *Settings) (bool, *credentials.Credent
 	}
 
 	return true, creds, nil
+}
+
+// verifyChannelBinding compares the Bnd field of the AP_REQ authenticator's GSS-API checksum against the channel
+// binding the service requires, as described by RFC 4121 Section 4.1.1. The comparison is constant time.
+func verifyChannelBinding(APReq *messages.APReq, cb *gssapi.ChannelBinding) error {
+	if APReq.Authenticator.Cksum.CksumType != chksumtype.GSSAPI || len(APReq.Authenticator.Cksum.Checksum) < 24 {
+		return messages.NewKRBError(APReq.Ticket.SName, APReq.Ticket.Realm, errorcode.KRB_AP_ERR_BADMATCH,
+			"authenticator does not contain a GSSAPI checksum carrying channel bindings")
+	}
+
+	expected := cb.Bnd()
+
+	if !hmac.Equal(APReq.Authenticator.Cksum.Checksum[4:20], expected[:]) {
+		return messages.NewKRBError(APReq.Ticket.SName, APReq.Ticket.Realm, errorcode.KRB_AP_ERR_BADMATCH,
+			"channel binding mismatch")
+	}
+
+	return nil
 }

--- a/service/ap_exchange_test.go
+++ b/service/ap_exchange_test.go
@@ -542,8 +542,12 @@ func TestVerifyAPREQWithChannelBindingConfigured(t *testing.T) {
 		require.False(t, ok)
 		require.EqualError(t, err, "KRB Error: (36) KRB_AP_ERR_BADMATCH Ticket and authenticator don't match - channel binding mismatch")
 
-		require.IsType(t, messages.KRBError{}, err)
-		assert.Equal(t, errorcode.KRB_AP_ERR_BADMATCH, err.(messages.KRBError).ErrorCode)
+		require.ErrorIs(t, err, ErrBadChannelBinding)
+
+		var krberr messages.KRBError
+
+		require.ErrorAs(t, err, &krberr)
+		assert.Equal(t, errorcode.KRB_AP_ERR_BADMATCH, krberr.ErrorCode)
 	})
 
 	t.Run("NoBindingConfigured", func(t *testing.T) {
@@ -601,42 +605,70 @@ func TestVerifyChannelBindingShouldRejectAMismatchedBinding(t *testing.T) {
 	want := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:want")}
 
 	err := verifyChannelBinding(testAPReqWithChecksum(chksumtype.GSSAPI, testGSSAPIChecksum(sent)), want)
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrBadChannelBinding)
 	assert.Contains(t, err.Error(), "channel binding mismatch")
 }
 
 // TestVerifyChannelBindingShouldRejectAnUnboundRequest asserts that configuring a requirement actually requires it:
 // an initiator that sent the sixteen zero bytes meaning "no channel bindings" must be rejected.
+//
+// The checksum is built with a nil binding rather than as 24 zero bytes because an unbound initiator still writes
+// Lgth, which RFC 4121 Section 4.1.1 fixes at 16 as the width of the Bnd field regardless of whether any bindings
+// were supplied. Only Bnd itself goes to zero. A wholly zeroed checksum would be rejected for its Lgth before the
+// comparison this test is about was ever reached.
 func TestVerifyChannelBindingShouldRejectAnUnboundRequest(t *testing.T) {
 	t.Parallel()
 
 	want := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:want")}
 
-	err := verifyChannelBinding(testAPReqWithChecksum(chksumtype.GSSAPI, make([]byte, 24)), want)
-	require.Error(t, err)
+	cksum := testGSSAPIChecksum(nil)
+	require.Equal(t, uint32(16), binary.LittleEndian.Uint32(cksum[:4]))
+	require.Equal(t, make([]byte, 16), cksum[4:20])
+
+	err := verifyChannelBinding(testAPReqWithChecksum(chksumtype.GSSAPI, cksum), want)
+	require.ErrorIs(t, err, ErrBadChannelBinding)
 	assert.Contains(t, err.Error(), "channel binding mismatch")
 }
+
+// wantMsgNoGSSAPIChecksum is the message verifyChannelBinding reports when the authenticator's checksum is not a
+// usable RFC 4121 Section 4.1.1 GSS-API checksum: wrong checksum type, or too short to carry one.
+const wantMsgNoGSSAPIChecksum = "does not contain a GSSAPI checksum"
 
 func TestVerifyChannelBindingShouldRejectAMalformedChecksum(t *testing.T) {
 	t.Parallel()
 
 	want := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:want")}
 
+	// lgthChecksum builds an otherwise well formed checksum whose four octet Lgth field declares the width given
+	// rather than the 16 RFC 4121 Section 4.1.1 fixes.
+	lgthChecksum := func(lgth uint32) []byte {
+		c := testGSSAPIChecksum(want)
+		binary.LittleEndian.PutUint32(c[:4], lgth)
+
+		return c
+	}
+
 	for _, tc := range []struct {
 		name      string
 		cksumType int32
 		checksum  []byte
+		wantMsg   string
 	}{
-		{"WrongType", chksumtype.HMAC_SHA1_96_AES256, make([]byte, 24)},
-		{"TooShort", chksumtype.GSSAPI, make([]byte, 23)},
-		{"Empty", chksumtype.GSSAPI, nil},
+		{"WrongType", chksumtype.HMAC_SHA1_96_AES256, make([]byte, 24), wantMsgNoGSSAPIChecksum},
+		{"TooShort", chksumtype.GSSAPI, make([]byte, 23), wantMsgNoGSSAPIChecksum},
+		{"Empty", chksumtype.GSSAPI, nil, wantMsgNoGSSAPIChecksum},
+		// A zero, short or oversized Lgth must be rejected on its own terms even when the Bnd octets that follow
+		// would have matched, so that a malformed checksum is never reported as a binding mismatch.
+		{"ZeroLgth", chksumtype.GSSAPI, lgthChecksum(0), "declares a Bnd length of 0 rather than 16"},
+		{"ShortLgth", chksumtype.GSSAPI, lgthChecksum(8), "declares a Bnd length of 8 rather than 16"},
+		{"LongLgth", chksumtype.GSSAPI, lgthChecksum(32), "declares a Bnd length of 32 rather than 16"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			err := verifyChannelBinding(testAPReqWithChecksum(tc.cksumType, tc.checksum), want)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "does not contain a GSSAPI checksum")
+			require.ErrorIs(t, err, ErrBadChannelBinding)
+			assert.Contains(t, err.Error(), tc.wantMsg)
 		})
 	}
 }

--- a/service/ap_exchange_test.go
+++ b/service/ap_exchange_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"testing"
 	"time"
@@ -11,6 +12,8 @@ import (
 	"github.com/go-krb5/krb5/client"
 	"github.com/go-krb5/krb5/config"
 	"github.com/go-krb5/krb5/credentials"
+	"github.com/go-krb5/krb5/gssapi"
+	"github.com/go-krb5/krb5/iana/chksumtype"
 	"github.com/go-krb5/krb5/iana/errorcode"
 	"github.com/go-krb5/krb5/iana/flags"
 	"github.com/go-krb5/krb5/iana/nametype"
@@ -463,6 +466,193 @@ func TestVerifyAPREQ_ExpiredTicket(t *testing.T) {
 	} else {
 		t.Fatalf("Error is not a KRBError: %v", err)
 	}
+}
+
+// TestVerifyAPREQWithChannelBindingConfigured exercises the s.RequireChannelBinding() guard inside VerifyAPREQ end
+// to end, against a real AP_REQ sealed against the test keytab: a matching binding is accepted, a mismatched one is
+// rejected with KRB_AP_ERR_BADMATCH, and leaving the requirement unset (the guard's false branch) reproduces the
+// unchanged, no-verification behaviour of TestVerifyAPREQ.
+func TestVerifyAPREQWithChannelBindingConfigured(t *testing.T) {
+	t.Parallel()
+
+	cl := getClient(t)
+	sname := types.PrincipalName{
+		NameType:   nametype.KRB_NT_PRINCIPAL,
+		NameString: []string{"HTTP", "host.test.gokrb5"},
+	}
+	b, _ := hex.DecodeString(testdata.HTTP_KEYTAB)
+	kt := keytab.New()
+	require.NoError(t, kt.Unmarshal(b))
+
+	sentBinding := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:sent")}
+
+	newSealedAPReq := func(t *testing.T) messages.APReq {
+		t.Helper()
+
+		st := time.Now().UTC()
+
+		tkt, sessionKey, err := messages.NewTicket(cl.Credentials.CName(), cl.Credentials.Domain(),
+			sname, "TEST.GOKRB5",
+			types.NewKrbFlags(),
+			kt,
+			18,
+			1,
+			st,
+			st,
+			st.Add(time.Duration(24)*time.Hour),
+			st.Add(time.Duration(48)*time.Hour),
+		)
+		require.NoError(t, err)
+
+		a := newTestAuthenticator(t, *cl.Credentials)
+		a.Cksum = types.Checksum{CksumType: chksumtype.GSSAPI, Checksum: testGSSAPIChecksum(sentBinding)}
+
+		APReq, err := messages.NewAPReq(tkt, sessionKey, a)
+		require.NoError(t, err)
+
+		return APReq
+	}
+
+	t.Run("MatchingBindingConfigured", func(t *testing.T) {
+		t.Parallel()
+
+		APReq := newSealedAPReq(t)
+
+		h, _ := types.GetHostAddress("127.0.0.1:1234")
+		s := NewSettings(kt, ClientAddress(h), RequireChannelBinding(sentBinding))
+
+		ok, creds, err := VerifyAPREQ(&APReq, s)
+		assert.True(t, ok)
+		assert.NoError(t, err)
+		require.NotNil(t, creds)
+		assert.Equal(t, cl.Credentials.CName(), creds.CName())
+	})
+
+	t.Run("MismatchedBindingConfigured", func(t *testing.T) {
+		t.Parallel()
+
+		APReq := newSealedAPReq(t)
+
+		wantBinding := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:want")}
+
+		h, _ := types.GetHostAddress("127.0.0.1:1234")
+		s := NewSettings(kt, ClientAddress(h), RequireChannelBinding(wantBinding))
+
+		ok, _, err := VerifyAPREQ(&APReq, s)
+		require.False(t, ok)
+		require.EqualError(t, err, "KRB Error: (36) KRB_AP_ERR_BADMATCH Ticket and authenticator don't match - channel binding mismatch")
+
+		require.IsType(t, messages.KRBError{}, err)
+		assert.Equal(t, errorcode.KRB_AP_ERR_BADMATCH, err.(messages.KRBError).ErrorCode)
+	})
+
+	t.Run("NoBindingConfigured", func(t *testing.T) {
+		t.Parallel()
+
+		APReq := newSealedAPReq(t)
+
+		h, _ := types.GetHostAddress("127.0.0.1:1234")
+		s := NewSettings(kt, ClientAddress(h))
+
+		ok, creds, err := VerifyAPREQ(&APReq, s)
+		assert.True(t, ok)
+		assert.NoError(t, err)
+		require.NotNil(t, creds)
+		assert.Equal(t, cl.Credentials.CName(), creds.CName())
+	})
+}
+
+// testAPReqWithChecksum builds the minimum AP_REQ needed to exercise channel binding verification.
+func testAPReqWithChecksum(cksumType int32, checksum []byte) *messages.APReq {
+	return &messages.APReq{
+		Ticket: messages.Ticket{
+			Realm: "EXAMPLE.ORG",
+			SName: types.PrincipalName{NameType: 1, NameString: []string{"HTTP", "host.example.org"}},
+		},
+		Authenticator: types.Authenticator{
+			Cksum: types.Checksum{CksumType: cksumType, Checksum: checksum},
+		},
+	}
+}
+
+// testGSSAPIChecksum builds an RFC 4121 Section 4.1.1 checksum carrying the binding provided.
+func testGSSAPIChecksum(cb *gssapi.ChannelBinding) []byte {
+	c := make([]byte, 24)
+	binary.LittleEndian.PutUint32(c[:4], 16)
+
+	bnd := cb.Bnd()
+	copy(c[4:20], bnd[:])
+
+	return c
+}
+
+func TestVerifyChannelBindingShouldAcceptAMatchingBinding(t *testing.T) {
+	t.Parallel()
+
+	cb := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:test")}
+
+	require.NoError(t, verifyChannelBinding(testAPReqWithChecksum(chksumtype.GSSAPI, testGSSAPIChecksum(cb)), cb))
+}
+
+func TestVerifyChannelBindingShouldRejectAMismatchedBinding(t *testing.T) {
+	t.Parallel()
+
+	sent := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:sent")}
+	want := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:want")}
+
+	err := verifyChannelBinding(testAPReqWithChecksum(chksumtype.GSSAPI, testGSSAPIChecksum(sent)), want)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "channel binding mismatch")
+}
+
+// TestVerifyChannelBindingShouldRejectAnUnboundRequest asserts that configuring a requirement actually requires it:
+// an initiator that sent the sixteen zero bytes meaning "no channel bindings" must be rejected.
+func TestVerifyChannelBindingShouldRejectAnUnboundRequest(t *testing.T) {
+	t.Parallel()
+
+	want := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:want")}
+
+	err := verifyChannelBinding(testAPReqWithChecksum(chksumtype.GSSAPI, make([]byte, 24)), want)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "channel binding mismatch")
+}
+
+func TestVerifyChannelBindingShouldRejectAMalformedChecksum(t *testing.T) {
+	t.Parallel()
+
+	want := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:want")}
+
+	for _, tc := range []struct {
+		name      string
+		cksumType int32
+		checksum  []byte
+	}{
+		{"WrongType", chksumtype.HMAC_SHA1_96_AES256, make([]byte, 24)},
+		{"TooShort", chksumtype.GSSAPI, make([]byte, 23)},
+		{"Empty", chksumtype.GSSAPI, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := verifyChannelBinding(testAPReqWithChecksum(tc.cksumType, tc.checksum), want)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "does not contain a GSSAPI checksum")
+		})
+	}
+}
+
+func TestSettingsRequireChannelBindingShouldDefaultToNil(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, NewSettings(nil).RequireChannelBinding())
+}
+
+func TestSettingsRequireChannelBindingShouldRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cb := &gssapi.ChannelBinding{ApplicationData: []byte("tls-exporter:test")}
+
+	assert.Same(t, cb, NewSettings(nil, RequireChannelBinding(cb)).RequireChannelBinding())
 }
 
 func newTestAuthenticator(t *testing.T, creds credentials.Credentials) types.Authenticator {

--- a/service/settings.go
+++ b/service/settings.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/go-krb5/krb5/gssapi"
 	"github.com/go-krb5/krb5/keytab"
 	"github.com/go-krb5/krb5/types"
 )
@@ -20,6 +21,7 @@ type Settings struct {
 	maxClockSkew       time.Duration
 	logger             *log.Logger
 	sessionMgr         SessionMgr
+	channelBinding     *gssapi.ChannelBinding
 }
 
 // NewSettings creates a new service Settings.
@@ -152,6 +154,30 @@ func SessionManager(sm SessionMgr) func(*Settings) {
 // SessionManager returns any configured session manager.
 func (s *Settings) SessionManager() SessionMgr {
 	return s.sessionMgr
+}
+
+// RequireChannelBinding used to configure the service to require the GSS-API channel binding provided. The binding
+// is compared against the Bnd field of the AP_REQ authenticator checksum described by RFC 4121 Section 4.1.1.
+//
+// When configured, a request that carries no channel binding is rejected: requiring a binding means requiring it.
+// When left unset no verification is performed, which is the default.
+//
+// Passing a nil binding disables verification exactly as if this option were never supplied: there is no error and
+// no log line, the service simply accepts requests without checking a binding. The gssapi.NewChannelBinding*
+// constructors return a nil binding alongside a non-nil error in some cases (for example, no mTLS on the
+// connection, or a certificate whose signature algorithm such as Ed25519 has no single hash to bind to), so callers
+// must check that error rather than discarding it before passing the result here.
+//
+// s := NewSettings(kt, RequireChannelBinding(cb)).
+func RequireChannelBinding(cb *gssapi.ChannelBinding) func(*Settings) {
+	return func(s *Settings) {
+		s.channelBinding = cb
+	}
+}
+
+// RequireChannelBinding returns the channel binding the service requires, or nil if it does not require one.
+func (s *Settings) RequireChannelBinding() *gssapi.ChannelBinding {
+	return s.channelBinding
 }
 
 // SessionMgr must provide a ways to:

--- a/spnego/http.go
+++ b/spnego/http.go
@@ -124,6 +124,14 @@ func TokenOptions(opts ...KRB5TokenOption) func(*Client) {
 // Requests that are not over TLS, or whose peer sent no certificate, proceed without a channel binding: there is no
 // channel to bind to. A binding configured explicitly through TokenOptions takes precedence over the derived one.
 //
+// A request that is over TLS but whose certificate yields no binding also proceeds without one, logging the reason
+// through the krb5 client. RFC 5929 Section 4.1 leaves the binding undefined for a certificate whose signature
+// algorithm has no single hash function, Ed25519 being the case in practice. This is a silent downgrade in both
+// directions: against a service that requires a binding the request fails authentication with nothing in the response
+// naming the certificate as the cause, and against a service that does not, the protection this option was enabled
+// for is simply absent. Callers who need the guarantee rather than the attempt should derive the binding themselves
+// with gssapi.NewChannelBindingTLSServerEndPoint, which reports the error, and pass it through TokenOptions.
+//
 // cl := NewClient(krb5Cl, httpCl, spn, ChannelBindingTLSServerEndPoint()).
 func ChannelBindingTLSServerEndPoint() func(*Client) {
 	return func(c *Client) {

--- a/spnego/http.go
+++ b/spnego/http.go
@@ -33,10 +33,12 @@ const DefaultMaxRedirects = 10
 // Client will negotiate authentication with a server using SPNEGO.
 type Client struct {
 	*http.Client
-	krb5Client   *client.Client
-	spn          string
-	reqs         []*http.Request
-	maxRedirects int
+	krb5Client         *client.Client
+	spn                string
+	reqs               []*http.Request
+	maxRedirects       int
+	tokenOptions       []KRB5TokenOption
+	autoChannelBinding bool
 }
 
 type redirectErr struct {
@@ -106,6 +108,29 @@ func MaxRedirects(n int) func(*Client) {
 	}
 }
 
+// TokenOptions configures options applied to every AP_REQ the client creates.
+//
+// cl := NewClient(krb5Cl, httpCl, spn, TokenOptions(ChannelBinding(cb))).
+func TokenOptions(opts ...KRB5TokenOption) func(*Client) {
+	return func(c *Client) {
+		c.tokenOptions = append(c.tokenOptions, opts...)
+	}
+}
+
+// ChannelBindingTLSServerEndPoint configures the client to derive a tls-server-end-point channel binding, as
+// described by RFC 5929 Section 4, from the TLS state of the response that challenged it. This is what Microsoft's
+// Extended Protection for Authentication requires and it needs no further configuration.
+//
+// Requests that are not over TLS, or whose peer sent no certificate, proceed without a channel binding: there is no
+// channel to bind to. A binding configured explicitly through TokenOptions takes precedence over the derived one.
+//
+// cl := NewClient(krb5Cl, httpCl, spn, ChannelBindingTLSServerEndPoint()).
+func ChannelBindingTLSServerEndPoint() func(*Client) {
+	return func(c *Client) {
+		c.autoChannelBinding = true
+	}
+}
+
 // Do is the SPNEGO enabled HTTP client's equivalent of the http.Client's Do method.
 func (c *Client) Do(req *http.Request) (resp *http.Response, err error) {
 	var body bytes.Buffer
@@ -143,7 +168,7 @@ func (c *Client) Do(req *http.Request) (resp *http.Response, err error) {
 	}
 
 	if respUnauthorizedNegotiate(resp) {
-		if err = SetSPNEGOHeader(c.krb5Client, req, c.spn); err != nil {
+		if err = SetSPNEGOHeader(c.krb5Client, req, c.spn, c.requestTokenOptions(resp)...); err != nil {
 			return resp, err
 		}
 
@@ -160,6 +185,26 @@ func (c *Client) Do(req *http.Request) (resp *http.Response, err error) {
 	c.reqs = c.reqs[:0]
 
 	return resp, err
+}
+
+// requestTokenOptions returns the token options to use for the response that challenged the client, deriving a
+// channel binding from its TLS state when the client is configured to. Derived options come first so that anything
+// configured explicitly overrides them.
+func (c *Client) requestTokenOptions(resp *http.Response) []KRB5TokenOption {
+	var opts []KRB5TokenOption
+
+	if c.autoChannelBinding && resp.TLS != nil && len(resp.TLS.PeerCertificates) > 0 {
+		cb, err := gssapi.NewChannelBindingTLSServerEndPoint(resp.TLS.PeerCertificates[0])
+		if err != nil && c.krb5Client != nil {
+			c.krb5Client.Log("could not derive tls-server-end-point channel binding: %v", err)
+		}
+
+		if cb != nil {
+			opts = append(opts, ChannelBinding(cb))
+		}
+	}
+
+	return append(opts, c.tokenOptions...)
 }
 
 // Get is the SPNEGO enabled HTTP client's equivalent of the http.Client's Get method.
@@ -245,7 +290,7 @@ func setRequestSPN(r *http.Request) (types.PrincipalName, error) {
 
 // SetSPNEGOHeader gets the service ticket and sets it as the SPNEGO authorization header on HTTP request object.
 // To auto generate the SPN from the request object pass a null string "".
-func SetSPNEGOHeader(cl *client.Client, r *http.Request, spn string) error {
+func SetSPNEGOHeader(cl *client.Client, r *http.Request, spn string, opts ...KRB5TokenOption) error {
 	if spn == "" {
 		pn, err := setRequestSPN(r)
 		if err != nil {
@@ -256,7 +301,7 @@ func SetSPNEGOHeader(cl *client.Client, r *http.Request, spn string) error {
 	}
 
 	cl.Log("using SPN %s", spn)
-	s := SPNEGOClient(cl, spn)
+	s := SPNEGOClient(cl, spn, opts...)
 
 	err := s.AcquireCred()
 	if err != nil {

--- a/spnego/http_test.go
+++ b/spnego/http_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/go-krb5/krb5/client"
 	"github.com/go-krb5/krb5/config"
+	"github.com/go-krb5/krb5/gssapi"
 	"github.com/go-krb5/krb5/keytab"
 	"github.com/go-krb5/krb5/service"
 	"github.com/go-krb5/krb5/test"
@@ -528,4 +529,81 @@ func (smgr SessionMgr) New(w http.ResponseWriter, r *http.Request, k any, v []by
 	s.Values[k] = v
 
 	return s.Save(r, w)
+}
+
+func TestClientShouldDeriveChannelBindingFromResponseTLS(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := srv.Client().Get(srv.URL)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	require.NotNil(t, resp.TLS)
+
+	c := NewClient(nil, srv.Client(), "HTTP/localhost", ChannelBindingTLSServerEndPoint())
+
+	opts := c.requestTokenOptions(resp)
+	require.Len(t, opts, 1)
+
+	expected, err := gssapi.NewChannelBindingTLSServerEndPoint(resp.TLS.PeerCertificates[0])
+	require.NoError(t, err)
+
+	assert.Equal(t, expected.ApplicationData, newKRB5TokenOptions(opts...).channelBinding.ApplicationData)
+}
+
+// TestClientShouldNotDeriveChannelBindingWithoutTLS asserts a plaintext request proceeds unbound rather than
+// failing, because there is no channel to bind to.
+func TestClientShouldNotDeriveChannelBindingWithoutTLS(t *testing.T) {
+	t.Parallel()
+
+	c := NewClient(nil, nil, "HTTP/localhost", ChannelBindingTLSServerEndPoint())
+
+	assert.Empty(t, c.requestTokenOptions(&http.Response{}))
+}
+
+func TestClientShouldNotDeriveChannelBindingWhenNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := srv.Client().Get(srv.URL)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	c := NewClient(nil, srv.Client(), "HTTP/localhost")
+
+	assert.Empty(t, c.requestTokenOptions(resp))
+}
+
+// TestClientExplicitChannelBindingShouldWinOverAutoDerivation asserts the precedence rule from the spec.
+func TestClientExplicitChannelBindingShouldWinOverAutoDerivation(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := srv.Client().Get(srv.URL)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	explicit := &gssapi.ChannelBinding{ApplicationData: []byte("tls-exporter:explicit")}
+
+	c := NewClient(nil, srv.Client(), "HTTP/localhost",
+		ChannelBindingTLSServerEndPoint(),
+		TokenOptions(ChannelBinding(explicit)),
+	)
+
+	assert.Same(t, explicit, newKRB5TokenOptions(c.requestTokenOptions(resp)...).channelBinding)
 }

--- a/spnego/krb5_token.go
+++ b/spnego/krb5_token.go
@@ -176,8 +176,40 @@ func (m *KRB5Token) Context() context.Context {
 	return m.context
 }
 
+// KRB5TokenOption configures optional content of a KRB5Token.
+type KRB5TokenOption func(*krb5TokenOptions)
+
+// krb5TokenOptions holds the resolved options for creating a KRB5Token.
+type krb5TokenOptions struct {
+	channelBinding *gssapi.ChannelBinding
+}
+
+// ChannelBinding configures the GSS-API channel binding to bind the AP_REQ to. The hash of the binding is carried in
+// the Bnd field of the authenticator checksum described by RFC 4121 Section 4.1.1.
+//
+// A nil binding means no channel bindings, which is the default.
+//
+//	cb, err := gssapi.NewChannelBindingTLSServerEndPointFromState(&state)
+//	s := SPNEGOClient(cl, spn, ChannelBinding(cb)).
+func ChannelBinding(cb *gssapi.ChannelBinding) KRB5TokenOption {
+	return func(o *krb5TokenOptions) {
+		o.channelBinding = cb
+	}
+}
+
+// newKRB5TokenOptions resolves the options provided, applying them in order so that the last value wins.
+func newKRB5TokenOptions(opts ...KRB5TokenOption) *krb5TokenOptions {
+	o := new(krb5TokenOptions)
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	return o
+}
+
 // NewKRB5TokenAPREQ creates a new KRB5 token with AP_REQ.
-func NewKRB5TokenAPREQ(cl *client.Client, tkt messages.Ticket, sessionKey types.EncryptionKey, flagsGSSAPI []int, optionsAP []int) (KRB5Token, error) {
+func NewKRB5TokenAPREQ(cl *client.Client, tkt messages.Ticket, sessionKey types.EncryptionKey, flagsGSSAPI []int, optionsAP []int, opts ...KRB5TokenOption) (KRB5Token, error) {
 	// TODO consider providing the SPN rather than the specific tkt and key and get these from the krb client.
 	var m KRB5Token
 
@@ -185,7 +217,7 @@ func NewKRB5TokenAPREQ(cl *client.Client, tkt messages.Ticket, sessionKey types.
 	tb, _ := hex.DecodeString(TOK_ID_KRB_AP_REQ)
 	m.tokID = tb
 
-	auth, err := krb5TokenAuthenticator(cl.Credentials, flagsGSSAPI)
+	auth, err := krb5TokenAuthenticator(cl.Credentials, flagsGSSAPI, newKRB5TokenOptions(opts...).channelBinding)
 	if err != nil {
 		return m, err
 	}
@@ -209,7 +241,7 @@ func NewKRB5TokenAPREQ(cl *client.Client, tkt messages.Ticket, sessionKey types.
 }
 
 // krb5TokenAuthenticator creates a new kerberos authenticator for kerberos MechToken.
-func krb5TokenAuthenticator(creds *credentials.Credentials, flags []int) (types.Authenticator, error) {
+func krb5TokenAuthenticator(creds *credentials.Credentials, flags []int, cb *gssapi.ChannelBinding) (types.Authenticator, error) {
 	// RFC 4121 Section 4.1.1.
 	auth, err := types.NewAuthenticator(creds.Domain(), creds.CName())
 	if err != nil {
@@ -218,16 +250,23 @@ func krb5TokenAuthenticator(creds *credentials.Credentials, flags []int) (types.
 
 	auth.Cksum = types.Checksum{
 		CksumType: chksumtype.GSSAPI,
-		Checksum:  newAuthenticatorChksum(flags),
+		Checksum:  newAuthenticatorChksum(flags, cb),
 	}
 
 	return auth, nil
 }
 
-// Create new authenticator checksum for kerberos MechToken.
-func newAuthenticatorChksum(flags []int) []byte {
+// newAuthenticatorChksum creates the authenticator checksum for a kerberos MechToken as described by RFC 4121
+// Section 4.1.1: a four byte length of 16, the sixteen byte Bnd channel bindings hash, the four byte context flags
+// and, when delegation is requested, the optional delegation fields.
+//
+// A nil channel binding leaves Bnd as the sixteen zero bytes that mean no channel bindings.
+func newAuthenticatorChksum(flags []int, cb *gssapi.ChannelBinding) []byte {
 	a := make([]byte, 24)
 	binary.LittleEndian.PutUint32(a[:4], 16)
+
+	bnd := cb.Bnd()
+	copy(a[4:20], bnd[:])
 
 	for _, i := range flags {
 		if i == gssapi.ContextFlagDeleg {

--- a/spnego/krb5_token.go
+++ b/spnego/krb5_token.go
@@ -130,6 +130,13 @@ func (m *KRB5Token) Verify() (bool, gssapi.Status) {
 	case TOK_ID_KRB_AP_REQ:
 		ok, creds, err := service.VerifyAPREQ(&m.APReq, m.settings)
 		if err != nil {
+			// RFC 2743 Section 2.2.2 separates a credential presented over the wrong channel from a malformed
+			// token. Reporting a channel binding failure as a defective token would leave the initiator unable to
+			// tell the two apart, and unable to tell that it is the channel rather than its credential at fault.
+			if errors.Is(err, service.ErrBadChannelBinding) {
+				return false, gssapi.Status{Code: gssapi.StatusBadBindings, Message: err.Error()}
+			}
+
 			return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: err.Error()}
 		}
 
@@ -248,20 +255,44 @@ func krb5TokenAuthenticator(creds *credentials.Credentials, flags []int, cb *gss
 		return auth, krberror.Errorf(err, krberror.KRBMsgError, "error generating new authenticator")
 	}
 
+	chksum, err := newAuthenticatorChksum(flags, cb)
+	if err != nil {
+		return auth, err
+	}
+
 	auth.Cksum = types.Checksum{
 		CksumType: chksumtype.GSSAPI,
-		Checksum:  newAuthenticatorChksum(flags, cb),
+		Checksum:  chksum,
 	}
 
 	return auth, nil
 }
 
+// ErrDelegationUnimplemented is returned when gssapi.ContextFlagDeleg is requested. RFC 4121 Section 4.1.1 requires
+// the delegation option identifier in DlgOpt and a KRB_CRED in Deleg whenever the flag is set; this library
+// implements neither, so it refuses the request rather than emitting a checksum that claims a delegation it cannot
+// perform. Callers match against it with errors.Is.
+var ErrDelegationUnimplemented = errors.New("credential delegation is not implemented")
+
 // newAuthenticatorChksum creates the authenticator checksum for a kerberos MechToken as described by RFC 4121
-// Section 4.1.1: a four byte length of 16, the sixteen byte Bnd channel bindings hash, the four byte context flags
-// and, when delegation is requested, the optional delegation fields.
+// Section 4.1.1: a four byte Lgth of 16, the sixteen byte Bnd channel bindings hash and the four byte context flags.
+// The result is always 24 bytes.
 //
 // A nil channel binding leaves Bnd as the sixteen zero bytes that mean no channel bindings.
-func newAuthenticatorChksum(flags []int, cb *gssapi.ChannelBinding) []byte {
+//
+// Requesting gssapi.ContextFlagDeleg returns ErrDelegationUnimplemented. Setting the flag obliges the initiator to
+// populate the DlgOpt, Dlgth and Deleg fields that follow Flags, and this library has no KRB_CRED to put there:
+// messages.KRBCred can be received but not emitted, and nothing acquires a forwarded TGT. Emitting the flag with
+// those fields zeroed is what this used to do, and MIT rejects it with GSS_S_FAILURE on reading DlgOpt as 0, so the
+// refusal costs no working deployment anything. Nothing in this library requests the flag: both SPNEGO paths ask for
+// ContextFlagInteg and ContextFlagConf only.
+func newAuthenticatorChksum(flags []int, cb *gssapi.ChannelBinding) ([]byte, error) {
+	for _, i := range flags {
+		if i&gssapi.ContextFlagDeleg != 0 {
+			return nil, fmt.Errorf("%w: RFC 4121 Section 4.1.1 requires DlgOpt to carry the delegation option identifier 1 and Deleg to carry a KRB_CRED", ErrDelegationUnimplemented)
+		}
+	}
+
 	a := make([]byte, 24)
 	binary.LittleEndian.PutUint32(a[:4], 16)
 
@@ -269,11 +300,6 @@ func newAuthenticatorChksum(flags []int, cb *gssapi.ChannelBinding) []byte {
 	copy(a[4:20], bnd[:])
 
 	for _, i := range flags {
-		if i == gssapi.ContextFlagDeleg {
-			x := make([]byte, 28-len(a))
-			a = append(a, x...)
-		}
-
 		f := binary.LittleEndian.Uint32(a[20:24])
 
 		f |= uint32(i)
@@ -281,5 +307,5 @@ func newAuthenticatorChksum(flags []int, cb *gssapi.ChannelBinding) []byte {
 		binary.LittleEndian.PutUint32(a[20:24], f)
 	}
 
-	return a
+	return a, nil
 }

--- a/spnego/krb5_token_test.go
+++ b/spnego/krb5_token_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,7 +18,9 @@ import (
 	"github.com/go-krb5/krb5/iana/chksumtype"
 	"github.com/go-krb5/krb5/iana/msgtype"
 	"github.com/go-krb5/krb5/iana/nametype"
+	"github.com/go-krb5/krb5/keytab"
 	"github.com/go-krb5/krb5/messages"
+	"github.com/go-krb5/krb5/service"
 	"github.com/go-krb5/krb5/test/testdata"
 	"github.com/go-krb5/krb5/types"
 )
@@ -50,7 +53,8 @@ func TestKRB5Token_newAuthenticatorChksum(t *testing.T) {
 	b, err := hex.DecodeString(AuthChksum)
 	require.NoError(t, err)
 
-	cb := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, nil)
+	cb, err := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, nil)
+	require.NoError(t, err)
 	assert.Equal(t, b, cb)
 }
 
@@ -217,7 +221,8 @@ func TestNewAuthenticatorChksumShouldEmbedTheChannelBinding(t *testing.T) {
 
 	cb := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:test")}
 
-	c := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, cb)
+	c, err := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, cb)
+	require.NoError(t, err)
 
 	require.Len(t, c, 24)
 	assert.Equal(t, uint32(16), binary.LittleEndian.Uint32(c[:4]))
@@ -233,12 +238,99 @@ func TestNewAuthenticatorChksumShouldEmbedTheChannelBinding(t *testing.T) {
 func TestNewAuthenticatorChksumShouldZeroBndWithoutAChannelBinding(t *testing.T) {
 	t.Parallel()
 
-	c := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, nil)
+	c, err := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, nil)
+	require.NoError(t, err)
 
 	require.Len(t, c, 24)
 	assert.Equal(t, uint32(16), binary.LittleEndian.Uint32(c[:4]))
 	assert.Equal(t, make([]byte, 16), c[4:20])
 	assert.Equal(t, uint32(gssapi.ContextFlagInteg|gssapi.ContextFlagConf), binary.LittleEndian.Uint32(c[20:24]))
+}
+
+// TestNewAuthenticatorChksumShouldRefuseDelegation asserts the library refuses to claim a delegation it cannot
+// perform. RFC 4121 Section 4.1.1 requires DlgOpt to carry the delegation option identifier 1 and Deleg to carry a
+// KRB_CRED whenever the delegation flag is set. This library implements neither, and the 28 zeroed octets it used to
+// emit are rejected by MIT with GSS_S_FAILURE once it reads DlgOpt as 0. Failing here names the cause at the call
+// site instead.
+func TestNewAuthenticatorChksumShouldRefuseDelegation(t *testing.T) {
+	t.Parallel()
+
+	c, err := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagDeleg}, nil)
+
+	require.ErrorIs(t, err, ErrDelegationUnimplemented)
+	assert.Nil(t, c, "no checksum is returned when the flags cannot be honoured")
+	assert.Contains(t, err.Error(), "RFC 4121")
+}
+
+// TestNewAuthenticatorChksumShouldRefuseCombinedDelegationBitmask asserts the guard tests the bit rather than the
+// value. The flags loop below the guard accumulates ORed values with f |= uint32(i), so a caller passing a combined
+// bitmask in a single slice element is an invited call style, not a misuse. A guard written as i ==
+// gssapi.ContextFlagDeleg misses that case: ContextFlagDeleg|ContextFlagInteg reaches the flags loop unrefused and
+// sets GSS_C_DELEG_FLAG in the emitted checksum with none of the delegation fields populated, which is exactly the
+// false claim of delegation this refusal exists to prevent.
+func TestNewAuthenticatorChksumShouldRefuseCombinedDelegationBitmask(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		flags       []int
+		wantRefused bool
+	}{
+		{
+			name:        "DelegationAlone",
+			flags:       []int{gssapi.ContextFlagDeleg},
+			wantRefused: true,
+		},
+		{
+			name:        "DelegationCombinedWithIntegInOneElement",
+			flags:       []int{gssapi.ContextFlagDeleg | gssapi.ContextFlagInteg},
+			wantRefused: true,
+		},
+		{
+			name:        "IntegAndConfCombinedWithoutDelegationMustStillSucceed",
+			flags:       []int{gssapi.ContextFlagInteg | gssapi.ContextFlagConf},
+			wantRefused: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := newAuthenticatorChksum(tt.flags, nil)
+
+			if tt.wantRefused {
+				require.ErrorIs(t, err, ErrDelegationUnimplemented)
+				assert.Nil(t, c, "no checksum is returned when the flags cannot be honoured")
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, c, 24)
+		})
+	}
+}
+
+// TestNewKRB5TokenAPREQShouldSurfaceDelegationRefusal covers the propagation hop rather than only the leaf: the error
+// has to travel newAuthenticatorChksum -> krb5TokenAuthenticator -> NewKRB5TokenAPREQ to reach a caller.
+func TestNewKRB5TokenAPREQShouldSurfaceDelegationRefusal(t *testing.T) {
+	t.Parallel()
+
+	creds := credentials.New("hftsai", testdata.TEST_REALM)
+	creds.SetCName(types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: testdata.TEST_PRINCIPALNAME_NAMESTRING})
+	cl := &client.Client{Credentials: creds}
+
+	var tkt messages.Ticket
+
+	b, err := hex.DecodeString(testdata.MarshaledKRB5ticket)
+	require.NoError(t, err)
+	require.NoError(t, tkt.Unmarshal(b))
+
+	key := types.EncryptionKey{KeyType: 18, KeyValue: make([]byte, 32)}
+
+	_, err = NewKRB5TokenAPREQ(cl, tkt, key, []int{gssapi.ContextFlagDeleg}, []int{})
+	require.ErrorIs(t, err, ErrDelegationUnimplemented)
 }
 
 func TestNewKRB5TokenOptionsShouldDefaultToNoChannelBinding(t *testing.T) {
@@ -253,4 +345,118 @@ func TestChannelBindingOptionShouldSetTheBinding(t *testing.T) {
 	cb := &gssapi.ChannelBinding{ApplicationData: []byte("tls-exporter:test")}
 
 	assert.Same(t, cb, newKRB5TokenOptions(ChannelBinding(cb)).channelBinding)
+}
+
+// TestKRB5TokenVerifyShouldReportChannelBindingFailuresAsBadBindings asserts the GSS-API major status an acceptor
+// reports for each outcome. RFC 2743 Section 2.2.2 gives channel binding failures their own status,
+// GSS_S_BAD_BINDINGS, so that an initiator can tell "your credential is fine but you are on the wrong channel" from
+// "your token is malformed". Collapsing both onto GSS_S_DEFECTIVE_TOKEN loses exactly the signal that distinguishes
+// a misconfigured proxy from an attacker relaying a captured token onto another channel.
+func TestKRB5TokenVerifyShouldReportChannelBindingFailuresAsBadBindings(t *testing.T) {
+	t.Parallel()
+
+	sname := types.PrincipalName{
+		NameType:   nametype.KRB_NT_PRINCIPAL,
+		NameString: []string{"HTTP", "host.test.gokrb5"},
+	}
+
+	b, err := hex.DecodeString(testdata.HTTP_KEYTAB)
+	require.NoError(t, err)
+
+	kt := keytab.New()
+	require.NoError(t, kt.Unmarshal(b))
+
+	sent := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:sent")}
+	want := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:want")}
+
+	// newTokenWithTicketTimes seals an AP_REQ carrying the Bnd of the binding provided (or the sixteen zero bytes
+	// meaning "no channel bindings" when it is nil) into a KRB5Token whose acceptor settings require want. The
+	// ticket's StartTime and EndTime are caller controlled so that tests can produce a ticket APReq.Verify rejects
+	// for reasons other than channel binding, such as expiry.
+	newTokenWithTicketTimes := func(t *testing.T, cb *gssapi.ChannelBinding, start, end time.Time) *KRB5Token {
+		t.Helper()
+
+		cl := getClient(t)
+		st := time.Now().UTC()
+
+		tkt, sessionKey, err := messages.NewTicket(cl.Credentials.CName(), cl.Credentials.Domain(),
+			sname, "TEST.GOKRB5", types.NewKrbFlags(), kt, 18, 1,
+			st, start, end, st.Add(48*time.Hour),
+		)
+		require.NoError(t, err)
+
+		auth, err := types.NewAuthenticator(cl.Credentials.Domain(), cl.Credentials.CName())
+		require.NoError(t, err)
+		require.NoError(t, auth.GenerateSeqNumberAndSubKey(18, 32))
+
+		chksum, err := newAuthenticatorChksum(nil, cb)
+		require.NoError(t, err)
+
+		auth.Cksum = types.Checksum{CksumType: chksumtype.GSSAPI, Checksum: chksum}
+
+		apreq, err := messages.NewAPReq(tkt, sessionKey, auth)
+		require.NoError(t, err)
+
+		tb, err := hex.DecodeString(TOK_ID_KRB_AP_REQ)
+		require.NoError(t, err)
+
+		return &KRB5Token{
+			tokID:    tb,
+			APReq:    apreq,
+			settings: service.NewSettings(kt, service.RequireChannelBinding(want)),
+		}
+	}
+
+	// newToken is newTokenWithTicketTimes with a ticket that is valid now, for the subtests below that exercise
+	// channel binding rather than ticket validity.
+	newToken := func(t *testing.T, cb *gssapi.ChannelBinding) *KRB5Token {
+		t.Helper()
+
+		st := time.Now().UTC()
+
+		return newTokenWithTicketTimes(t, cb, st, st.Add(24*time.Hour))
+	}
+
+	t.Run("MismatchedBinding", func(t *testing.T) {
+		t.Parallel()
+
+		ok, status := newToken(t, sent).Verify()
+		assert.False(t, ok)
+		assert.Equal(t, gssapi.StatusBadBindings, status.Code)
+		assert.Contains(t, status.Message, "channel binding mismatch")
+	})
+
+	// An initiator that sent no bindings at all is still a bad-bindings failure rather than a defective token: the
+	// token is well formed, it simply does not match the bindings the acceptor supplied.
+	t.Run("NoBindingSent", func(t *testing.T) {
+		t.Parallel()
+
+		ok, status := newToken(t, nil).Verify()
+		assert.False(t, ok)
+		assert.Equal(t, gssapi.StatusBadBindings, status.Code)
+	})
+
+	t.Run("MatchingBinding", func(t *testing.T) {
+		t.Parallel()
+
+		ok, status := newToken(t, want).Verify()
+		assert.True(t, ok)
+		assert.Equal(t, gssapi.StatusComplete, status.Code)
+	})
+
+	// A VerifyAPREQ failure that is not a channel binding failure must still surface as GSS_S_DEFECTIVE_TOKEN even
+	// when the binding sent matches the binding required. An expired ticket exercises this: APReq.Verify rejects it
+	// in messages.Ticket.Valid before verifyChannelBinding is ever reached, so the only way this subtest could see
+	// StatusBadBindings is if the errors.Is(err, service.ErrBadChannelBinding) discrimination in KRB5Token.Verify were
+	// broadened to match unconditionally.
+	t.Run("ExpiredTicketWithMatchingBindingIsNotABadBindingsFailure", func(t *testing.T) {
+		t.Parallel()
+
+		past := time.Now().UTC().Add(-24 * time.Hour)
+
+		ok, status := newTokenWithTicketTimes(t, want, past, past.Add(time.Hour)).Verify()
+		assert.False(t, ok)
+		assert.Equal(t, gssapi.StatusDefectiveToken, status.Code)
+		assert.NotEqual(t, gssapi.StatusBadBindings, status.Code)
+	})
 }

--- a/spnego/krb5_token_test.go
+++ b/spnego/krb5_token_test.go
@@ -1,6 +1,7 @@
 package spnego
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"math"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"github.com/go-krb5/krb5/client"
 	"github.com/go-krb5/krb5/credentials"
 	"github.com/go-krb5/krb5/gssapi"
+	"github.com/go-krb5/krb5/iana/chksumtype"
 	"github.com/go-krb5/krb5/iana/msgtype"
 	"github.com/go-krb5/krb5/iana/nametype"
 	"github.com/go-krb5/krb5/messages"
@@ -48,7 +50,7 @@ func TestKRB5Token_newAuthenticatorChksum(t *testing.T) {
 	b, err := hex.DecodeString(AuthChksum)
 	require.NoError(t, err)
 
-	cb := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf})
+	cb := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, nil)
 	assert.Equal(t, b, cb)
 }
 
@@ -63,7 +65,7 @@ func TestKRB5Token_newAuthenticatorWithSubkeyGeneration(t *testing.T) {
 
 	keyLen := 32
 
-	a, err := krb5TokenAuthenticator(creds, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf})
+	a, err := krb5TokenAuthenticator(creds, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, a.GenerateSeqNumberAndSubKey(etypeID, keyLen))
@@ -97,7 +99,7 @@ func TestKRB5Token_newAuthenticator(t *testing.T) {
 	creds := credentials.New("hftsai", testdata.TEST_REALM)
 	creds.SetCName(types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: testdata.TEST_PRINCIPALNAME_NAMESTRING})
 
-	a, err := krb5TokenAuthenticator(creds, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf})
+	a, err := krb5TokenAuthenticator(creds, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(32771), a.Cksum.CksumType)
@@ -149,4 +151,106 @@ func TestNewAPREQKRB5Token_and_Marshal(t *testing.T) {
 	assert.Equal(t, testdata.TEST_REALM, mt.APReq.Ticket.Realm)
 	assert.Equal(t, testdata.TEST_PRINCIPALNAME_NAMESTRING, mt.APReq.Ticket.SName.NameString)
 	assert.Equal(t, int32(18), mt.APReq.EncryptedAuthenticator.EType)
+}
+
+// TestNewNegTokenInitKRB5ShouldForwardChannelBindingToTheSealedAPREQ asserts that a ChannelBinding option supplied
+// to NewNegTokenInitKRB5 actually reaches the AP_REQ it seals, exercising both the negotiation_token.go ->
+// NewKRB5TokenAPREQ forwarding hop and the krb5TokenAuthenticator -> newAuthenticatorChksum hop beneath it.
+//
+// A bare inequality between the two calls' MechTokenBytes would not prove this: types.NewAuthenticator embeds a
+// fresh random SeqNumber and a CTime with microsecond resolution on every call, so the two AP_REQs (and therefore
+// their encrypted, and marshalled, bytes) are all but certain to differ regardless of whether the channel binding
+// is forwarded at all. Instead this decrypts each authenticator with the same session key used to seal it and reads
+// the Bnd field out of its GSS-API checksum directly, which isolates exactly the value the binding option controls.
+func TestNewNegTokenInitKRB5ShouldForwardChannelBindingToTheSealedAPREQ(t *testing.T) {
+	t.Parallel()
+
+	creds := credentials.New("hftsai", testdata.TEST_REALM)
+	creds.SetCName(types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: testdata.TEST_PRINCIPALNAME_NAMESTRING})
+	cl := &client.Client{Credentials: creds}
+
+	var tkt messages.Ticket
+
+	b, err := hex.DecodeString(testdata.MarshaledKRB5ticket)
+	require.NoError(t, err)
+	require.NoError(t, tkt.Unmarshal(b))
+
+	key := types.EncryptionKey{
+		KeyType:  18,
+		KeyValue: make([]byte, 32),
+	}
+
+	cb := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:test")}
+
+	// sealedBnd unmarshals the NegTokenInit's MechTokenBytes, decrypts the authenticator sealed inside it with the
+	// same session key used to seal it, and returns the Bnd bytes carried in its GSS-API checksum.
+	sealedBnd := func(t *testing.T, nti NegTokenInit) []byte {
+		t.Helper()
+
+		var mt KRB5Token
+
+		require.NoError(t, mt.Unmarshal(nti.MechTokenBytes))
+		require.NoError(t, mt.APReq.DecryptAuthenticator(key))
+		require.Equal(t, chksumtype.GSSAPI, mt.APReq.Authenticator.Cksum.CksumType)
+		require.Len(t, mt.APReq.Authenticator.Cksum.Checksum, 24)
+
+		return mt.APReq.Authenticator.Cksum.Checksum[4:20]
+	}
+
+	bound, err := NewNegTokenInitKRB5(cl, tkt, key, ChannelBinding(cb))
+	require.NoError(t, err)
+
+	unbound, err := NewNegTokenInitKRB5(cl, tkt, key)
+	require.NoError(t, err)
+
+	boundBnd := sealedBnd(t, bound)
+	unboundBnd := sealedBnd(t, unbound)
+
+	bnd := cb.Bnd()
+	assert.Equal(t, bnd[:], boundBnd, "the AP_REQ sealed with ChannelBinding must carry the binding's Bnd hash")
+	assert.Equal(t, make([]byte, 16), unboundBnd, "the AP_REQ sealed without ChannelBinding must carry the all-zero Bnd meaning no channel bindings")
+	assert.NotEqual(t, boundBnd, unboundBnd)
+}
+
+func TestNewAuthenticatorChksumShouldEmbedTheChannelBinding(t *testing.T) {
+	t.Parallel()
+
+	cb := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:test")}
+
+	c := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, cb)
+
+	require.Len(t, c, 24)
+	assert.Equal(t, uint32(16), binary.LittleEndian.Uint32(c[:4]))
+
+	bnd := cb.Bnd()
+	assert.Equal(t, bnd[:], c[4:20])
+
+	assert.Equal(t, uint32(gssapi.ContextFlagInteg|gssapi.ContextFlagConf), binary.LittleEndian.Uint32(c[20:24]))
+}
+
+// TestNewAuthenticatorChksumShouldZeroBndWithoutAChannelBinding is the regression guard for the default path: with
+// no binding the checksum must be byte for byte what it was before this feature existed.
+func TestNewAuthenticatorChksumShouldZeroBndWithoutAChannelBinding(t *testing.T) {
+	t.Parallel()
+
+	c := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, nil)
+
+	require.Len(t, c, 24)
+	assert.Equal(t, uint32(16), binary.LittleEndian.Uint32(c[:4]))
+	assert.Equal(t, make([]byte, 16), c[4:20])
+	assert.Equal(t, uint32(gssapi.ContextFlagInteg|gssapi.ContextFlagConf), binary.LittleEndian.Uint32(c[20:24]))
+}
+
+func TestNewKRB5TokenOptionsShouldDefaultToNoChannelBinding(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, newKRB5TokenOptions().channelBinding)
+}
+
+func TestChannelBindingOptionShouldSetTheBinding(t *testing.T) {
+	t.Parallel()
+
+	cb := &gssapi.ChannelBinding{ApplicationData: []byte("tls-exporter:test")}
+
+	assert.Same(t, cb, newKRB5TokenOptions(ChannelBinding(cb)).channelBinding)
 }

--- a/spnego/negotiation_token.go
+++ b/spnego/negotiation_token.go
@@ -333,8 +333,8 @@ func UnmarshalNegToken(b []byte) (bool, any, error) {
 }
 
 // NewNegTokenInitKRB5 creates new Init negotiation token for Kerberos 5.
-func NewNegTokenInitKRB5(cl *client.Client, tkt messages.Ticket, sessionKey types.EncryptionKey) (NegTokenInit, error) {
-	mt, err := NewKRB5TokenAPREQ(cl, tkt, sessionKey, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, []int{})
+func NewNegTokenInitKRB5(cl *client.Client, tkt messages.Ticket, sessionKey types.EncryptionKey, opts ...KRB5TokenOption) (NegTokenInit, error) {
+	mt, err := NewKRB5TokenAPREQ(cl, tkt, sessionKey, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, []int{}, opts...)
 	if err != nil {
 		return NegTokenInit{}, fmt.Errorf("error getting KRB5 token; %w", err)
 	}

--- a/spnego/spnego.go
+++ b/spnego/spnego.go
@@ -20,13 +20,20 @@ type SPNEGO struct {
 	serviceSettings *service.Settings
 	client          *client.Client
 	spn             string
+	tokenOptions    []KRB5TokenOption
 }
 
 // SPNEGOClient configures the SPNEGO mechanism suitable for client side use.
-func SPNEGOClient(cl *client.Client, spn string) *SPNEGO {
+//
+// Pass ChannelBinding to bind the context to the transport channel underneath it:
+//
+//	cb, err := gssapi.NewChannelBindingTLSServerEndPointFromState(&state)
+//	s := SPNEGOClient(cl, spn, ChannelBinding(cb)).
+func SPNEGOClient(cl *client.Client, spn string, opts ...KRB5TokenOption) *SPNEGO {
 	s := new(SPNEGO)
 	s.client = cl
 	s.spn = spn
+	s.tokenOptions = opts
 	s.serviceSettings = service.NewSettings(nil, service.SName(spn))
 
 	return s
@@ -57,7 +64,7 @@ func (s *SPNEGO) InitSecContext() (gssapi.ContextToken, error) {
 		return &SPNEGOToken{}, err
 	}
 
-	negTokenInit, err := NewNegTokenInitKRB5(s.client, tkt, key)
+	negTokenInit, err := NewNegTokenInitKRB5(s.client, tkt, key, s.tokenOptions...)
 	if err != nil {
 		return &SPNEGOToken{}, fmt.Errorf("could not create NegTokenInit: %w", err)
 	}

--- a/spnego/spnego_test.go
+++ b/spnego/spnego_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-krb5/x/encoding/asn1"
+
+	"github.com/go-krb5/krb5/gssapi"
 )
 
 const (
@@ -93,4 +95,24 @@ func TestMarshal_SPNEGO_RespTarg(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, b, mb)
+}
+
+func TestSPNEGOClientShouldRetainTokenOptions(t *testing.T) {
+	t.Parallel()
+
+	cb := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:test")}
+
+	s := SPNEGOClient(nil, "HTTP/host.example.org", ChannelBinding(cb))
+
+	require.Len(t, s.tokenOptions, 1)
+	assert.Same(t, cb, newKRB5TokenOptions(s.tokenOptions...).channelBinding)
+}
+
+func TestSPNEGOClientShouldDefaultToNoTokenOptions(t *testing.T) {
+	t.Parallel()
+
+	s := SPNEGOClient(nil, "HTTP/host.example.org")
+
+	assert.Empty(t, s.tokenOptions)
+	assert.Nil(t, newKRB5TokenOptions(s.tokenOptions...).channelBinding)
 }


### PR DESCRIPTION
Bind Kerberos authentication to the underlying TLS channel per RFC5929 and RFC9266.

The gssapi.ChannelBinding implements the RFC1964 structure and its Bnd digest, with tls-server-end-point, tls-exporter and tls-unique constructors. Initiators attach it to the AP-REQ authenticator checksum via spnego.ChannelBinding, the SPNEGO HTTP client can derive tls-server-end-point from the challenging response, and acceptors opt in with service.RequireChannelBinding. Behaviour is unchanged when unset.