### PR TITLE
feat!: credential delegation

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -79,4 +79,22 @@ change will be elaborated on in time):
   token with `GSS_S_FAILURE` once it reads `DlgOpt` as `0`, so no working deployment loses functionality — the change
   converts an opaque remote failure into a local one that names the cause. Credential delegation is not implemented;
   nothing in this library requests the flag, so only a caller passing `flagsGSSAPI` to `NewKRB5TokenAPREQ` directly is
-  affected.
+  affected. **This entry has been superseded by the one below**: credential delegation is now implemented, and
+  `spnego.ErrDelegationUnimplemented` no longer exists.
+- `spnego.ErrDelegationUnimplemented` has been removed. Credential delegation is now implemented, so nothing can
+  return it; code matching on it will no longer compile. Requesting `gssapi.ContextFlagDeleg`, or passing the new
+  `spnego.Delegation()` option, now obtains a forwarded ticket-granting ticket and carries it in the AP-REQ as
+  RFC 4121 Section 4.1.1 requires. Note that this adds a TGS exchange with the KDC during context establishment,
+  and that it requires `forwardable = true` in the `libdefaults` section of `krb5.conf`: the KDC will not forward a
+  ticket it did not mark forwardable, and this library defaults the setting to `false`.
+- Acceptors now read the delegation fields of the AP-REQ authenticator checksum, and reject an AP-REQ that claims a
+  delegation they cannot fully process with `KRB_AP_ERR_INAPP_CKSUM`, where they previously authenticated it and
+  silently ignored the delegation. `service.VerifyAPREQ` extracts unconditionally — there is no `Settings` opt in —
+  and every defect past the `GSS_C_DELEG_FLAG` bit is fatal: a 28 octet checksum with `DlgOpt` zeroed, which is
+  precisely what this library itself emitted before the entry above, a `Dlgth` running past the end of the checksum,
+  a `KRB_CRED` that will not unmarshal, and a `KRB_CRED` encrypted with an encryption type this library does not
+  have registered. Nothing runs unless the peer set the delegation flag, so a client that does not request
+  delegation is unaffected. This is deliberate: an acceptor has no `ret_flags` channel on which to tell an initiator
+  that its forwarded ticket was discarded, so accepting the request while dropping the credential would leave the
+  initiator believing a delegation happened that did not. Services that must keep authenticating such clients need
+  those clients fixed or the encryption type registered with `crypto.AddEType`.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,50 @@ The following section contains some implementation specific information.
 [RFC8429]: https://datatracker.ietf.org/doc/html/rfc8429
 [RFC6803]: https://datatracker.ietf.org/doc/html/rfc6803
 
+### Credential Delegation
+
+RFC 4121 Section 4.1.1 lets a client forward a ticket-granting ticket to the service it authenticates to, so the
+service can act as the client against a third party. This library implements both halves.
+
+As an initiator, request it with `gssapi.ContextFlagDeleg` or, for the SPNEGO client, the `spnego.Delegation()`
+option:
+
+```go
+s := spnego.SPNEGOClient(cl, spn, spnego.Delegation())
+```
+
+This requires a forwardable TGT: set `forwardable = true` in the `libdefaults` section of `krb5.conf` before
+authenticating, or the KDC will refuse to issue the forwarded ticket. This library defaults the setting to `false`.
+Delegating grants the service complete use of the client's identity, as RFC 4120 Section 2.6 describes, so request it
+only against services trusted with that. If the TGT is not forwardable the failure is local and matchable:
+`errors.Is(err, client.ErrNotForwardable)`.
+
+Note that a forwarded ticket is obtained fresh for every token created, because the credential is bound to the
+service it is delegated to and is deliberately not cached. Each token creation therefore costs one extra TGS exchange
+with the KDC, and for the SPNEGO HTTP client that is one extra KDC round trip per request.
+
+As an acceptor, a delegated credential arriving on an AP_REQ is attached to the `*credentials.Credentials` that
+`service.VerifyAPREQ` returns. Retrieve it with `credentials.DelegatedCredentials()` and load it into a client with
+`client.NewFromCCache`, where `conf` is the `*config.Config` the service was built with:
+
+```go
+if cc, ok := creds.DelegatedCredentials(); ok {
+    delegated, err := client.NewFromCCache(cc, conf)
+    if err != nil {
+        return err
+    }
+
+    // Act as the client with delegated.
+}
+```
+
+The principal named inside that credential cache is asserted by the peer, not vouched for by the KDC: it comes from
+the `pname` and `prealm` of the delegated `KRB_CRED`, whereas the identity in `creds` comes from the KDC-sealed
+encrypted part of the ticket. Nothing compares the two, matching MIT's `rd_cred.c`. A forged ticket is useless
+without the matching session key, so this is not a way to impersonate anyone, but a service that authorises on
+`creds.UserName()` and then acts through the delegated cache may be acting as a different principal than the one it
+authorised. Compare them yourself if that matters to your authorisation model.
+
 ### Tested Scenarios
 
 The following is working/tested:

--- a/client/cache.go
+++ b/client/cache.go
@@ -26,6 +26,15 @@ type CacheEntry struct {
 	EndTime    time.Time
 	RenewTill  time.Time
 	SessionKey types.EncryptionKey `json:"-"`
+
+	// SupportedETypes are the encryption types the application server advertised in the PA-SUPPORTED-ENCTYPES
+	// pre-authentication data of the TGS-REP that issued this ticket, or zero if it advertised none. MS-KILE
+	// Section 3.3.5.7.4 has a client requesting a forwardable TGT for that server build its own
+	// PA-SUPPORTED-ENCTYPES from what the KDC and that server both support; this is the server half.
+	//
+	// Excluded from the JSON rendering, like Ticket and SessionKey, so that Client.Diagnostics keeps the output
+	// it had before delegation existed.
+	SupportedETypes types.SupportedETypes `json:"-"`
 }
 
 // NewCache creates a new client ticket cache instance.
@@ -72,7 +81,7 @@ func (c *Cache) JSON() (string, error) {
 }
 
 // addEntry adds a ticket to the cache.
-func (c *Cache) addEntry(tkt messages.Ticket, authTime, startTime, endTime, renewTill time.Time, sessionKey types.EncryptionKey) CacheEntry {
+func (c *Cache) addEntry(tkt messages.Ticket, authTime, startTime, endTime, renewTill time.Time, sessionKey types.EncryptionKey, supported types.SupportedETypes) CacheEntry {
 	spn := tkt.SName.PrincipalNameString()
 
 	c.mux.Lock()
@@ -86,6 +95,8 @@ func (c *Cache) addEntry(tkt messages.Ticket, authTime, startTime, endTime, rene
 		EndTime:    endTime,
 		RenewTill:  renewTill,
 		SessionKey: sessionKey,
+
+		SupportedETypes: supported,
 	}
 
 	return c.Entries[spn]

--- a/client/cache_test.go
+++ b/client/cache_test.go
@@ -7,7 +7,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/go-krb5/krb5/iana/etypeID"
+	"github.com/go-krb5/krb5/iana/nametype"
 	"github.com/go-krb5/krb5/messages"
 	"github.com/go-krb5/krb5/types"
 )
@@ -34,7 +37,7 @@ func TestCache_addEntry_getEntry_remove_clear(t *testing.T) {
 			KeyValue: []byte{byte(i)},
 		}
 		go func(i int) {
-			e := c.addEntry(tkt, time.Unix(int64(0+i), 0).UTC(), time.Unix(int64(10+i), 0).UTC(), time.Unix(int64(20+i), 0).UTC(), time.Unix(int64(30+i), 0).UTC(), key)
+			e := c.addEntry(tkt, time.Unix(int64(0+i), 0).UTC(), time.Unix(int64(10+i), 0).UTC(), time.Unix(int64(20+i), 0).UTC(), time.Unix(int64(30+i), 0).UTC(), key, 0)
 			assert.Equal(t, fmt.Sprintf("%d/test.cache", i), e.SPN)
 			wg.Done()
 		}(i)
@@ -130,7 +133,7 @@ func TestCache_JSON(t *testing.T) {
 			KeyType:  1,
 			KeyValue: []byte{byte(i)},
 		}
-		e := c.addEntry(tkt, time.Unix(int64(0+i), 0).UTC(), time.Unix(int64(10+i), 0).UTC(), time.Unix(int64(20+i), 0).UTC(), time.Unix(int64(30+i), 0).UTC(), key)
+		e := c.addEntry(tkt, time.Unix(int64(0+i), 0).UTC(), time.Unix(int64(10+i), 0).UTC(), time.Unix(int64(20+i), 0).UTC(), time.Unix(int64(30+i), 0).UTC(), key, 0)
 		assert.Equal(t, fmt.Sprintf("%d/test.cache", i), e.SPN)
 	}
 
@@ -162,4 +165,25 @@ func TestCache_JSON(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, expected, j)
+}
+
+// TestCacheShouldRetainTheServerSupportedEncryptionTypes asserts the application server's PA-SUPPORTED-ENCTYPES
+// advertisement is kept against its SPN. Delegation happens long after the TGS exchange that learned it, and
+// ForwardedTGT has only the SPN to look it up by.
+func TestCacheShouldRetainTheServerSupportedEncryptionTypes(t *testing.T) {
+	t.Parallel()
+
+	want := types.NewSupportedETypesFromIDs([]int32{etypeID.AES256_CTS_HMAC_SHA1_96})
+
+	c := NewCache()
+	tkt := messages.Ticket{
+		SName: types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{"HTTP", "host.test.gokrb5"}},
+	}
+
+	c.addEntry(tkt, time.Unix(0, 0).UTC(), time.Unix(10, 0).UTC(), time.Unix(20, 0).UTC(), time.Unix(30, 0).UTC(),
+		types.EncryptionKey{}, want)
+
+	e, ok := c.getEntry("HTTP/host.test.gokrb5")
+	require.True(t, ok)
+	assert.Equal(t, want, e.SupportedETypes)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -91,6 +91,10 @@ func NewFromCCache(c *credentials.CCache, krb5conf *config.Config, settings ...f
 		return cl, fmt.Errorf("TGT bytes in cache are not valid: %w", err)
 	}
 
+	// The ticket flags and addresses are carried into the session alongside the times and the key. They are what
+	// ForwardedTGT consults to decide whether the TGT can be forwarded at all, and whether the forwarding request
+	// carries addresses, so a session built from a ccache has to answer those questions as well as one built by an
+	// AS exchange in addSession.
 	cl.sessions.Entries[c.DefaultPrincipal.Realm] = &session{
 		realm:      c.DefaultPrincipal.Realm,
 		authTime:   cred.AuthTime,
@@ -98,6 +102,8 @@ func NewFromCCache(c *credentials.CCache, krb5conf *config.Config, settings ...f
 		renewTill:  cred.RenewTill,
 		tgt:        tgt,
 		sessionKey: cred.Key,
+		flags:      cred.TicketFlags,
+		addresses:  types.HostAddresses(cred.Addresses),
 	}
 	for _, cred := range c.GetEntries() {
 		var tkt messages.Ticket
@@ -114,6 +120,9 @@ func NewFromCCache(c *credentials.CCache, krb5conf *config.Config, settings ...f
 			cred.EndTime,
 			cred.RenewTill,
 			cred.Key,
+			// A ccache records no PA-SUPPORTED-ENCTYPES, so the application server's advertised encryption
+			// types are unknown for tickets loaded from one.
+			0,
 		)
 	}
 

--- a/client/forwarding.go
+++ b/client/forwarding.go
@@ -1,0 +1,154 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/go-krb5/krb5/krberror"
+	"github.com/go-krb5/krb5/messages"
+	"github.com/go-krb5/krb5/types"
+)
+
+// ErrNotForwardable is returned when the client's TGT cannot be forwarded because the KDC did not mark it
+// FORWARDABLE. RFC 4120 Section 3.3 honours the FORWARDED option "only if the FORWARDABLE flag is set in the TGT".
+// Callers match against it with errors.Is.
+var ErrNotForwardable = errors.New("the client's ticket granting ticket is not forwardable")
+
+// errNotForwardable wraps ErrNotForwardable with the operator-actionable causes, so callers matching with
+// errors.Is still see them in err.Error().
+//
+// Both causes are named because the local one is not the likelier one in a domain. Against Active Directory the
+// KDC withholds FORWARDABLE regardless of what the client asks for when the account carries the
+// ADS_UF_NOT_DELEGATED bit of MS-ADTS Section 2.2.16, or is in Protected Users; naming only the krb5.conf setting
+// would send an operator to change something that is already correct.
+func errNotForwardable() error {
+	return fmt.Errorf("%w: the KDC will not honour a FORWARDED request against it. Either forwardable = true is not set in the libdefaults section of krb5.conf, or the account is barred from delegation: in Active Directory by the ADS_UF_NOT_DELEGATED bit (\"Account is sensitive and cannot be delegated\") or by membership of Protected Users, both of which withhold the FORWARDABLE flag however it is requested", ErrNotForwardable)
+}
+
+// ForwardedTGT obtains a ticket-granting ticket for this client marked FORWARDED, for delegating the client's
+// identity to the service named by spn as described by RFC 4121 Section 4.1.1.
+//
+// The ticket returned is deliberately not added to the client's ticket cache. It is a credential intended for
+// another host, and handing it back from GetCachedTicket, or letting it stand in for the client's own session TGT,
+// would be a correctness bug. Callers use it once and discard it.
+//
+// Addresses are supplied only when the client's own TGT has them, matching MIT's krb5_fwd_tgt_creds. With this
+// library's NoAddresses default the forwarded ticket is addressless, which RFC 4120 Section 2.6 blesses.
+//
+// svcKey is the session key of the service ticket the delegation accompanies. MS-KILE Section 3.3.5.7.4 has the
+// client "set the etype field of the TGS-REQ to the contents of the keytype field in the previous TGS-REP", so
+// that the KDC issues the forwarded ticket with a session key the application server can use; svcKey's type is
+// that keytype. If the KDC refuses that encryption type the request is retried once with the configured defaults,
+// mirroring MIT's krb5_fwd_tgt_creds, which does the same rather than failing the delegation outright.
+func (cl *Client) ForwardedTGT(spn types.PrincipalName, svcKey types.EncryptionKey) (tkt messages.Ticket, dep messages.EncKDCRepPart, err error) {
+	realm := cl.Credentials.Realm()
+
+	// sessionTGT is called before the forwardable check, not after: it is the only path (via ensureValidSession's
+	// refreshSession -> realmLogin) by which a stale session picks up a FORWARDABLE flag from a fresh AS-REQ, e.g.
+	// after an operator flips LibDefaults.Forwardable at runtime. Checking forwardable first would short-circuit
+	// exactly the re-login that could satisfy the request. When the existing session is still valid,
+	// ensureValidSession's fast path returns without any network I/O, so this costs nothing in the common case.
+	tgt, sessionKey, err := cl.sessionTGT(realm)
+	if err != nil {
+		return tkt, dep, err
+	}
+
+	s, ok := cl.sessions.get(realm)
+	if !ok {
+		return tkt, dep, fmt.Errorf("could not find TGT session for %s", realm)
+	}
+
+	if !s.forwardable() {
+		return tkt, dep, errNotForwardable()
+	}
+
+	var addrs types.HostAddresses
+
+	if s.addressed() {
+		if addrs, err = spnHostAddresses(spn); err != nil {
+			return tkt, dep, err
+		}
+	}
+
+	supported := s.supported()
+	if e, ok := cl.cache.getEntry(spn.PrincipalNameString()); ok {
+		supported = supported.Intersect(e.SupportedETypes)
+	}
+
+	tkt, dep, err = cl.forwardedTGSExchange(realm, tgt, sessionKey, addrs, []int32{svcKey.KeyType}, supported)
+	if err == nil || !kdcRefused(err) {
+		return tkt, dep, err
+	}
+
+	// MIT's krb5_fwd_tgt_creds retries with an unrestricted encryption type when the KDC rejects the pinned one,
+	// rather than failing the delegation. The pinned type is a MS-KILE SHOULD chosen to suit the application
+	// server; a KDC that cannot honour it has not said the delegation itself is impossible.
+	cl.Log("KDC refused a forwarded TGT with encryption type %d, retrying with the configured defaults", svcKey.KeyType)
+
+	return cl.forwardedTGSExchange(realm, tgt, sessionKey, addrs, nil, supported)
+}
+
+// kdcRefused reports whether the error carries a KRB_ERROR, meaning the KDC answered and declined, as opposed to a
+// local or network failure that a retry would only repeat.
+func kdcRefused(err error) bool {
+	var krberr messages.KRBError
+
+	return errors.As(err, &krberr)
+}
+
+// forwardedTGSExchange performs one forwarding request. It is separate from ForwardedTGT so that the encryption
+// type fallback can run it twice without duplicating the exchange, and it deliberately does not touch cl.cache.
+func (cl *Client) forwardedTGSExchange(realm string, tgt messages.Ticket, sessionKey types.EncryptionKey, addrs types.HostAddresses, etypes []int32, supported types.SupportedETypes) (tkt messages.Ticket, dep messages.EncKDCRepPart, err error) {
+	req, err := messages.NewForwardedTGSReq(cl.Credentials.CName(), realm, realm, cl.Config, tgt, sessionKey, addrs, etypes, supported)
+	if err != nil {
+		return tkt, dep, krberror.Errorf(err, krberror.KRBMsgError, "failed to generate a forwarded TGS_REQ")
+	}
+
+	b, err := req.Marshal()
+	if err != nil {
+		return tkt, dep, krberror.Errorf(err, krberror.EncodingError, "failed to marshal the forwarded TGS_REQ")
+	}
+
+	r, err := cl.sendToKDC(b, realm)
+	if err != nil {
+		// Wrapped with %w rather than krberror.Errorf, which does not implement Unwrap: the caller needs
+		// errors.As to recover a KRB_ERROR so it can tell a KDC refusal from a network failure.
+		return tkt, dep, fmt.Errorf("error requesting a forwarded TGT: %w", err)
+	}
+
+	var rep messages.TGSRep
+
+	if err = rep.Unmarshal(r); err != nil {
+		return tkt, dep, krberror.Errorf(err, krberror.EncodingError, "failed to process the forwarded TGS_REP")
+	}
+
+	if err = rep.DecryptEncPart(sessionKey); err != nil {
+		return tkt, dep, krberror.Errorf(err, krberror.DecryptingError, "failed to decrypt the forwarded TGS_REP")
+	}
+
+	if ok, err := rep.Verify(cl.Config, req); !ok {
+		return tkt, dep, krberror.Errorf(err, krberror.KRBMsgError, "the forwarded TGS_REP is not valid")
+	}
+
+	return rep.Ticket, rep.DecryptedEncPart, nil
+}
+
+// spnHostAddresses resolves the addresses of the host a service principal names, for the addresses field of a
+// forwarding request. RFC 4120 Section 3.3 describes these as "the address(es) of the host from which the resulting
+// ticket is to be valid".
+//
+// MIT derives the same host from the service principal's second component, and fails with KRB5_FWD_BAD_PRINCIPAL
+// when the principal is not host based, which is what the length check mirrors.
+func spnHostAddresses(spn types.PrincipalName) (types.HostAddresses, error) {
+	if len(spn.NameString) < 2 {
+		return nil, fmt.Errorf("cannot determine the host to forward a ticket to from service principal %s: it is not host based", spn.PrincipalNameString())
+	}
+
+	ips, err := net.LookupIP(spn.NameString[1])
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve %s to forward a ticket to it: %w", spn.NameString[1], err)
+	}
+
+	return types.HostAddressesFromNetIPs(ips), nil
+}

--- a/client/forwarding_test.go
+++ b/client/forwarding_test.go
@@ -1,0 +1,214 @@
+package client
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/krb5/config"
+	"github.com/go-krb5/krb5/credentials"
+	"github.com/go-krb5/krb5/iana/etypeID"
+	"github.com/go-krb5/krb5/iana/flags"
+	"github.com/go-krb5/krb5/iana/nametype"
+	"github.com/go-krb5/krb5/keytab"
+	"github.com/go-krb5/krb5/messages"
+	"github.com/go-krb5/krb5/test"
+	"github.com/go-krb5/krb5/test/testdata"
+	"github.com/go-krb5/krb5/types"
+)
+
+// TestForwardedTGTShouldRefuseANonForwardableSession asserts the local pre-check. Without it the KDC answers
+// KDC_ERR_BADOPTION, which names nothing the operator can act on; forwardable defaults to false in this library, so
+// this is the failure an unmodified deployment hits first.
+//
+// The fixture session is given realistic, currently-valid times (authTime in the recent past, endTime comfortably
+// in the future) so that ensureValidSession's fast path applies and ForwardedTGT never dials the KDC: sessionTGT is
+// called before the forwardable check specifically so a stale session can re-login and pick up a newly-forwardable
+// TGT, and a fixture with zero times would exercise that re-login path instead of the check this test targets.
+func TestForwardedTGTShouldRefuseANonForwardableSession(t *testing.T) {
+	t.Parallel()
+
+	c, err := config.NewFromString(testdata.KRB5_CONF)
+	require.NoError(t, err)
+
+	cl := NewWithPassword("testuser1", "TEST.GOKRB5", "passwordvalue", c)
+
+	now := time.Now().UTC()
+	cl.sessions.update(&session{
+		realm:     "TEST.GOKRB5",
+		authTime:  now.Add(-1 * time.Hour),
+		endTime:   now.Add(9 * time.Hour),
+		renewTill: now.Add(7 * 24 * time.Hour),
+		tgt: messages.Ticket{
+			Realm: "TEST.GOKRB5",
+			SName: types.PrincipalName{NameType: nametype.KRB_NT_SRV_INST, NameString: []string{"krbtgt", "TEST.GOKRB5"}},
+		},
+		sessionKey: types.EncryptionKey{
+			KeyType:  etypeID.AES256_CTS_HMAC_SHA1_96,
+			KeyValue: []byte("0123456789abcdef0123456789abcdef"),
+		},
+		flags: types.NewKrbFlags(),
+	})
+
+	svcKey := types.EncryptionKey{KeyType: etypeID.AES256_CTS_HMAC_SHA1_96, KeyValue: bytes.Repeat([]byte{0x0B}, 32)}
+	spn := types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{"HTTP", "host.test.gokrb5"}}
+
+	start := time.Now()
+	_, _, err = cl.ForwardedTGT(spn, svcKey)
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, ErrNotForwardable)
+	assert.Contains(t, err.Error(), "forwardable = true",
+		"the error must name the setting that fixes it")
+	// Against Active Directory the local setting is often already correct and the KDC is withholding FORWARDABLE
+	// on account policy, so naming only krb5.conf would send an operator to change something that is not wrong.
+	assert.Contains(t, err.Error(), "ADS_UF_NOT_DELEGATED",
+		"the error must also name the Active Directory account flag that withholds the flag")
+	assert.Contains(t, err.Error(), "Protected Users")
+	assert.Less(t, elapsed, 1*time.Second,
+		"a valid, non-forwardable session must be rejected locally, without a KDC round trip")
+}
+
+// ccacheWithCurrentTGT parses the captured credential cache test vector and shifts every credential forward by one
+// offset so that the TGT it carries is currently valid.
+//
+// The vector was captured in 2017, and an expired session sends ensureValidSession down refreshSession rather than
+// its fast path, which is not the state delegation is used in. Only the times are moved: the ticket flags stay
+// exactly as the KDC issued them (0x40c10000, FORWARDABLE set), which is the value under test.
+func ccacheWithCurrentTGT(t *testing.T) *credentials.CCache {
+	t.Helper()
+
+	b, err := hex.DecodeString(testdata.CCACHE_TEST)
+	require.NoError(t, err)
+
+	cc := new(credentials.CCache)
+	require.NoError(t, cc.Unmarshal(b))
+
+	spn := types.PrincipalName{NameType: nametype.KRB_NT_SRV_INST, NameString: []string{"krbtgt", "TEST.GOKRB5"}}
+
+	tgt, ok := cc.GetEntry(spn)
+	require.True(t, ok, "the ccache test vector must contain a TGT")
+	require.True(t, types.IsFlagSet(&tgt.TicketFlags, flags.Forwardable),
+		"the ccache test vector's TGT must be forwardable for this fixture to mean anything")
+
+	offset := time.Now().UTC().Add(-1 * time.Hour).Sub(tgt.AuthTime)
+
+	for _, cred := range cc.Credentials {
+		cred.AuthTime = cred.AuthTime.Add(offset)
+		cred.StartTime = cred.StartTime.Add(offset)
+		cred.EndTime = cred.EndTime.Add(offset)
+		cred.RenewTill = cred.RenewTill.Add(offset)
+	}
+
+	return cc
+}
+
+// configWithoutKDCs parses the test krb5.conf and removes the KDCs of the realm the fixtures authenticate against,
+// so that anything reaching the network fails locally rather than dialling.
+func configWithoutKDCs(t *testing.T) *config.Config {
+	t.Helper()
+
+	c, err := config.NewFromString(testdata.KRB5_CONF)
+	require.NoError(t, err)
+
+	var cleared bool
+
+	for i := range c.Realms {
+		if c.Realms[i].Realm == "TEST.GOKRB5" {
+			c.Realms[i].KDC = nil
+			cleared = true
+
+			break
+		}
+	}
+
+	require.True(t, cleared, "test fixture must clear the KDC list of the realm it authenticates against")
+
+	return c
+}
+
+// TestNewFromCCacheShouldCarryTheTicketFlagsIntoTheSession pins the session population that NewFromCCache performs
+// against the two other population sites, addSession and session.update. A client built from a ccache is the normal
+// way a delegating service acts as its user, and the session it builds has to answer the same questions as one built
+// by an AS exchange: the flags field left zeroed made session.forwardable panic in types.IsFlagSet, and merely
+// bounds-guarding that would have turned the panic into every ccache client being refused ErrNotForwardable while
+// holding a forwardable TGT.
+//
+// The client is built through NewFromCCache rather than by setting session fields directly, because a hand-built
+// session sets flags explicitly and so cannot observe a constructor that fails to.
+func TestNewFromCCacheShouldCarryTheTicketFlagsIntoTheSession(t *testing.T) {
+	t.Parallel()
+
+	cl, err := NewFromCCache(ccacheWithCurrentTGT(t), configWithoutKDCs(t))
+	require.NoError(t, err)
+
+	s, ok := cl.sessions.get("TEST.GOKRB5")
+	require.True(t, ok, "NewFromCCache must establish a session for the ccache's realm")
+
+	assert.True(t, s.forwardable(),
+		"a forwardable TGT loaded from a ccache must be recognised as forwardable")
+	assert.False(t, s.addressed(),
+		"the ccache test vector's TGT is addressless, so the session must be too")
+}
+
+// TestForwardedTGTShouldNotPanicForACCacheClient exercises the delegation entry point on a client built the way
+// spnego.Delegation() callers build one. With a still-valid ccache TGT, ensureValidSession's fast path returns
+// without touching the session, so session.forwardable is the first thing to read the flags; before the flags were
+// populated this panicked with "index out of range [0] with length 0" inside types.IsFlagSet.
+func TestForwardedTGTShouldNotPanicForACCacheClient(t *testing.T) {
+	t.Parallel()
+
+	cl, err := NewFromCCache(ccacheWithCurrentTGT(t), configWithoutKDCs(t))
+	require.NoError(t, err)
+
+	svcKey := types.EncryptionKey{KeyType: etypeID.AES256_CTS_HMAC_SHA1_96, KeyValue: bytes.Repeat([]byte{0x0B}, 32)}
+	spn := types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{"HTTP", "host.test.gokrb5"}}
+
+	require.NotPanics(t, func() {
+		_, _, err = cl.ForwardedTGT(spn, svcKey)
+	})
+
+	require.Error(t, err, "the fixture config has no KDCs, so the exchange itself cannot succeed")
+	assert.NotErrorIs(t, err, ErrNotForwardable,
+		"a forwardable ccache TGT must get past the forwardable check")
+	assert.ErrorContains(t, err, "error requesting a forwarded TGT",
+		"the request must fail at the KDC exchange, which is past every local check")
+}
+
+// TestForwardedTGTIntegration obtains a real forwarded TGT from the KDC. This is the only proof that the KDC
+// accepts the options NewForwardedTGSReq sends, and it does not run in CI.
+func TestForwardedTGTIntegration(t *testing.T) {
+	test.Integration(t)
+
+	b, err := hex.DecodeString(testdata.KEYTAB_TESTUSER1_TEST_GOKRB5)
+	require.NoError(t, err)
+
+	kt := keytab.New()
+	require.NoError(t, kt.Unmarshal(b))
+
+	c, err := config.NewFromString(testdata.KRB5_CONF)
+	require.NoError(t, err)
+
+	c.LibDefaults.Forwardable = true
+
+	cl := NewWithKeytab("testuser1", "TEST.GOKRB5", kt, c)
+	require.NoError(t, cl.Login())
+
+	svcKey := types.EncryptionKey{KeyType: etypeID.AES256_CTS_HMAC_SHA1_96, KeyValue: bytes.Repeat([]byte{0x0B}, 32)}
+	spn := types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{"HTTP", "host.test.gokrb5"}}
+
+	tkt, dep, err := cl.ForwardedTGT(spn, svcKey)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"krbtgt", "TEST.GOKRB5"}, tkt.SName.NameString)
+	assert.True(t, types.IsFlagSet(&dep.Flags, flags.Forwarded),
+		"the KDC must mark the issued ticket FORWARDED")
+	assert.NotEmpty(t, dep.Key.KeyValue)
+
+	_, _, cached := cl.GetCachedTicket("krbtgt/TEST.GOKRB5")
+	assert.False(t, cached, "a forwarded TGT must not enter the ticket cache")
+}

--- a/client/session.go
+++ b/client/session.go
@@ -8,6 +8,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-krb5/x/encoding/asn1"
+
+	"github.com/go-krb5/krb5/iana/flags"
 	"github.com/go-krb5/krb5/iana/nametype"
 	"github.com/go-krb5/krb5/krberror"
 	"github.com/go-krb5/krb5/messages"
@@ -75,6 +78,9 @@ type session struct {
 	tgt                  messages.Ticket
 	sessionKey           types.EncryptionKey
 	sessionKeyExpiration time.Time
+	flags                asn1.BitString
+	addresses            types.HostAddresses
+	supportedETypes      types.SupportedETypes
 	cancel               chan bool
 	mux                  sync.RWMutex
 }
@@ -105,6 +111,9 @@ func (cl *Client) addSession(tgt messages.Ticket, dep messages.EncKDCRepPart) {
 		tgt:                  tgt,
 		sessionKey:           dep.Key,
 		sessionKeyExpiration: dep.KeyExpiration,
+		flags:                dep.Flags,
+		supportedETypes:      types.SupportedETypesFromPAData(dep.EncPAData),
+		addresses:            types.HostAddresses(dep.CAddr),
 	}
 	cl.sessions.update(s)
 	cl.enableAutoSessionRenewal(s)
@@ -122,6 +131,9 @@ func (s *session) update(tgt messages.Ticket, dep messages.EncKDCRepPart) {
 	s.tgt = tgt
 	s.sessionKey = dep.Key
 	s.sessionKeyExpiration = dep.KeyExpiration
+	s.flags = dep.Flags
+	s.supportedETypes = types.SupportedETypesFromPAData(dep.EncPAData)
+	s.addresses = types.HostAddresses(dep.CAddr)
 }
 
 // destroy will cancel any auto renewal of the session and set the expiration times to the current time.
@@ -165,6 +177,37 @@ func (s *session) timeDetails() (string, time.Time, time.Time, time.Time, time.T
 	defer s.mux.RUnlock()
 
 	return s.realm, s.authTime, s.endTime, s.renewTill, s.sessionKeyExpiration
+}
+
+// forwardable reports whether the session's TGT has the FORWARDABLE flag set. RFC 4120 Section 3.3 makes the
+// FORWARDED KDC option honoured "only if the FORWARDABLE flag is set in the TGT", so a TGT without it cannot be
+// forwarded and the KDC would answer KDC_ERR_BADOPTION.
+func (s *session) forwardable() bool {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+
+	return types.IsFlagSet(&s.flags, flags.Forwardable)
+}
+
+// addressed reports whether the session's TGT carries host addresses. A forwarding request supplies addresses only
+// when the source TGT has them, matching MIT's krb5_fwd_tgt_creds; with this library's NoAddresses default it does
+// not, and the forwarded ticket is addressless as RFC 4120 Section 2.6 permits.
+func (s *session) addressed() bool {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+
+	return len(s.addresses) > 0
+}
+
+// supported returns the encryption types the KDC advertised in the PA-SUPPORTED-ENCTYPES pre-authentication data
+// of its reply, or zero if it advertised none. MS-KILE Section 3.3.5.7.4 has a client requesting a forwardable TGT
+// build its own PA-SUPPORTED-ENCTYPES from the types the KDC and the application server both support, and this is
+// the KDC half of that.
+func (s *session) supported() types.SupportedETypes {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+
+	return s.supportedETypes
 }
 
 // JSON return information about the held sessions in a JSON format.

--- a/client/session_test.go
+++ b/client/session_test.go
@@ -14,10 +14,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-krb5/krb5/config"
+	"github.com/go-krb5/krb5/iana/addrtype"
 	"github.com/go-krb5/krb5/iana/etypeID"
+	"github.com/go-krb5/krb5/iana/flags"
 	"github.com/go-krb5/krb5/keytab"
+	"github.com/go-krb5/krb5/messages"
 	"github.com/go-krb5/krb5/test"
 	"github.com/go-krb5/krb5/test/testdata"
+	"github.com/go-krb5/krb5/types"
 )
 
 func TestMultiThreadedClientSession(t *testing.T) {
@@ -168,4 +172,57 @@ func TestSessions_JSON(t *testing.T) {
   }
 ]`
 	assert.Equal(t, expected, j)
+}
+
+// TestSessionShouldRetainTheTicketFlags asserts the TGT's flags survive into the session. RFC 4120 Section 3.3
+// makes the FORWARDED KDC option honoured "only if the FORWARDABLE flag is set in the TGT", so a client that
+// discards them cannot tell whether delegation is possible without asking the KDC and being refused.
+func TestSessionShouldRetainTheTicketFlags(t *testing.T) {
+	t.Parallel()
+
+	forwardableFlags := types.NewKrbFlags()
+	types.SetFlag(&forwardableFlags, flags.Forwardable)
+
+	s := &session{}
+	s.update(messages.Ticket{}, messages.EncKDCRepPart{Flags: forwardableFlags})
+	assert.True(t, s.forwardable())
+
+	s.update(messages.Ticket{}, messages.EncKDCRepPart{Flags: types.NewKrbFlags()})
+	assert.False(t, s.forwardable())
+}
+
+// TestSessionShouldRetainTheTicketAddresses asserts the KDC reply's caddr survives into the session. A client
+// cannot read its own TGT's EncTicketPart, which is encrypted under the KDC's key, so the reply is the only place
+// it can learn whether its TGT is addressless; and MIT supplies addresses in a forwarding request only when the
+// source TGT has them.
+func TestSessionShouldRetainTheTicketAddresses(t *testing.T) {
+	t.Parallel()
+
+	s := &session{}
+	s.update(messages.Ticket{}, messages.EncKDCRepPart{})
+	assert.False(t, s.addressed())
+
+	s.update(messages.Ticket{}, messages.EncKDCRepPart{
+		CAddr: []types.HostAddress{{AddrType: addrtype.IPv4, Address: []byte{10, 0, 0, 1}}},
+	})
+	assert.True(t, s.addressed())
+}
+
+// TestSessionShouldRetainTheKDCSupportedEncryptionTypes asserts the KDC's PA-SUPPORTED-ENCTYPES advertisement
+// survives into the session. MS-KILE Section 3.3.5.7.4 has a client requesting a forwardable TGT build its own
+// advertisement from what the KDC and the application server both support, and this is the KDC half; a client that
+// discards it can only ever advertise half the intersection.
+func TestSessionShouldRetainTheKDCSupportedEncryptionTypes(t *testing.T) {
+	t.Parallel()
+
+	want := types.NewSupportedETypesFromIDs([]int32{etypeID.AES256_CTS_HMAC_SHA1_96, etypeID.AES128_CTS_HMAC_SHA1_96})
+
+	s := &session{}
+	s.update(messages.Ticket{}, messages.EncKDCRepPart{})
+	assert.True(t, s.supported().IsZero(), "a KDC that advertised nothing leaves the value unknown")
+
+	s.update(messages.Ticket{}, messages.EncKDCRepPart{
+		EncPAData: types.PADataSequence{want.PAData()},
+	})
+	assert.Equal(t, want, s.supported())
 }

--- a/client/tgs_exchange.go
+++ b/client/tgs_exchange.go
@@ -84,6 +84,7 @@ func (cl *Client) TGSExchange(tgsReq messages.TGSReq, kdcRealm string, tgt messa
 		tgsRep.DecryptedEncPart.EndTime,
 		tgsRep.DecryptedEncPart.RenewTill,
 		tgsRep.DecryptedEncPart.Key,
+		types.SupportedETypesFromPAData(tgsRep.DecryptedEncPart.EncPAData),
 	)
 	cl.Log("ticket added to cache for %s (EndTime: %v)", tgsRep.Ticket.SName.PrincipalNameString(), tgsRep.DecryptedEncPart.EndTime)
 

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -17,6 +17,8 @@ import (
 const (
 	// AttributeKeyADCredentials assigned number for AD credentials.
 	AttributeKeyADCredentials = "krb5AttributeKeyADCredentials"
+	// AttributeKeyDelegatedCredentials assigned number for a credential delegated by the client.
+	AttributeKeyDelegatedCredentials = "krb5AttributeKeyDelegatedCredentials"
 )
 
 // Credentials struct for a user.
@@ -163,6 +165,31 @@ func (c *Credentials) GetADCredentials() ADCredentials {
 	}
 
 	return ADCredentials{}
+}
+
+// SetDelegatedCredentials attaches the credential cache a client delegated to this service in its AP_REQ, as
+// described by RFC 4121 Section 4.1.1. Pass it to client.NewFromCCache to act as that client.
+//
+// Delegation grants complete use of the client's identity, so treat the contents as the secret they are.
+//
+// The cache's default principal is asserted by the peer, not by the KDC. It is the pname and prealm of the
+// delegated KRB_CRED, all of which the initiator chose, whereas this credential's CName and CRealm come from the
+// KDC-sealed encrypted part of the AP_REQ ticket. Nothing compares the two, matching MIT's rd_cred.c, and a forged
+// ticket is useless without the session key that goes with it. It is still the caller's business if the two differ:
+// authorising on UserName and then acting through DelegatedCredentials may act as a principal other than the one
+// that was authorised.
+func (c *Credentials) SetDelegatedCredentials(cc *CCache) {
+	c.SetAttribute(AttributeKeyDelegatedCredentials, cc)
+}
+
+// DelegatedCredentials returns the credential cache the client delegated, and whether one was delegated at all.
+//
+// The principal named in the cache is asserted by the peer rather than vouched for by the KDC; see
+// SetDelegatedCredentials for what that does and does not mean.
+func (c *Credentials) DelegatedCredentials() (*CCache, bool) {
+	cc, ok := c.attributes[AttributeKeyDelegatedCredentials].(*CCache)
+
+	return cc, ok
 }
 
 // Methods to implement goidentity.Identity interface.

--- a/credentials/credentials_test.go
+++ b/credentials/credentials_test.go
@@ -27,3 +27,22 @@ func TestCredentials_Marshal(t *testing.T) {
 
 	require.NoError(t, credum.Unmarshal(b))
 }
+
+// TestDelegatedCredentialsShouldRoundTrip asserts the accessor pair an acceptor uses to hand a forwarded TGT to
+// application code.
+func TestDelegatedCredentialsShouldRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	c := New("testuser1", "TEST.GOKRB5")
+
+	cc, ok := c.DelegatedCredentials()
+	assert.Nil(t, cc)
+	assert.False(t, ok, "credentials with no delegation must report none")
+
+	want := NewV4CCache()
+	c.SetDelegatedCredentials(want)
+
+	cc, ok = c.DelegatedCredentials()
+	require.True(t, ok)
+	assert.Same(t, want, cc)
+}

--- a/crypto/rfc3961/encryption.go
+++ b/crypto/rfc3961/encryption.go
@@ -105,6 +105,13 @@ func DES3DecryptData(key, data []byte, e etype.EType) ([]byte, error) {
 // DES3DecryptMessage decrypts the message provided using DES3 and methods specific to the etype provided.
 // The integrity of the message is also verified.
 func DES3DecryptMessage(key, ciphertext []byte, usage uint32, e etype.EType) ([]byte, error) {
+	// An encrypted message is a confounder and the message, encrypted, followed by the integrity hash. Anything
+	// shorter than a confounder plus a hash cannot be one, and slicing the hash off it would index out of range.
+	// The length is chosen by whoever encoded the message, so this has to be a returned error rather than a panic.
+	if min := e.GetConfounderByteSize() + e.GetHMACBitLength()/8; len(ciphertext) < min {
+		return nil, fmt.Errorf("ciphertext is too short to be an encrypted message: %d bytes, need at least %d", len(ciphertext), min)
+	}
+
 	// Derive the key.
 	k, err := e.DeriveKey(key, common.GetUsageKe(usage))
 	if err != nil {
@@ -124,7 +131,13 @@ func DES3DecryptMessage(key, ciphertext []byte, usage uint32, e etype.EType) ([]
 }
 
 // VerifyIntegrity verifies the integrity of cipertext bytes ct.
+//
+// A ct too short to carry an integrity hash fails verification rather than indexing past its end.
 func VerifyIntegrity(key, ct, pt []byte, usage uint32, etype etype.EType) bool {
+	if len(ct) < etype.GetHMACBitLength()/8 {
+		return false
+	}
+
 	h := make([]byte, etype.GetHMACBitLength()/8)
 	copy(h, ct[len(ct)-etype.GetHMACBitLength()/8:])
 	expectedMAC, _ := common.GetIntegrityHash(pt, key, usage, etype)

--- a/crypto/rfc3961/encryption_test.go
+++ b/crypto/rfc3961/encryption_test.go
@@ -294,3 +294,39 @@ func TestDES3DecryptMessage_InvalidCiphertextSize(t *testing.T) {
 	assert.Contains(t, err.Error(), "ciphertext is not a multiple of the block size",
 		"Error message should mention invalid ciphertext size")
 }
+
+// TestDES3DecryptMessageShouldRejectAShortCiphertext covers the length guard, matching the one in rfc3962 and
+// rfc8009: an EncryptedData shorter than a confounder plus an integrity hash cannot be an encrypted message, and
+// slicing the hash off it used to index out of range.
+func TestDES3DecryptMessageShouldRejectAShortCiphertext(t *testing.T) {
+	t.Parallel()
+
+	var e crypto.Des3CbcSha1Kd
+
+	key := make([]byte, 24)
+
+	for _, size := range []int{0, 1, 6, 20, 27} {
+		assert.NotPanics(t, func() {
+			_, err := rfc3961.DES3DecryptMessage(key, make([]byte, size), 2, &e)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "ciphertext is too short to be an encrypted message")
+		}, "a %d byte ciphertext must be an error, not a panic", size)
+	}
+}
+
+// TestVerifyIntegrityShouldRejectAShortCiphertext covers the same exposure on the exported integrity check, which
+// reads the trailing hash out of the ciphertext directly.
+func TestVerifyIntegrityShouldRejectAShortCiphertext(t *testing.T) {
+	t.Parallel()
+
+	var e crypto.Des3CbcSha1Kd
+
+	key := make([]byte, 24)
+
+	for _, size := range []int{0, 1, 19} {
+		assert.NotPanics(t, func() {
+			assert.False(t, rfc3961.VerifyIntegrity(key, make([]byte, size), make([]byte, 8), 2, &e))
+		}, "a %d byte ciphertext must verify false, not panic", size)
+	}
+}

--- a/crypto/rfc3962/encryption.go
+++ b/crypto/rfc3962/encryption.go
@@ -79,6 +79,14 @@ func DecryptData(key, data []byte, e etype.EType) ([]byte, error) {
 // DecryptMessage decrypts the message provided using the methods specific to the etype provided as defined in RFC 3962.
 // The integrity of the message is also verified.
 func DecryptMessage(key, ciphertext []byte, usage uint32, e etype.EType) ([]byte, error) {
+	// An encrypted message is a confounder and the message, encrypted, followed by the integrity hash. Anything
+	// shorter than a confounder plus a hash cannot be one, and slicing the hash off it would index out of range.
+	// The length is chosen by whoever encoded the message: the EncryptedData of a ticket, or of the KRB_CRED a peer
+	// delegates, arrives with whatever Cipher the peer sent, so this has to be a returned error rather than a panic.
+	if min := e.GetConfounderByteSize() + e.GetHMACBitLength()/8; len(ciphertext) < min {
+		return nil, fmt.Errorf("ciphertext is too short to be an encrypted message: %d bytes, need at least %d", len(ciphertext), min)
+	}
+
 	// Derive the key.
 	k, err := e.DeriveKey(key, common.GetUsageKe(usage))
 	if err != nil {

--- a/crypto/rfc3962/encryption_test.go
+++ b/crypto/rfc3962/encryption_test.go
@@ -365,3 +365,24 @@ func decodeHex(s string) string {
 
 	return s
 }
+
+// TestDecryptMessageShouldRejectAShortCiphertext covers the length guard. The EncryptedData being decrypted is
+// chosen by whoever encoded it: a peer can send a KRB_CRED, or a ticket, whose Cipher is a handful of bytes, and
+// slicing the integrity hash off it used to index out of range and take the process down. Found by fuzzing the
+// delegated credential path.
+func TestDecryptMessageShouldRejectAShortCiphertext(t *testing.T) {
+	t.Parallel()
+
+	var e crypto.Aes256CtsHmacSha96
+
+	key := make([]byte, 32)
+
+	for _, size := range []int{0, 1, 6, 12, 27} {
+		assert.NotPanics(t, func() {
+			_, err := rfc3962.DecryptMessage(key, make([]byte, size), 2, &e)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "ciphertext is too short to be an encrypted message")
+		}, "a %d byte ciphertext must be an error, not a panic", size)
+	}
+}

--- a/crypto/rfc4757/encryption.go
+++ b/crypto/rfc4757/encryption.go
@@ -67,6 +67,13 @@ func EncryptMessage(key, data []byte, usage uint32, export bool, e etype.EType) 
 // DecryptMessage decrypts the message provided using the methods specific to the etype provided as defined in RFC 4757.
 // The integrity of the message is also verified.
 func DecryptMessage(key, data []byte, usage uint32, export bool, e etype.EType) ([]byte, error) {
+	// An encrypted message is the checksum followed by the encrypted confounder and message. Anything shorter than
+	// a checksum plus a confounder cannot be one, and splitting it anyway would index out of range. The length is
+	// chosen by whoever encoded the message, so this has to be a returned error rather than a panic.
+	if min := e.GetHMACBitLength()/8 + e.GetConfounderByteSize(); len(data) < min {
+		return nil, fmt.Errorf("ciphertext is too short to be an encrypted message: %d bytes, need at least %d", len(data), min)
+	}
+
 	checksum := data[:e.GetHMACBitLength()/8]
 	ct := data[e.GetHMACBitLength()/8:]
 	_, k2, k3 := deriveKeys(key, checksum, usage, export)
@@ -84,7 +91,14 @@ func DecryptMessage(key, data []byte, usage uint32, export bool, e etype.EType) 
 }
 
 // VerifyIntegrity checks the integrity checksum of the data matches that calculated from the decrypted data.
+//
+// Data too short to carry the checksum fails verification rather than indexing past its end.
 func VerifyIntegrity(key, pt, data []byte, e etype.EType) bool {
+	if len(data) < e.GetHMACBitLength()/8 {
+		return false
+	}
+
 	chksum := HMAC(key, pt)
+
 	return hmac.Equal(chksum, data[:e.GetHMACBitLength()/8])
 }

--- a/crypto/rfc4757/encryption_test.go
+++ b/crypto/rfc4757/encryption_test.go
@@ -1,0 +1,48 @@
+package rfc4757_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/krb5/crypto"
+	"github.com/go-krb5/krb5/crypto/rfc4757"
+)
+
+// TestDecryptMessageShouldRejectAShortCiphertext covers the length guard, matching the ones in rfc3961, rfc3962 and
+// rfc8009. RC4 puts its checksum first rather than last, but the exposure is the same: the length of the
+// EncryptedData is chosen by whoever encoded it, and splitting a message shorter than the checksum plus a
+// confounder used to index out of range.
+func TestDecryptMessageShouldRejectAShortCiphertext(t *testing.T) {
+	t.Parallel()
+
+	var e crypto.RC4HMAC
+
+	key := make([]byte, 16)
+
+	for _, size := range []int{0, 1, 6, 16, 23} {
+		assert.NotPanics(t, func() {
+			_, err := rfc4757.DecryptMessage(key, make([]byte, size), 2, false, &e)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "ciphertext is too short to be an encrypted message")
+		}, "a %d byte ciphertext must be an error, not a panic", size)
+	}
+}
+
+// TestVerifyIntegrityShouldRejectAShortMessage covers the same exposure on the exported integrity check, which
+// reads the checksum out of the message directly.
+func TestVerifyIntegrityShouldRejectAShortMessage(t *testing.T) {
+	t.Parallel()
+
+	var e crypto.RC4HMAC
+
+	key := make([]byte, 16)
+
+	for _, size := range []int{0, 1, 15} {
+		assert.NotPanics(t, func() {
+			assert.False(t, rfc4757.VerifyIntegrity(key, make([]byte, 8), make([]byte, size), &e))
+		}, "a %d byte message must verify false, not panic", size)
+	}
+}

--- a/crypto/rfc8009/encryption.go
+++ b/crypto/rfc8009/encryption.go
@@ -99,6 +99,13 @@ func DecryptData(key, data []byte, e etype.EType) ([]byte, error) {
 // DecryptMessage decrypts the message provided using the methods specific to the etype provided as defined in RFC 8009.
 // The integrity of the message is also verified.
 func DecryptMessage(key, ciphertext []byte, usage uint32, e etype.EType) ([]byte, error) {
+	// An encrypted message is a confounder and the message, encrypted, followed by the integrity hash. Anything
+	// shorter than a confounder plus a hash cannot be one, and slicing the hash off it would index out of range.
+	// The length is chosen by whoever encoded the message, so this has to be a returned error rather than a panic.
+	if min := e.GetConfounderByteSize() + e.GetHMACBitLength()/8; len(ciphertext) < min {
+		return nil, fmt.Errorf("ciphertext is too short to be an encrypted message: %d bytes, need at least %d", len(ciphertext), min)
+	}
+
 	// Derive the key.
 	k, err := e.DeriveKey(key, common.GetUsageKe(usage))
 	if err != nil {
@@ -127,7 +134,13 @@ func GetIntegityHash(iv, c, key []byte, usage uint32, e etype.EType) ([]byte, er
 }
 
 // VerifyIntegrity verifies the integrity of cipertext bytes ct.
+//
+// A ct too short to carry an integrity hash fails verification rather than indexing past its end.
 func VerifyIntegrity(key, ct []byte, usage uint32, etype etype.EType) bool {
+	if len(ct) < etype.GetHMACBitLength()/8 {
+		return false
+	}
+
 	h := make([]byte, etype.GetHMACBitLength()/8)
 	copy(h, ct[len(ct)-etype.GetHMACBitLength()/8:])
 	ivz := make([]byte, etype.GetConfounderByteSize())

--- a/crypto/rfc8009/encryption_test.go
+++ b/crypto/rfc8009/encryption_test.go
@@ -580,3 +580,39 @@ func TestDecryptData_InvalidKeySize_AES128(t *testing.T) {
 		})
 	}
 }
+
+// TestDecryptMessageShouldRejectAShortCiphertext covers the length guard, matching the one in rfc3961 and rfc3962:
+// an EncryptedData shorter than a confounder plus an integrity hash cannot be an encrypted message, and slicing the
+// hash off it used to index out of range.
+func TestDecryptMessageShouldRejectAShortCiphertext(t *testing.T) {
+	t.Parallel()
+
+	var e crypto.Aes128CtsHmacSha256128
+
+	key := make([]byte, 16)
+
+	for _, size := range []int{0, 1, 6, 12, 27} {
+		assert.NotPanics(t, func() {
+			_, err := rfc8009.DecryptMessage(key, make([]byte, size), 2, &e)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "ciphertext is too short to be an encrypted message")
+		}, "a %d byte ciphertext must be an error, not a panic", size)
+	}
+}
+
+// TestVerifyIntegrityShouldRejectAShortCiphertext covers the same exposure on the exported integrity check, which
+// reads the trailing hash out of the ciphertext directly.
+func TestVerifyIntegrityShouldRejectAShortCiphertext(t *testing.T) {
+	t.Parallel()
+
+	var e crypto.Aes128CtsHmacSha256128
+
+	key := make([]byte, 16)
+
+	for _, size := range []int{0, 1, 11} {
+		assert.NotPanics(t, func() {
+			assert.False(t, rfc8009.VerifyIntegrity(key, make([]byte, size), 2, &e))
+		}, "a %d byte ciphertext must verify false, not panic", size)
+	}
+}

--- a/gssapi/authenticator_checksum.go
+++ b/gssapi/authenticator_checksum.go
@@ -1,0 +1,204 @@
+package gssapi
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+// Field widths and offsets of the GSS-API authenticator checksum described by RFC 4121 Section 4.1.1.
+const (
+	// ChecksumBndLgth is the value RFC 4121 Section 4.1.1 fixes in the four octet Lgth field at the start of the
+	// checksum: the width of the Bnd field that follows it.
+	ChecksumBndLgth = 16
+
+	// ChecksumMinLen is the smallest checksum RFC 4121 Section 4.1.1 describes, holding Lgth, Bnd and Flags.
+	ChecksumMinLen = 24
+
+	// ChecksumDelegMinLen is the smallest checksum carrying delegation, adding the two octet DlgOpt and Dlgth
+	// fields. RFC 4121 Section 4.1.1 requires "at least 28 octets plus Dlgth octets when GSS_C_DELEG_FLAG is set".
+	ChecksumDelegMinLen = 28
+
+	// ChecksumDlgOpt is the delegation option identifier RFC 4121 Section 4.1.1 fixes in DlgOpt.
+	ChecksumDlgOpt = 1
+
+	// ChecksumMaxDelegLen is the largest Deleg field this library will emit. The two octet Dlgth could express
+	// 65535, but MIT Kerberos rejects credmsg.length+28 > KRB5_INT16_MAX in
+	// lib/gssapi/krb5/init_sec_context.c, so a larger KRB_CRED is one no MIT acceptor is prepared to read. This is
+	// an interoperability bound rather than a protocol one.
+	ChecksumMaxDelegLen = 32767 - ChecksumDelegMinLen
+)
+
+// checksumFlagMask selects the flag values RFC 4121 Section 4.1.1.1 permits in the Flags field. Everything else is
+// cleared on marshalling, because that section requires it: "Undefined flag values MUST be cleared by the sender,
+// and unknown flags MUST be ignored by the receiver."
+//
+// Two ranges survive. The low bits are the six context establishment flags Section 4.1.1.1 names. Bits 12 to 19 are
+// the range it reserves "for use with legacy vendor-specific extensions to this mechanism", which is where the
+// Windows flags of RFC 4757 Section 7.1 live; GSS_C_DCE_STYLE (0x1000), GSS_C_IDENTIFY_FLAG (0x2000) and
+// GSS_C_EXTENDED_ERROR_FLAG (0x4000), all three of which MS-KILE Section 3.2.5.2 has a client set in this very
+// field, along with GSS_C_DELEG_POLICY_FLAG (0x8000) which MIT sets. Masking those away would break interoperation
+// with both, so the whole reserved range passes through even though this library defines none of it.
+//
+// Clearing a flag here removes nothing a peer would have acted on, since the same sentence obliges receivers to
+// ignore what they do not recognise. That is what separates this from a silent downgrade: the flag had no effect
+// to lose. A caller is therefore not told, and Marshal does not fail.
+//
+// MIT masks in the same place and for the same reason, at lib/gssapi/krb5/init_sec_context.c, though its mask is
+// narrower; it enumerates the three RFC 4757 flags rather than the whole reserved range; and it then ORs in
+// GSS_C_TRANS_FLAG (0x100), which this mask clears because Section 4.1.1.1 defines no such value for this field.
+const checksumFlagMask = ContextFlagDeleg | ContextFlagMutual | ContextFlagReplay |
+	ContextFlagSequence | ContextFlagConf | ContextFlagInteg |
+	0x000FF000
+
+// ErrDelegationMissing is returned by Marshal when GSS_C_DELEG_FLAG is set in Flags but Deleg is empty. RFC 4121
+// Section 4.1.1 makes DlgOpt, Dlgth and Deleg present if and only if the flag is set, so the two cannot disagree.
+// Emitting the flag with those fields zeroed is what MIT rejects with GSS_S_FAILURE on reading DlgOpt as 0.
+var ErrDelegationMissing = errors.New("delegation flag set without a delegated credential")
+
+// ErrDelegationTooLarge is returned by Marshal when Deleg exceeds ChecksumMaxDelegLen.
+var ErrDelegationTooLarge = errors.New("delegated credential too large")
+
+// ErrDelegationMalformed is returned by Unmarshal when a checksum claims delegation but the fields carrying it
+// cannot be read. Callers match against it with errors.Is.
+var ErrDelegationMalformed = errors.New("malformed delegation in authenticator checksum")
+
+// ChecksumLgthError reports a checksum whose Lgth field declares a Bnd width other than the 16 RFC 4121 Section
+// 4.1.1 fixes. Lgth is the width of Bnd, so any other value moves Flags and every field after it: the layout
+// cannot be interpreted at all, not merely its Bnd. Reading the documented offsets anyway would report whatever
+// happened to sit there as though it were the real Flags.
+type ChecksumLgthError struct {
+	Lgth uint32
+}
+
+// Error describes the offending length.
+func (e ChecksumLgthError) Error() string {
+	return fmt.Sprintf("declares a Bnd length of %d rather than %d", e.Lgth, ChecksumBndLgth)
+}
+
+// AuthenticatorChecksum is the GSS-API authenticator checksum of RFC 4121 Section 4.1.1, carried in the AP_REQ
+// authenticator under checksum type chksumtype.GSSAPI. It conveys the context establishment flags, the channel
+// bindings hash, and optionally a delegated credential.
+//
+//	Octet          Field   Meaning
+//	0..3           Lgth    octets in Bnd; always ChecksumBndLgth
+//	4..19          Bnd     MD5 of the RFC 1964 Section 1.1.1 channel bindings structure
+//	20..23         Flags   context establishment flags, little-endian
+//	24..25         DlgOpt  ChecksumDlgOpt; present if and only if GSS_C_DELEG_FLAG is set
+//	26..27         Dlgth   length of Deleg; present if and only if GSS_C_DELEG_FLAG is set
+//	28..28+Dlgth   Deleg   a KRB_CRED message
+//	trailing       Exts    extensions
+//
+// Every integer is little-endian.
+type AuthenticatorChecksum struct {
+	// Bnd is the channel bindings hash. Sixteen zero bytes mean no channel bindings.
+	Bnd [16]byte
+
+	// Flags are the context establishment flags. GSS_C_DELEG_FLAG is derived from Deleg by Marshal.
+	Flags uint32
+
+	// Deleg is a marshalled KRB_CRED, or nil when no credential is delegated.
+	Deleg []byte
+
+	// Exts is carried verbatim and never interpreted. RFC 4121 Section 4.1.1 requires that acceptors which do not
+	// understand the extensions ignore any octets past Deleg, so they are preserved rather than rejected.
+	Exts []byte
+}
+
+// Delegated reports whether GSS_C_DELEG_FLAG is set in Flags.
+func (c *AuthenticatorChecksum) Delegated() bool {
+	return c.Flags&ContextFlagDeleg != 0
+}
+
+// Marshal returns the checksum in the RFC 4121 Section 4.1.1 layout.
+//
+// The delegation flag is derived from Deleg rather than trusted from Flags: a non-empty Deleg sets it, and the flag
+// set with an empty Deleg returns ErrDelegationMissing. That is the malformed checksum this type exists to make
+// unrepresentable. Clearing the flag instead would be a silent downgrade the caller could not observe.
+//
+// Flags outside the set RFC 4121 Section 4.1.1.1 permits are cleared, as that section requires of senders. See
+// checksumFlagMask for which survive and why clearing them costs a caller nothing.
+func (c *AuthenticatorChecksum) Marshal() ([]byte, error) {
+	flags := c.Flags & checksumFlagMask
+
+	switch {
+	case len(c.Deleg) > ChecksumMaxDelegLen:
+		return nil, fmt.Errorf("%w: %d octets exceeds the %d octet interoperable maximum",
+			ErrDelegationTooLarge, len(c.Deleg), ChecksumMaxDelegLen)
+	case len(c.Deleg) > 0:
+		flags |= ContextFlagDeleg
+	case flags&ContextFlagDeleg != 0:
+		return nil, fmt.Errorf("%w: RFC 4121 Section 4.1.1 makes DlgOpt, Dlgth and Deleg present if and only if GSS_C_DELEG_FLAG is set", ErrDelegationMissing)
+	}
+
+	n := ChecksumMinLen
+	if len(c.Deleg) > 0 {
+		n = ChecksumDelegMinLen + len(c.Deleg)
+	}
+
+	b := make([]byte, n, n+len(c.Exts))
+
+	binary.LittleEndian.PutUint32(b[:4], ChecksumBndLgth)
+	copy(b[4:20], c.Bnd[:])
+	binary.LittleEndian.PutUint32(b[20:24], flags)
+
+	if len(c.Deleg) > 0 {
+		binary.LittleEndian.PutUint16(b[24:26], ChecksumDlgOpt)
+		//nolint:gosec // G115: len(c.Deleg) is bounded by ChecksumMaxDelegLen in the switch above.
+		binary.LittleEndian.PutUint16(b[26:28], uint16(len(c.Deleg)))
+		copy(b[ChecksumDelegMinLen:], c.Deleg)
+	}
+
+	return append(b, c.Exts...), nil
+}
+
+// Unmarshal parses the checksum, resetting the receiver first.
+//
+// Its strictness is deliberately asymmetric. A checksum too short to hold Lgth, Bnd and Flags leaves the receiver
+// zeroed and returns no error, because acceptors parse every checksum in order to discover whether delegation is
+// claimed and parsing more often must not reject more often: whether an uninterpretable checksum matters is the
+// caller's decision, not this parser's. Once the checksum is long enough and claims delegation, every defect in the
+// delegation fields is an error.
+func (c *AuthenticatorChecksum) Unmarshal(b []byte) error {
+	*c = AuthenticatorChecksum{}
+
+	if len(b) < ChecksumMinLen {
+		return nil
+	}
+
+	if lgth := binary.LittleEndian.Uint32(b[:4]); lgth != ChecksumBndLgth {
+		return ChecksumLgthError{Lgth: lgth}
+	}
+
+	copy(c.Bnd[:], b[4:20])
+	c.Flags = binary.LittleEndian.Uint32(b[20:24])
+
+	rest := b[ChecksumMinLen:]
+
+	if c.Delegated() {
+		if len(b) < ChecksumDelegMinLen {
+			return fmt.Errorf("%w: %d octets is too short to carry the delegation fields", ErrDelegationMalformed, len(b))
+		}
+
+		if opt := binary.LittleEndian.Uint16(b[24:26]); opt != ChecksumDlgOpt {
+			return fmt.Errorf("%w: carries delegation option identifier %d rather than %d",
+				ErrDelegationMalformed, opt, ChecksumDlgOpt)
+		}
+
+		dlgth := int(binary.LittleEndian.Uint16(b[26:28]))
+		if ChecksumDelegMinLen+dlgth > len(b) {
+			return fmt.Errorf("%w: declares a Deleg length of %d with only %d octets remaining",
+				ErrDelegationMalformed, dlgth, len(b)-ChecksumDelegMinLen)
+		}
+
+		c.Deleg = bytes.Clone(b[ChecksumDelegMinLen : ChecksumDelegMinLen+dlgth])
+		rest = b[ChecksumDelegMinLen+dlgth:]
+	}
+
+	if len(rest) > 0 {
+		c.Exts = bytes.Clone(rest)
+	}
+
+	return nil
+}

--- a/gssapi/authenticator_checksum_test.go
+++ b/gssapi/authenticator_checksum_test.go
@@ -1,0 +1,293 @@
+package gssapi
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAuthenticatorChecksumMarshalShouldProduce24OctetsWithoutDelegation pins the default path: the checksum an
+// initiator that is not delegating emits must be byte for byte what it was before delegation existed.
+func TestAuthenticatorChecksumMarshalShouldProduce24OctetsWithoutDelegation(t *testing.T) {
+	t.Parallel()
+
+	c := &AuthenticatorChecksum{Flags: ContextFlagInteg | ContextFlagConf}
+
+	b, err := c.Marshal()
+	require.NoError(t, err)
+
+	require.Len(t, b, 24)
+	assert.Equal(t, uint32(16), binary.LittleEndian.Uint32(b[:4]))
+	assert.Equal(t, make([]byte, 16), b[4:20])
+	assert.Equal(t, uint32(ContextFlagInteg|ContextFlagConf), binary.LittleEndian.Uint32(b[20:24]))
+}
+
+// TestAuthenticatorChecksumMarshalShouldAppendDelegation asserts the DlgOpt, Dlgth and Deleg fields of RFC 4121
+// Section 4.1.1 follow Flags, and that the delegation flag is derived from the field rather than trusted from the
+// caller.
+func TestAuthenticatorChecksumMarshalShouldAppendDelegation(t *testing.T) {
+	t.Parallel()
+
+	deleg := []byte("a marshalled KRB_CRED")
+
+	c := &AuthenticatorChecksum{Flags: ContextFlagInteg, Deleg: deleg}
+
+	b, err := c.Marshal()
+	require.NoError(t, err)
+
+	require.Len(t, b, 28+len(deleg))
+	assert.Equal(t, uint32(ContextFlagInteg|ContextFlagDeleg), binary.LittleEndian.Uint32(b[20:24]),
+		"a non-empty Deleg must set GSS_C_DELEG_FLAG so the field and the flag cannot disagree")
+	assert.Equal(t, uint16(1), binary.LittleEndian.Uint16(b[24:26]), "DlgOpt is the delegation option identifier 1")
+	assert.Equal(t, uint16(len(deleg)), binary.LittleEndian.Uint16(b[26:28]))
+	assert.Equal(t, deleg, b[28:])
+}
+
+// TestAuthenticatorChecksumMarshalShouldRefuseTheFlagWithoutTheField pins the defect this type exists to make
+// unrepresentable: a 28 octet checksum claiming a delegation with all its delegation fields zeroed. MIT rejects
+// that with GSS_S_FAILURE on reading DlgOpt as 0.
+func TestAuthenticatorChecksumMarshalShouldRefuseTheFlagWithoutTheField(t *testing.T) {
+	t.Parallel()
+
+	c := &AuthenticatorChecksum{Flags: ContextFlagInteg | ContextFlagDeleg}
+
+	b, err := c.Marshal()
+
+	require.ErrorIs(t, err, ErrDelegationMissing)
+	assert.Nil(t, b)
+}
+
+// TestAuthenticatorChecksumMarshalShouldRefuseAnOversizeDelegation asserts the MIT interoperability bound. MIT's
+// init_sec_context.c rejects credmsg.length+28 > KRB5_INT16_MAX, so a KRB_CRED larger than 32739 octets is one no
+// MIT acceptor is prepared to read even though the two octet Dlgth field could express it.
+func TestAuthenticatorChecksumMarshalShouldRefuseAnOversizeDelegation(t *testing.T) {
+	t.Parallel()
+
+	atLimit := &AuthenticatorChecksum{Deleg: bytes.Repeat([]byte{0xAA}, ChecksumMaxDelegLen)}
+	b, err := atLimit.Marshal()
+	require.NoError(t, err, "the largest interoperable Deleg must still marshal")
+	assert.Len(t, b, 28+ChecksumMaxDelegLen)
+
+	over := &AuthenticatorChecksum{Deleg: bytes.Repeat([]byte{0xAA}, ChecksumMaxDelegLen+1)}
+	b, err = over.Marshal()
+	require.ErrorIs(t, err, ErrDelegationTooLarge)
+	assert.Nil(t, b)
+}
+
+// TestAuthenticatorChecksumExtsShouldFollowWhicheverFieldIsLast asserts the placement RFC 4121 Section 4.1.1 gives
+// Exts: "When delegation is not used, but the Exts field is present, the Exts field starts at octet 24."
+func TestAuthenticatorChecksumExtsShouldFollowWhicheverFieldIsLast(t *testing.T) {
+	t.Parallel()
+
+	exts := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+
+	without := &AuthenticatorChecksum{Exts: exts}
+	b, err := without.Marshal()
+	require.NoError(t, err)
+	require.Len(t, b, 24+len(exts))
+	assert.Equal(t, exts, b[24:])
+
+	with := &AuthenticatorChecksum{Deleg: []byte("cred"), Exts: exts}
+	b, err = with.Marshal()
+	require.NoError(t, err)
+	require.Len(t, b, 28+4+len(exts))
+	assert.Equal(t, exts, b[32:])
+}
+
+// TestAuthenticatorChecksumShouldRoundTrip covers both regimes through Marshal then Unmarshal.
+func TestAuthenticatorChecksumShouldRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		in   AuthenticatorChecksum
+	}{
+		{"NoDelegation", AuthenticatorChecksum{Bnd: [16]byte{1, 2, 3}, Flags: ContextFlagConf}},
+		{"WithDelegation", AuthenticatorChecksum{Bnd: [16]byte{4, 5, 6}, Flags: ContextFlagConf, Deleg: []byte("cred")}},
+		{"WithExts", AuthenticatorChecksum{Flags: ContextFlagConf, Exts: []byte{9, 9}}},
+		{"WithBoth", AuthenticatorChecksum{Flags: ContextFlagConf, Deleg: []byte("cred"), Exts: []byte{9, 9}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b, err := tc.in.Marshal()
+			require.NoError(t, err)
+
+			var out AuthenticatorChecksum
+			require.NoError(t, out.Unmarshal(b))
+
+			assert.Equal(t, tc.in.Bnd, out.Bnd)
+			assert.Equal(t, tc.in.Deleg, out.Deleg)
+			assert.Equal(t, tc.in.Exts, out.Exts)
+			assert.Equal(t, len(tc.in.Deleg) > 0, out.Delegated())
+		})
+	}
+}
+
+// TestAuthenticatorChecksumUnmarshalShouldTolerateAShortChecksum asserts the leniency that keeps this parser from
+// rejecting AP_REQs that succeed today. VerifyAPREQ now parses unconditionally to discover whether delegation is
+// claimed, parsing more often must not reject more often.
+func TestAuthenticatorChecksumUnmarshalShouldTolerateAShortChecksum(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		in   []byte
+	}{
+		{"Empty", nil},
+		{"OneOctetShort", make([]byte, 23)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var c AuthenticatorChecksum
+
+			require.NoError(t, c.Unmarshal(tc.in), "a checksum too short to interpret is not an error here")
+			assert.False(t, c.Delegated())
+			assert.Nil(t, c.Deleg)
+		})
+	}
+}
+
+// TestAuthenticatorChecksumUnmarshalShouldRejectAnUnsupportedLgth asserts the parser reports a layout it cannot
+// interpret rather than reading fixed offsets anyway. Lgth is the width of Bnd, so any value other than 16 moves
+// Flags and everything after it.
+func TestAuthenticatorChecksumUnmarshalShouldRejectAnUnsupportedLgth(t *testing.T) {
+	t.Parallel()
+
+	b := make([]byte, 24)
+	binary.LittleEndian.PutUint32(b[:4], 8)
+
+	var c AuthenticatorChecksum
+
+	err := c.Unmarshal(b)
+
+	var lgthErr ChecksumLgthError
+
+	require.ErrorAs(t, err, &lgthErr)
+	assert.Equal(t, uint32(8), lgthErr.Lgth)
+	assert.Contains(t, err.Error(), "declares a Bnd length of 8 rather than 16")
+	assert.False(t, c.Delegated(), "the struct is left zeroed when the layout cannot be interpreted")
+}
+
+// TestAuthenticatorChecksumUnmarshalShouldRejectMalformedDelegation asserts that once a checksum claims delegation,
+// strictness applies. A checksum that says it carries a credential and then does not is defective.
+func TestAuthenticatorChecksumUnmarshalShouldRejectMalformedDelegation(t *testing.T) {
+	t.Parallel()
+
+	// delegChecksum builds a well formed delegating checksum, then applies mutate to it.
+	delegChecksum := func(mutate func([]byte)) []byte {
+		c := &AuthenticatorChecksum{Deleg: []byte("cred")}
+		b, err := c.Marshal()
+		require.NoError(t, err)
+		mutate(b)
+
+		return b
+	}
+
+	for _, tc := range []struct {
+		name    string
+		in      []byte
+		wantMsg string
+	}{
+		{
+			name:    "TruncatedBeforeDlgth",
+			in:      delegChecksum(func(b []byte) {})[:26],
+			wantMsg: "too short to carry the delegation fields",
+		},
+		{
+			name:    "WrongDlgOpt",
+			in:      delegChecksum(func(b []byte) { binary.LittleEndian.PutUint16(b[24:26], 2) }),
+			wantMsg: "delegation option identifier 2 rather than 1",
+		},
+		{
+			name:    "DlgthPastTheEnd",
+			in:      delegChecksum(func(b []byte) { binary.LittleEndian.PutUint16(b[26:28], 4096) }),
+			wantMsg: "declares a Deleg length of 4096",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var c AuthenticatorChecksum
+
+			err := c.Unmarshal(tc.in)
+
+			require.ErrorIs(t, err, ErrDelegationMalformed)
+			assert.Contains(t, err.Error(), tc.wantMsg)
+		})
+	}
+}
+
+// TestAuthenticatorChecksumMarshalShouldClearUndefinedFlags asserts the sender obligation of RFC 4121 Section
+// 4.1.1.1: "Undefined flag values MUST be cleared by the sender, and unknown flags MUST be ignored by the
+// receiver." Before this mask existed, ContextFlagAnon and any high bit a caller passed reached the wire.
+func TestAuthenticatorChecksumMarshalShouldClearUndefinedFlags(t *testing.T) {
+	t.Parallel()
+
+	c := &AuthenticatorChecksum{
+		Flags: ContextFlagInteg | ContextFlagConf | ContextFlagAnon | 0x00000100 | 0x80000000,
+	}
+
+	b, err := c.Marshal()
+	require.NoError(t, err)
+
+	assert.Equal(t, uint32(ContextFlagInteg|ContextFlagConf), binary.LittleEndian.Uint32(b[20:24]),
+		"ContextFlagAnon, GSS_C_TRANS_FLAG and the undefined high bit must all be cleared")
+}
+
+// TestAuthenticatorChecksumMarshalShouldPreserveTheVendorFlagRange asserts the mask does not break Windows or MIT.
+// RFC 4121 Section 4.1.1.1 reserves flag values 4096 to 524288 "for use with legacy vendor-specific extensions to
+// this mechanism", and that is where the RFC 4757 Section 7.1 flags MS-KILE sets in this field live:
+// GSS_C_DCE_STYLE 0x1000, GSS_C_IDENTIFY_FLAG 0x2000 and GSS_C_EXTENDED_ERROR_FLAG 0x4000, plus MIT's
+// GSS_C_DELEG_POLICY_FLAG 0x8000. Clearing those would be a conformance fix that broke interoperation.
+func TestAuthenticatorChecksumMarshalShouldPreserveTheVendorFlagRange(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		flag uint32
+	}{
+		{"GSSCDCEStyle", 0x1000},
+		{"GSSCIdentify", 0x2000},
+		{"GSSCExtendedError", 0x4000},
+		{"GSSCDelegPolicy", 0x8000},
+		{"ReservedRangeLowBit", 1 << 12},
+		{"ReservedRangeHighBit", 1 << 19},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &AuthenticatorChecksum{Flags: ContextFlagInteg | tc.flag}
+
+			b, err := c.Marshal()
+			require.NoError(t, err)
+
+			assert.Equal(t, ContextFlagInteg|tc.flag, binary.LittleEndian.Uint32(b[20:24]))
+		})
+	}
+
+	// The bit immediately above the reserved range is not vendor space and must go.
+	c := &AuthenticatorChecksum{Flags: ContextFlagInteg | (1 << 20)}
+
+	b, err := c.Marshal()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(ContextFlagInteg), binary.LittleEndian.Uint32(b[20:24]))
+}
+
+// TestAuthenticatorChecksumMarshalShouldStillRefuseDelegationAfterMasking asserts the mask does not defeat the
+// flag-without-field guard: ContextFlagDeleg survives the mask, so a caller setting it with an empty Deleg is
+// still refused rather than quietly emitting a 24 octet checksum.
+func TestAuthenticatorChecksumMarshalShouldStillRefuseDelegationAfterMasking(t *testing.T) {
+	t.Parallel()
+
+	c := &AuthenticatorChecksum{Flags: ContextFlagDeleg | ContextFlagAnon}
+
+	b, err := c.Marshal()
+
+	require.ErrorIs(t, err, ErrDelegationMissing)
+	assert.Nil(t, b)
+}

--- a/messages/ap_req_test.go
+++ b/messages/ap_req_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-krb5/krb5/iana"
+	"github.com/go-krb5/krb5/iana/keyusage"
 	"github.com/go-krb5/krb5/iana/msgtype"
 	"github.com/go-krb5/krb5/iana/nametype"
 	"github.com/go-krb5/krb5/test/testdata"
+	"github.com/go-krb5/krb5/types"
 )
 
 func TestUnmarshalAPReq(t *testing.T) {
@@ -50,4 +52,29 @@ func TestMarshalAPReq(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, b, mb)
+}
+
+// TestAuthenticatorKeyUsageEmptyNameStringDoesNotPanic guards against a remotely reachable panic. A service ticket's
+// plaintext Ticket.SName sits outside EncPart, and PrincipalName.NameString may legally be empty, so a client
+// holding any valid service ticket can blank SName and still reach DecryptAuthenticator ->
+// authenticatorKeyUsage(a.Ticket.SName) - an unauthenticated caller must not be able to crash the server this way.
+func TestAuthenticatorKeyUsageEmptyNameStringDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	var usage int
+
+	assert.NotPanics(t, func() {
+		usage = authenticatorKeyUsage(types.PrincipalName{})
+	})
+	assert.Equal(t, keyusage.AP_REQ_AUTHENTICATOR, usage)
+}
+
+// TestAuthenticatorKeyUsageKrbtgtSelectsTGSReqUsage pins the pre-existing behaviour the guard must not change: a
+// krbtgt SName (as a real TGT carries) still selects the TGS-REQ PA-DATA authenticator key usage.
+func TestAuthenticatorKeyUsageKrbtgtSelectsTGSReqUsage(t *testing.T) {
+	t.Parallel()
+
+	pn := types.PrincipalName{NameType: nametype.KRB_NT_SRV_INST, NameString: []string{"krbtgt", "TEST.GOKRB5"}}
+
+	assert.Equal(t, keyusage.TGS_REQ_PA_TGS_REQ_AP_REQ_AUTHENTICATOR, authenticatorKeyUsage(pn))
 }

--- a/messages/kdc_req.go
+++ b/messages/kdc_req.go
@@ -176,6 +176,59 @@ func NewTGSReq(cname types.PrincipalName, paRealm, kdcRealm string, c *config.Co
 	return a, err
 }
 
+// NewForwardedTGSReq generates a TGS_REQ for a forwarded ticket-granting ticket, for delegating the client's
+// identity to a service as described by RFC 4121 Section 4.1.1.
+//
+// The service requested is the client realm's own krbtgt, since what is forwarded is a TGT rather than a service
+// ticket. FORWARDED asks for the forwarding, and RFC 4121 Section 4.1.1 says the resulting ticket "SHOULD have its
+// forwardable flag set", so FORWARDABLE is requested too.
+//
+// RFC 4120 Section 3.3 makes this honoured "only if the FORWARDABLE flag is set in the TGT" supplied; a KDC will
+// otherwise answer KDC_ERR_BADOPTION.
+//
+// addrs are the addresses of the host the resulting ticket is to be valid from. Pass nil for an addressless
+// forwarded ticket, which RFC 4120 Section 2.6 blesses and which is what MIT sends whenever the source TGT is
+// itself addressless.
+//
+// etypes replaces the configured default encryption types when non-empty. MS-KILE Section 3.3.5.7.4 has the client
+// "set the etype field of the TGS-REQ to the contents of the keytype field in the previous TGS-REP to specify the
+// common encryption type", so that the KDC issues the forwarded ticket with a session key the application server
+// can actually use. Pass nil to leave the configured defaults in place.
+//
+// supported advertises the encryption types the KDC and the application server both support, which MS-KILE has the
+// client send as PA-SUPPORTED-ENCTYPES alongside the pinned etype. A zero value appends nothing.
+func NewForwardedTGSReq(cname types.PrincipalName, crealm, kdcRealm string, c *config.Config, tgt Ticket, sessionKey types.EncryptionKey, addrs types.HostAddresses, etypes []int32, supported types.SupportedETypes) (TGSReq, error) {
+	sname := types.PrincipalName{
+		NameType:   nametype.KRB_NT_SRV_INST,
+		NameString: []string{"krbtgt", crealm},
+	}
+
+	a, err := tgsReq(cname, sname, kdcRealm, false, c)
+	if err != nil {
+		return a, err
+	}
+
+	types.SetFlag(&a.ReqBody.KDCOptions, flags.Forwarded)
+	types.SetFlag(&a.ReqBody.KDCOptions, flags.Forwardable)
+
+	a.ReqBody.Addresses = addrs
+
+	if len(etypes) > 0 {
+		a.ReqBody.EType = etypes
+	}
+
+	if err = a.setPAData(crealm, tgt, sessionKey); err != nil {
+		return a, err
+	}
+
+	// setPAData replaces PAData wholesale, so the advertisement is appended after it rather than before.
+	if !supported.IsZero() {
+		a.PAData = append(a.PAData, supported.PAData())
+	}
+
+	return a, nil
+}
+
 // NewUser2UserTGSReq returns a TGS-REQ suitable for user-to-user authentication (https://tools.ietf.org/html/rfc4120#section-3.7)
 func NewUser2UserTGSReq(cname types.PrincipalName, kdcRealm string, c *config.Config, clientTGT Ticket, sessionKey types.EncryptionKey, sname types.PrincipalName, renewal bool, verifyingTGT Ticket) (TGSReq, error) {
 	a, err := tgsReq(cname, sname, kdcRealm, renewal, c)

--- a/messages/kdc_req_test.go
+++ b/messages/kdc_req_test.go
@@ -1,6 +1,7 @@
 package messages
 
 import (
+	"bytes"
 	"encoding/hex"
 	"testing"
 	"time"
@@ -8,12 +9,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-krb5/krb5/config"
+	"github.com/go-krb5/krb5/crypto"
 	"github.com/go-krb5/krb5/iana"
 	"github.com/go-krb5/krb5/iana/addrtype"
+	"github.com/go-krb5/krb5/iana/etypeID"
+	"github.com/go-krb5/krb5/iana/flags"
+	"github.com/go-krb5/krb5/iana/keyusage"
 	"github.com/go-krb5/krb5/iana/msgtype"
 	"github.com/go-krb5/krb5/iana/nametype"
 	"github.com/go-krb5/krb5/iana/patype"
 	"github.com/go-krb5/krb5/test/testdata"
+	"github.com/go-krb5/krb5/types"
 )
 
 func TestUnmarshalKDCReqBody(t *testing.T) {
@@ -424,4 +431,159 @@ func TestMarshalTGSReq(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, b, mb)
+}
+
+// forwardedTGSReqTestTGT builds a TGT shaped like a real one for NewForwardedTGSReq's tests: SName is the realm's
+// own krbtgt, since that is what setPAData's authenticator is encrypted against
+// (keyusage.TGS_REQ_PA_TGS_REQ_AP_REQ_AUTHENTICATOR, selected by authenticatorKeyUsage keying off Ticket.SName).
+func forwardedTGSReqTestTGT(realm string) Ticket {
+	return Ticket{
+		Realm: realm,
+		SName: types.PrincipalName{NameType: nametype.KRB_NT_SRV_INST, NameString: []string{"krbtgt", realm}},
+	}
+}
+
+// decryptForwardedAuthenticator decrypts the PA-TGS-REQ entry of a forwarded TGS-REQ, requiring it to succeed
+// under the hardcoded keyusage.TGS_REQ_PA_TGS_REQ_AP_REQ_AUTHENTICATOR (7) - the usage RFC 4120 Section 3.3.1
+// specifies for an authenticator carried inside TGS-REQ PA-DATA - rather than deriving that usage from the
+// decrypted ticket the way APReq.DecryptAuthenticator does, which would make the check tautological against
+// authenticatorKeyUsage's own logic. Decryption fails here if the encryption side actually used
+// AP_REQ_AUTHENTICATOR (11), the usage for a bare AP-REQ presented directly to a service, pinning that setPAData
+// encrypts under the correct, fixed usage.
+func decryptForwardedAuthenticator(t *testing.T, req TGSReq, sessionKey types.EncryptionKey) types.Authenticator {
+	t.Helper()
+
+	// The entry is located by type rather than by position: a forwarded request may also carry
+	// PA-SUPPORTED-ENCTYPES, and asserting a position would break the moment it does.
+	var pa *types.PAData
+
+	for i := range req.PAData {
+		if req.PAData[i].PADataType == patype.PA_TGS_REQ {
+			pa = &req.PAData[i]
+
+			break
+		}
+	}
+
+	require.NotNil(t, pa, "a TGS-REQ must carry a PA-TGS-REQ entry")
+
+	var apReq APReq
+	require.NoError(t, apReq.Unmarshal(pa.PADataValue))
+
+	ab, err := crypto.DecryptEncPart(apReq.EncryptedAuthenticator, sessionKey, keyusage.TGS_REQ_PA_TGS_REQ_AP_REQ_AUTHENTICATOR)
+	require.NoError(t, err, "PA-DATA authenticator must decrypt under key usage 7 (TGS_REQ_PA_TGS_REQ_AP_REQ_AUTHENTICATOR)")
+
+	var auth types.Authenticator
+	require.NoError(t, auth.Unmarshal(ab))
+
+	return auth
+}
+
+// TestNewForwardedTGSReqShouldRequestAForwardedTGT asserts the KDC options and service name RFC 4120 Section 3.3
+// requires of a forwarding request, and mirrors what MIT's krb5_fwd_tgt_creds sends.
+func TestNewForwardedTGSReqShouldRequestAForwardedTGT(t *testing.T) {
+	t.Parallel()
+
+	c, err := config.NewFromString(testdata.KRB5_CONF)
+	require.NoError(t, err)
+
+	cname := types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{"testuser1"}}
+	key := types.EncryptionKey{KeyType: 18, KeyValue: bytes.Repeat([]byte{0x0E}, 32)}
+
+	req, err := NewForwardedTGSReq(cname, "TEST.GOKRB5", "TEST.GOKRB5", c, forwardedTGSReqTestTGT("TEST.GOKRB5"), key, nil, nil, 0)
+	require.NoError(t, err)
+
+	assert.True(t, types.IsFlagSet(&req.ReqBody.KDCOptions, flags.Forwarded), "FORWARDED requests the forwarding")
+	assert.True(t, types.IsFlagSet(&req.ReqBody.KDCOptions, flags.Forwardable),
+		"RFC 4121 Section 4.1.1: the forwarded ticket SHOULD have its forwardable flag set")
+	assert.Equal(t, []string{"krbtgt", "TEST.GOKRB5"}, req.ReqBody.SName.NameString)
+	assert.Equal(t, nametype.KRB_NT_SRV_INST, req.ReqBody.SName.NameType)
+
+	decryptForwardedAuthenticator(t, req, key)
+}
+
+// TestNewForwardedTGSReqShouldCarryOnlyTheAddressesGiven asserts addresses are the caller's decision. MIT supplies
+// them only when the source TGT itself has addresses, and this library defaults NoAddresses to true, so the
+// addressless path RFC 4120 Section 2.6 blesses is the normal one.
+func TestNewForwardedTGSReqShouldCarryOnlyTheAddressesGiven(t *testing.T) {
+	t.Parallel()
+
+	c, err := config.NewFromString(testdata.KRB5_CONF)
+	require.NoError(t, err)
+
+	cname := types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{"testuser1"}}
+	key := types.EncryptionKey{KeyType: 18, KeyValue: bytes.Repeat([]byte{0x0E}, 32)}
+
+	none, err := NewForwardedTGSReq(cname, "TEST.GOKRB5", "TEST.GOKRB5", c, forwardedTGSReqTestTGT("TEST.GOKRB5"), key, nil, nil, 0)
+	require.NoError(t, err)
+	assert.Empty(t, none.ReqBody.Addresses)
+	decryptForwardedAuthenticator(t, none, key)
+
+	addr := types.HostAddress{AddrType: addrtype.IPv4, Address: []byte{10, 0, 0, 9}}
+
+	some, err := NewForwardedTGSReq(cname, "TEST.GOKRB5", "TEST.GOKRB5", c, forwardedTGSReqTestTGT("TEST.GOKRB5"), key,
+		types.HostAddresses{addr}, nil, 0)
+	require.NoError(t, err)
+	require.Len(t, some.ReqBody.Addresses, 1)
+	assert.Equal(t, addr, some.ReqBody.Addresses[0])
+	decryptForwardedAuthenticator(t, some, key)
+}
+
+// TestNewForwardedTGSReqShouldPinTheEncryptionType asserts the MS-KILE Section 3.3.5.7.4 requirement that the
+// client "set the etype field of the TGS-REQ to the contents of the keytype field in the previous TGS-REP". The
+// forwarded ticket's session key has to be one the application server can use, and the configured default list
+// says nothing about that server.
+func TestNewForwardedTGSReqShouldPinTheEncryptionType(t *testing.T) {
+	t.Parallel()
+
+	c, err := config.NewFromString(testdata.KRB5_CONF)
+	require.NoError(t, err)
+
+	cname := types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{"testuser1"}}
+	key := types.EncryptionKey{KeyType: 18, KeyValue: bytes.Repeat([]byte{0x0E}, 32)}
+
+	pinned, err := NewForwardedTGSReq(cname, "TEST.GOKRB5", "TEST.GOKRB5", c,
+		forwardedTGSReqTestTGT("TEST.GOKRB5"), key, nil, []int32{etypeID.AES128_CTS_HMAC_SHA1_96}, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []int32{etypeID.AES128_CTS_HMAC_SHA1_96}, pinned.ReqBody.EType)
+	decryptForwardedAuthenticator(t, pinned, key)
+
+	// A nil list leaves whatever the configuration chose, which is the pre-MS-KILE behaviour and the fallback the
+	// client retries with when a KDC refuses the pinned type.
+	unpinned, err := NewForwardedTGSReq(cname, "TEST.GOKRB5", "TEST.GOKRB5", c,
+		forwardedTGSReqTestTGT("TEST.GOKRB5"), key, nil, nil, 0)
+	require.NoError(t, err)
+	assert.Equal(t, c.LibDefaults.DefaultTGSEnctypeIDs, unpinned.ReqBody.EType)
+	assert.NotEqual(t, []int32{etypeID.AES128_CTS_HMAC_SHA1_96}, unpinned.ReqBody.EType)
+}
+
+// TestNewForwardedTGSReqShouldAdvertiseSupportedEncryptionTypes asserts the PA-SUPPORTED-ENCTYPES entry is
+// appended alongside the PA-TGS-REQ that setPAData installs, rather than replacing it. Losing the PA-TGS-REQ would
+// make the request unauthenticated and the KDC would reject it outright.
+func TestNewForwardedTGSReqShouldAdvertiseSupportedEncryptionTypes(t *testing.T) {
+	t.Parallel()
+
+	c, err := config.NewFromString(testdata.KRB5_CONF)
+	require.NoError(t, err)
+
+	cname := types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{"testuser1"}}
+	key := types.EncryptionKey{KeyType: 18, KeyValue: bytes.Repeat([]byte{0x0E}, 32)}
+	supported := types.NewSupportedETypesFromIDs([]int32{etypeID.AES256_CTS_HMAC_SHA1_96, etypeID.RC4_HMAC})
+
+	req, err := NewForwardedTGSReq(cname, "TEST.GOKRB5", "TEST.GOKRB5", c,
+		forwardedTGSReqTestTGT("TEST.GOKRB5"), key, nil, nil, supported)
+	require.NoError(t, err)
+
+	require.True(t, req.PAData.Contains(patype.PA_TGS_REQ), "the authenticating PA-TGS-REQ must survive")
+	require.True(t, req.PAData.Contains(patype.PA_SUPPORTED_ETYPES))
+
+	assert.Equal(t, supported, types.SupportedETypesFromPAData(req.PAData))
+	decryptForwardedAuthenticator(t, req, key)
+
+	// Nothing is advertised when nothing is known, rather than an empty advertisement claiming no common type.
+	none, err := NewForwardedTGSReq(cname, "TEST.GOKRB5", "TEST.GOKRB5", c,
+		forwardedTGSReqTestTGT("TEST.GOKRB5"), key, nil, nil, 0)
+	require.NoError(t, err)
+	assert.False(t, none.PAData.Contains(patype.PA_SUPPORTED_ETYPES))
+	assert.True(t, none.PAData.Contains(patype.PA_TGS_REQ))
 }

--- a/messages/krb_cred.go
+++ b/messages/krb_cred.go
@@ -6,7 +6,10 @@ import (
 
 	"github.com/go-krb5/x/encoding/asn1"
 
+	"github.com/go-krb5/krb5/asn1tools"
+	"github.com/go-krb5/krb5/credentials"
 	"github.com/go-krb5/krb5/crypto"
+	"github.com/go-krb5/krb5/iana"
 	"github.com/go-krb5/krb5/iana/asn1apptag"
 	"github.com/go-krb5/krb5/iana/keyusage"
 	"github.com/go-krb5/krb5/iana/msgtype"
@@ -55,6 +58,84 @@ type KrbCredInfo struct {
 	CAddr     types.HostAddresses `asn1:"optional,explicit,tag:10"`
 }
 
+// NewKRBCred builds a KRB_CRED conveying the tickets given, with info[i] describing tkts[i] as RFC 4120 Section
+// 5.8.1 requires: "Successive tickets are paired with the corresponding KrbCredInfo sequence from the enc-part".
+//
+// The EncKrbCredPart is encrypted under key with key usage 14, per RFC 4120 Section 5.8.1. For the GSS-API
+// delegation of RFC 4121 Section 4.1.1 that key is the session key of the ticket authenticating the context.
+func NewKRBCred(tkts []Ticket, info []KrbCredInfo, key types.EncryptionKey) (KRBCred, error) {
+	var k KRBCred
+
+	if len(tkts) != len(info) {
+		return k, krberror.NewErrorf(krberror.KRBMsgError,
+			"KRB_CRED carries %d tickets and %d KrbCredInfo entries; they must correspond", len(tkts), len(info))
+	}
+
+	denc := EncKrbCredPart{TicketInfo: info}
+
+	b, err := denc.Marshal()
+	if err != nil {
+		return k, krberror.Errorf(err, krberror.EncodingError, "error marshalling EncKrbCredPart")
+	}
+
+	ed, err := crypto.GetEncryptedData(b, key, keyusage.KRB_CRED_ENCPART, 0)
+	if err != nil {
+		return k, krberror.Errorf(err, krberror.EncryptingError, "error encrypting KRB_CRED EncPart")
+	}
+
+	return KRBCred{
+		PVNO:             iana.PVNO,
+		MsgType:          msgtype.KRB_CRED,
+		Tickets:          tkts,
+		EncPart:          ed,
+		DecryptedEncPart: denc,
+	}, nil
+}
+
+// NewKrbCredInfo builds the KrbCredInfo describing a ticket obtained from a KDC exchange. RFC 4120 Section 5.8.1
+// defines these fields as "the values of the corresponding fields from the ticket found in the ticket field", with
+// prealm and pname naming "the delegated principal identity".
+func NewKrbCredInfo(dep EncKDCRepPart, cname types.PrincipalName, crealm string) KrbCredInfo {
+	return KrbCredInfo{
+		Key:       dep.Key,
+		PRealm:    crealm,
+		PName:     cname,
+		Flags:     dep.Flags,
+		AuthTime:  dep.AuthTime,
+		StartTime: dep.StartTime,
+		EndTime:   dep.EndTime,
+		RenewTill: dep.RenewTill,
+		SRealm:    dep.SRealm,
+		SName:     dep.SName,
+		CAddr:     types.HostAddresses(dep.CAddr),
+	}
+}
+
+// Marshal the KRB_CRED.
+func (k *KRBCred) Marshal() ([]byte, error) {
+	m := marshalKRBCred{
+		PVNO:    k.PVNO,
+		MsgType: k.MsgType,
+		EncPart: k.EncPart,
+	}
+
+	var err error
+
+	if m.Tickets, err = MarshalTicketSequence(k.Tickets); err != nil {
+		return nil, krberror.Errorf(err, krberror.EncodingError, "error marshalling tickets within KRB_CRED")
+	}
+	// MarshalTicketSequence does not set Tag: it must match this field's explicit tag number, as
+	// KDCReqBody.Marshal does for AdditionalTickets.
+	m.Tickets.Tag = 2
+
+	b, err := asn1.Marshal(m, asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
+	if err != nil {
+		return nil, krberror.Errorf(err, krberror.EncodingError, "error marshalling KRB_CRED")
+	}
+
+	return asn1tools.AddASNAppTag(b, asn1apptag.KRBCred), nil
+}
+
 // Unmarshal bytes b into the KRBCred struct.
 func (k *KRBCred) Unmarshal(b []byte) error {
 	var m marshalKRBCred
@@ -84,22 +165,87 @@ func (k *KRBCred) Unmarshal(b []byte) error {
 }
 
 // DecryptEncPart decrypts the encrypted part of a KRB_CRED.
+//
+// An EncPart whose EType is zero is not encrypted and its Cipher field is the EncKrbCredPart itself. RFC 4120
+// Section 5.8.1 records that some GSS-API mechanism implementations send it that way, and that this is not a
+// vulnerability because the whole KRB_CRED is already inside an encrypted message. This library accepts that form
+// and never emits it.
 func (k *KRBCred) DecryptEncPart(key types.EncryptionKey) error {
-	b, err := crypto.DecryptEncPart(k.EncPart, key, keyusage.KRB_CRED_ENCPART)
-	if err != nil {
-		return krberror.Errorf(err, krberror.DecryptingError, "error decrypting KRB_CRED EncPart")
+	b := k.EncPart.Cipher
+
+	if k.EncPart.EType != 0 {
+		var err error
+
+		if b, err = crypto.DecryptEncPart(k.EncPart, key, keyusage.KRB_CRED_ENCPART); err != nil {
+			return krberror.Errorf(err, krberror.DecryptingError, "error decrypting KRB_CRED EncPart")
+		}
 	}
 
 	var denc EncKrbCredPart
 
-	err = denc.Unmarshal(b)
-	if err != nil {
+	if err := denc.Unmarshal(b); err != nil {
 		return krberror.Errorf(err, krberror.EncodingError, "error unmarshalling encrypted part of KRB_CRED")
 	}
 
 	k.DecryptedEncPart = denc
 
 	return nil
+}
+
+// CCache converts a decrypted KRB_CRED into a version 4 credential cache, which client.NewFromCCache accepts. Call
+// DecryptEncPart first.
+//
+// The default principal is taken from the first KrbCredInfo's pname and prealm, which RFC 4120 Section 5.8.1 names
+// as "the delegated principal identity".
+func (k *KRBCred) CCache() (*credentials.CCache, error) {
+	info := k.DecryptedEncPart.TicketInfo
+
+	if len(info) == 0 {
+		return nil, krberror.NewErrorf(krberror.KRBMsgError, "KRB_CRED conveys no credentials")
+	}
+
+	if len(k.Tickets) != len(info) {
+		return nil, krberror.NewErrorf(krberror.KRBMsgError,
+			"KRB_CRED carries %d tickets and %d KrbCredInfo entries; they must correspond", len(k.Tickets), len(info))
+	}
+
+	cc := credentials.NewV4CCache()
+	cc.SetDefaultPrincipal(credentials.NewPrincipal(info[0].PName, info[0].PRealm))
+
+	for i, in := range info {
+		b, err := k.Tickets[i].Marshal()
+		if err != nil {
+			return nil, krberror.Errorf(err, krberror.EncodingError, "error marshalling ticket %d of KRB_CRED", i+1)
+		}
+
+		cc.AddCredential(&credentials.Credential{
+			Client:      credentials.NewPrincipal(in.PName, in.PRealm),
+			Server:      credentials.NewPrincipal(in.SName, in.SRealm),
+			Key:         in.Key,
+			AuthTime:    in.AuthTime,
+			StartTime:   in.StartTime,
+			EndTime:     in.EndTime,
+			RenewTill:   in.RenewTill,
+			TicketFlags: in.Flags,
+			Addresses:   []types.HostAddress(in.CAddr),
+			Ticket:      b,
+		})
+	}
+
+	return cc, nil
+}
+
+// Marshal the encrypted part of a KRB_CRED.
+//
+// The optional nonce, timestamp, usec, s-address and r-address fields of RFC 4120 Section 5.8.1 are omitted when
+// unset: the asn1 encoder drops an optional field at its zero value.
+func (k *EncKrbCredPart) Marshal() ([]byte, error) {
+	b, err := asn1.Marshal(*k, asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
+	if err != nil {
+		return nil, krberror.Errorf(err, krberror.EncodingError, "error marshalling EncKrbCredPart")
+	}
+
+	return asn1tools.AddASNAppTag(b, asn1apptag.EncKrbCredPart), nil
 }
 
 // Unmarshal bytes b into the encrypted part of KRB_CRED.

--- a/messages/krb_cred_test.go
+++ b/messages/krb_cred_test.go
@@ -1,6 +1,7 @@
 package messages
 
 import (
+	"bytes"
 	"encoding/hex"
 	"testing"
 	"time"
@@ -8,11 +9,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-krb5/x/encoding/asn1"
+
+	"github.com/go-krb5/krb5/crypto"
 	"github.com/go-krb5/krb5/iana"
 	"github.com/go-krb5/krb5/iana/addrtype"
+	"github.com/go-krb5/krb5/iana/keyusage"
 	"github.com/go-krb5/krb5/iana/msgtype"
 	"github.com/go-krb5/krb5/iana/nametype"
 	"github.com/go-krb5/krb5/test/testdata"
+	"github.com/go-krb5/krb5/types"
 )
 
 func TestUnmarshalKRBCred(t *testing.T) {
@@ -130,4 +136,222 @@ func TestUnmarshalEncCredPart_optionalsNULL(t *testing.T) {
 		assert.Equal(t, addrtype.IPv4, addr.AddrType)
 		assert.Equal(t, "12d00023", hex.EncodeToString(addr.Address))
 	}
+}
+
+// testCredKey returns a deterministic aes256-cts-hmac-sha1-96 key for KRB_CRED round trips.
+func testCredKey() types.EncryptionKey {
+	return types.EncryptionKey{KeyType: 18, KeyValue: bytes.Repeat([]byte{0x0B}, 32)}
+}
+
+// testKrbCredInfo returns a KrbCredInfo with every field this library populates set to a distinguishable value.
+func testKrbCredInfo() KrbCredInfo {
+	return KrbCredInfo{
+		Key:      types.EncryptionKey{KeyType: 18, KeyValue: bytes.Repeat([]byte{0x0C}, 32)},
+		PRealm:   "TEST.GOKRB5",
+		PName:    types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{"testuser1"}},
+		SRealm:   "TEST.GOKRB5",
+		SName:    types.PrincipalName{NameType: nametype.KRB_NT_SRV_INST, NameString: []string{"krbtgt", "TEST.GOKRB5"}},
+		EndTime:  time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+		AuthTime: time.Date(2026, 8, 9, 10, 0, 0, 0, time.UTC),
+	}
+}
+
+// TestKRBCredShouldRoundTrip asserts a KRB_CRED this library builds can be read back by the unmarshalling that
+// already existed, which is the only in-tree evidence that the encoding is right.
+func TestKRBCredShouldRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	key := testCredKey()
+	info := testKrbCredInfo()
+	tkt := Ticket{TktVNO: iana.PVNO, Realm: info.SRealm, SName: info.SName}
+
+	cred, err := NewKRBCred([]Ticket{tkt}, []KrbCredInfo{info}, key)
+	require.NoError(t, err)
+
+	assert.Equal(t, msgtype.KRB_CRED, cred.MsgType)
+	assert.Equal(t, iana.PVNO, cred.PVNO)
+
+	b, err := cred.Marshal()
+	require.NoError(t, err)
+
+	var out KRBCred
+
+	require.NoError(t, out.Unmarshal(b))
+	require.NoError(t, out.DecryptEncPart(key))
+
+	require.Len(t, out.DecryptedEncPart.TicketInfo, 1)
+	got := out.DecryptedEncPart.TicketInfo[0]
+	assert.Equal(t, info.PRealm, got.PRealm)
+	assert.Equal(t, info.PName, got.PName)
+	assert.Equal(t, info.SRealm, got.SRealm)
+	assert.Equal(t, info.SName, got.SName)
+	assert.Equal(t, info.Key, got.Key)
+	assert.True(t, info.EndTime.Equal(got.EndTime))
+}
+
+// TestKRBCredEncPartShouldUseKeyUsage14 asserts RFC 4120 Section 5.8.1: the enc-part is "encrypted under the
+// session key shared by the sender and the intended recipient, with a key usage value of 14". A different usage
+// would still round trip through our own code and fail against every other implementation.
+func TestKRBCredEncPartShouldUseKeyUsage14(t *testing.T) {
+	t.Parallel()
+
+	key := testCredKey()
+	info := testKrbCredInfo()
+	tkt := Ticket{TktVNO: iana.PVNO, Realm: info.SRealm, SName: info.SName}
+
+	cred, err := NewKRBCred([]Ticket{tkt}, []KrbCredInfo{info}, key)
+	require.NoError(t, err)
+
+	_, err = crypto.DecryptEncPart(cred.EncPart, key, keyusage.KRB_CRED_ENCPART)
+	require.NoError(t, err)
+
+	_, err = crypto.DecryptEncPart(cred.EncPart, key, keyusage.KRB_PRIV_ENCPART)
+	require.Error(t, err, "decrypting under the wrong usage must fail, proving the usage is not incidental")
+}
+
+// TestEncKrbCredPartShouldOmitTheOptionalFields asserts nonce, timestamp, usec, s-address and r-address are absent
+// when unset. They are OPTIONAL in RFC 4120 Section 5.8.1, and MIT clears KRB5_AUTH_CONTEXT_DO_TIME on both sides
+// of the GSS forwarding path, so emitting a timestamp buys no freshness check any peer performs while risking a
+// clock skew rejection.
+func TestEncKrbCredPartShouldOmitTheOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	p := &EncKrbCredPart{TicketInfo: []KrbCredInfo{testKrbCredInfo()}}
+
+	b, err := p.Marshal()
+	require.NoError(t, err)
+
+	var out EncKrbCredPart
+
+	require.NoError(t, out.Unmarshal(b))
+	assert.Zero(t, out.Nouce)
+	assert.True(t, out.Timestamp.IsZero())
+	assert.Zero(t, out.Usec)
+	assert.Empty(t, out.SAddress.Address)
+	assert.Empty(t, out.RAddress.Address)
+}
+
+// TestKRBCredDecryptEncPartShouldAcceptAnUnencryptedEncPart covers the RFC 4120 Section 5.8.1 implementation note:
+// "Implementations of certain applications, most notably certain implementations of the Kerberos GSS-API
+// mechanism, do not separately encrypt the contents of the EncKrbCredPart". No confidentiality is lost because the
+// whole message travels inside the already encrypted authenticator. We accept this and never emit it.
+func TestKRBCredDecryptEncPartShouldAcceptAnUnencryptedEncPart(t *testing.T) {
+	t.Parallel()
+
+	info := testKrbCredInfo()
+
+	plain, err := (&EncKrbCredPart{TicketInfo: []KrbCredInfo{info}}).Marshal()
+	require.NoError(t, err)
+
+	cred := KRBCred{EncPart: types.EncryptedData{EType: 0, Cipher: plain}}
+
+	require.NoError(t, cred.DecryptEncPart(testCredKey()))
+	require.Len(t, cred.DecryptedEncPart.TicketInfo, 1)
+	assert.Equal(t, info.PName, cred.DecryptedEncPart.TicketInfo[0].PName)
+}
+
+// TestKRBCredDecryptEncPartShouldRejectAShortCipher pins the acceptor side of the delegation path against a peer
+// that sends a KRB_CRED whose EncPart declares a real encryption type over a few bytes of Cipher. Any client
+// holding a valid service ticket can send one, and the ciphertext used to be sliced to strip its integrity hash
+// with no length check, panicking the acceptor process. Found by fuzzing.
+func TestKRBCredDecryptEncPartShouldRejectAShortCipher(t *testing.T) {
+	t.Parallel()
+
+	for _, etype := range []int32{17, 18, 19, 20} {
+		cred := KRBCred{EncPart: types.EncryptedData{EType: etype, Cipher: []byte{1, 2, 3, 4, 5, 6}}}
+
+		assert.NotPanics(t, func() {
+			err := cred.DecryptEncPart(testCredKey())
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "too short")
+		}, "etype %d must reject a six byte cipher with an error, not a panic", etype)
+	}
+}
+
+// TestNewKrbCredInfoShouldCopyTheTicketFields asserts the KrbCredInfo mirrors the TGS_REP, as RFC 4120 Section
+// 5.8.1 requires: "These fields contain the values of the corresponding fields from the ticket found in the ticket
+// field."
+func TestNewKrbCredInfoShouldCopyTheTicketFields(t *testing.T) {
+	t.Parallel()
+
+	cname := types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{"testuser1"}}
+	dep := EncKDCRepPart{
+		Key:      types.EncryptionKey{KeyType: 18, KeyValue: bytes.Repeat([]byte{0x0D}, 32)},
+		Flags:    asn1.BitString{Bytes: []byte{0x40, 0x00, 0x00, 0x00}, BitLength: 32},
+		AuthTime: time.Date(2026, 8, 9, 10, 0, 0, 0, time.UTC),
+		EndTime:  time.Date(2026, 8, 9, 20, 0, 0, 0, time.UTC),
+		SRealm:   "TEST.GOKRB5",
+		SName:    types.PrincipalName{NameType: nametype.KRB_NT_SRV_INST, NameString: []string{"krbtgt", "TEST.GOKRB5"}},
+	}
+
+	info := NewKrbCredInfo(dep, cname, "TEST.GOKRB5")
+
+	assert.Equal(t, dep.Key, info.Key)
+	assert.Equal(t, dep.Flags, info.Flags)
+	assert.Equal(t, dep.SRealm, info.SRealm)
+	assert.Equal(t, dep.SName, info.SName)
+	assert.Equal(t, cname, info.PName)
+	assert.Equal(t, "TEST.GOKRB5", info.PRealm)
+	assert.True(t, dep.EndTime.Equal(info.EndTime))
+}
+
+// TestKRBCredCCacheShouldPairTicketsWithTheirInfo asserts the conversion an acceptor uses to turn a delegated
+// credential into something client.NewFromCCache can consume.
+func TestKRBCredCCacheShouldPairTicketsWithTheirInfo(t *testing.T) {
+	t.Parallel()
+
+	info := testKrbCredInfo()
+	tkt := Ticket{
+		TktVNO: iana.PVNO,
+		Realm:  info.SRealm,
+		SName:  info.SName,
+	}
+
+	cred, err := NewKRBCred([]Ticket{tkt}, []KrbCredInfo{info}, testCredKey())
+	require.NoError(t, err)
+
+	cc, err := cred.CCache()
+	require.NoError(t, err)
+
+	assert.Equal(t, uint8(4), cc.Version)
+	assert.Equal(t, info.PName, cc.GetClientPrincipalName())
+	assert.Equal(t, info.PRealm, cc.GetClientRealm())
+
+	require.Len(t, cc.Credentials, 1)
+	got := cc.Credentials[0]
+	assert.Equal(t, info.Key, got.Key)
+	assert.Equal(t, info.SName, got.Server.PrincipalName)
+	assert.Equal(t, info.SRealm, got.Server.Realm)
+	assert.True(t, info.EndTime.Equal(got.EndTime))
+	assert.NotEmpty(t, got.Ticket, "the marshalled ticket must be carried so the cache is usable")
+}
+
+// TestKRBCredCCacheShouldRejectAMismatchedCount asserts the pairing RFC 4120 Section 5.8.1 requires is checked
+// rather than assumed. A KRB_CRED from a peer can carry any counts at all.
+func TestKRBCredCCacheShouldRejectAMismatchedCount(t *testing.T) {
+	t.Parallel()
+
+	cred := KRBCred{
+		Tickets:          []Ticket{{Realm: "TEST.GOKRB5"}, {Realm: "TEST.GOKRB5"}},
+		DecryptedEncPart: EncKrbCredPart{TicketInfo: []KrbCredInfo{testKrbCredInfo()}},
+	}
+
+	cc, err := cred.CCache()
+
+	require.Error(t, err)
+	assert.Nil(t, cc)
+	assert.Contains(t, err.Error(), "they must correspond")
+}
+
+// TestKRBCredCCacheShouldRejectAnEmptyCredential asserts a KRB_CRED conveying nothing is an error rather than an
+// empty cache, which a caller would otherwise use as though a delegation had happened.
+func TestKRBCredCCacheShouldRejectAnEmptyCredential(t *testing.T) {
+	t.Parallel()
+
+	cc, err := (&KRBCred{}).CCache()
+
+	require.Error(t, err)
+	assert.Nil(t, cc)
+	assert.Contains(t, err.Error(), "no credentials")
 }

--- a/service/ap_exchange.go
+++ b/service/ap_exchange.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"crypto/hmac"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/go-krb5/krb5/iana/chksumtype"
 	"github.com/go-krb5/krb5/iana/errorcode"
 	"github.com/go-krb5/krb5/messages"
+	"github.com/go-krb5/krb5/types"
 )
 
 // VerifyAPREQ verifies an AP_REQ sent to the service. Returns a boolean for if the AP_REQ is valid and the client's principal name and realm.
@@ -46,6 +46,10 @@ func VerifyAPREQ(APReq *messages.APReq, s *Settings) (bool, *credentials.Credent
 	creds.SetAuthTime(time.Now().UTC())
 	creds.SetAuthenticated(true)
 	creds.SetValidUntil(APReq.Ticket.DecryptedEncPart.EndTime)
+
+	if err = extractDelegatedCredential(APReq, creds); err != nil {
+		return false, creds, err
+	}
 
 	// PAC decoding.
 	if !s.disablePACDecoding {
@@ -108,14 +112,6 @@ func newBadChannelBindingError(APReq *messages.APReq, etext string) error {
 	}
 }
 
-// authenticatorChksumBndLgth is the value RFC 4121 Section 4.1.1 fixes in the four octet little-endian Lgth field at
-// the start of the GSS-API authenticator checksum: the width of the Bnd field that follows it.
-const authenticatorChksumBndLgth = 16
-
-// authenticatorChksumMinLen is the smallest GSS-API authenticator checksum RFC 4121 Section 4.1.1 describes, holding
-// Lgth, Bnd and Flags. The delegation and extension fields beyond it are optional.
-const authenticatorChksumMinLen = 24
-
 // verifyChannelBinding compares the Bnd field of the AP_REQ authenticator's GSS-API checksum against the channel
 // binding the service requires, as described by RFC 4121 Section 4.1.1. The comparison is constant time.
 //
@@ -129,20 +125,133 @@ const authenticatorChksumMinLen = 24
 func verifyChannelBinding(APReq *messages.APReq, cb *gssapi.ChannelBinding) error {
 	cksum := APReq.Authenticator.Cksum.Checksum
 
-	if APReq.Authenticator.Cksum.CksumType != chksumtype.GSSAPI || len(cksum) < authenticatorChksumMinLen {
+	if APReq.Authenticator.Cksum.CksumType != chksumtype.GSSAPI || len(cksum) < gssapi.ChecksumMinLen {
 		return newBadChannelBindingError(APReq, "authenticator does not contain a GSSAPI checksum carrying channel bindings")
 	}
 
-	if lgth := binary.LittleEndian.Uint32(cksum[:4]); lgth != authenticatorChksumBndLgth {
-		return newBadChannelBindingError(APReq, fmt.Sprintf(
-			"authenticator GSSAPI checksum declares a Bnd length of %d rather than %d", lgth, authenticatorChksumBndLgth))
+	var c gssapi.AuthenticatorChecksum
+
+	if err := c.Unmarshal(cksum); err != nil {
+		var lgth gssapi.ChecksumLgthError
+		if errors.As(err, &lgth) {
+			return newBadChannelBindingError(APReq, fmt.Sprintf("authenticator GSSAPI checksum %s", lgth.Error()))
+		}
+
+		return newBadChannelBindingError(APReq, fmt.Sprintf("authenticator GSSAPI checksum could not be read: %s", err.Error()))
 	}
 
 	expected := cb.Bnd()
 
-	if !hmac.Equal(cksum[4:20], expected[:]) {
+	if !hmac.Equal(c.Bnd[:], expected[:]) {
 		return newBadChannelBindingError(APReq, "channel binding mismatch")
 	}
 
 	return nil
+}
+
+// ErrBadDelegation identifies a failure to accept a credential a client delegated in its AP_REQ. RFC 4121 Section
+// 4.1.1 makes the delegation fields present if and only if GSS_C_DELEG_FLAG is set, so a request that claims a
+// delegation this service cannot read is defective rather than merely unhelpful: an acceptor has no way to tell the
+// initiator that its forwarded ticket was discarded. Callers translating an AP_REQ failure into a GSS-API status
+// match against this with errors.Is.
+var ErrBadDelegation = errors.New("bad delegated credential")
+
+// badDelegationError joins ErrBadDelegation to the KRB_ERROR describing the failure. Both are exposed through
+// Unwrap so that a caller can classify the failure with errors.Is and still recover the KRB_ERROR to send on the
+// wire with errors.As. KRB_AP_ERR_INAPP_CKSUM is the wire error because the defect is in the authenticator's
+// checksum.
+type badDelegationError struct {
+	krberr messages.KRBError
+}
+
+// Error returns the description of the underlying KRB_ERROR.
+func (e badDelegationError) Error() string {
+	return e.krberr.Error()
+}
+
+// Unwrap exposes the sentinel and the KRB_ERROR.
+func (e badDelegationError) Unwrap() []error {
+	return []error{ErrBadDelegation, e.krberr}
+}
+
+// newBadDelegationError builds the error returned when a delegated credential cannot be accepted.
+func newBadDelegationError(APReq *messages.APReq, etext string) error {
+	return badDelegationError{
+		krberr: messages.NewKRBError(APReq.Ticket.SName, APReq.Ticket.Realm, errorcode.KRB_AP_ERR_INAPP_CKSUM, etext),
+	}
+}
+
+// extractDelegatedCredential reads the KRB_CRED a client delegated in the Deleg field of the AP_REQ authenticator's
+// GSS-API checksum, as described by RFC 4121 Section 4.1.1, and attaches it to creds.
+//
+// An AP_REQ that does not claim delegation, or whose checksum cannot be interpreted at all, is left alone: a
+// checksum whose Lgth moves every field after Bnd is one in which Flags cannot be located, so whether delegation
+// was requested is unknowable and reporting a delegation failure would be a guess. Once delegation is claimed,
+// every defect is fatal.
+//
+// The credential is decrypted with the authenticator's subkey when it carries one, falling back to the ticket
+// session key. RFC 4121 Section 4.1.1 requires initiators to use the session key and this library does, but MIT's
+// rd_cred.c accepts either and peers exist that send the subkey.
+func extractDelegatedCredential(APReq *messages.APReq, creds *credentials.Credentials) error {
+	cksum := APReq.Authenticator.Cksum.Checksum
+
+	if APReq.Authenticator.Cksum.CksumType != chksumtype.GSSAPI || len(cksum) < gssapi.ChecksumMinLen {
+		return nil
+	}
+
+	var c gssapi.AuthenticatorChecksum
+
+	if err := c.Unmarshal(cksum); err != nil {
+		var lgth gssapi.ChecksumLgthError
+		if errors.As(err, &lgth) {
+			return nil
+		}
+
+		return newBadDelegationError(APReq, fmt.Sprintf("authenticator GSSAPI checksum %s", err.Error()))
+	}
+
+	if !c.Delegated() {
+		return nil
+	}
+
+	var cred messages.KRBCred
+
+	if err := cred.Unmarshal(c.Deleg); err != nil {
+		return newBadDelegationError(APReq, fmt.Sprintf("delegated credential could not be read: %s", err.Error()))
+	}
+
+	if err := decryptDelegatedCredential(&cred, APReq); err != nil {
+		return newBadDelegationError(APReq, err.Error())
+	}
+
+	cc, err := cred.CCache()
+	if err != nil {
+		return newBadDelegationError(APReq, fmt.Sprintf("delegated credential could not be used: %s", err.Error()))
+	}
+
+	creds.SetDelegatedCredentials(cc)
+
+	return nil
+}
+
+// decryptDelegatedCredential decrypts the KRB_CRED with the authenticator subkey if one is present, falling back to
+// the ticket session key, mirroring MIT's rd_cred.c.
+func decryptDelegatedCredential(cred *messages.KRBCred, APReq *messages.APReq) error {
+	keys := make([]types.EncryptionKey, 0, 2)
+
+	if len(APReq.Authenticator.SubKey.KeyValue) > 0 {
+		keys = append(keys, APReq.Authenticator.SubKey)
+	}
+
+	keys = append(keys, APReq.Ticket.DecryptedEncPart.Key)
+
+	var err error
+
+	for _, key := range keys {
+		if err = cred.DecryptEncPart(key); err == nil {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("could not decrypt the delegated credential with the authenticator subkey or the ticket session key: %w", err)
 }

--- a/service/ap_exchange_test.go
+++ b/service/ap_exchange_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/hex"
 	"testing"
@@ -685,6 +686,240 @@ func TestSettingsRequireChannelBindingShouldRoundTrip(t *testing.T) {
 	cb := &gssapi.ChannelBinding{ApplicationData: []byte("tls-exporter:test")}
 
 	assert.Same(t, cb, NewSettings(nil, RequireChannelBinding(cb)).RequireChannelBinding())
+}
+
+// testDelegatedAPReq builds an AP_REQ carrying a KRB_CRED for the principal given, encrypted under key, in the
+// Deleg field of its RFC 4121 Section 4.1.1 checksum.
+func testDelegatedAPReq(t *testing.T, cname types.PrincipalName, crealm string, key types.EncryptionKey, subkey types.EncryptionKey) *messages.APReq {
+	t.Helper()
+
+	info := messages.KrbCredInfo{
+		Key:     types.EncryptionKey{KeyType: 18, KeyValue: bytes.Repeat([]byte{0x0C}, 32)},
+		PRealm:  crealm,
+		PName:   cname,
+		SRealm:  crealm,
+		SName:   types.PrincipalName{NameType: nametype.KRB_NT_SRV_INST, NameString: []string{"krbtgt", crealm}},
+		EndTime: time.Now().UTC().Add(time.Hour),
+	}
+	tkt := messages.Ticket{TktVNO: 5, Realm: crealm, SName: info.SName}
+
+	credKey := key
+	if len(subkey.KeyValue) > 0 {
+		credKey = subkey
+	}
+
+	cred, err := messages.NewKRBCred([]messages.Ticket{tkt}, []messages.KrbCredInfo{info}, credKey)
+	require.NoError(t, err)
+
+	deleg, err := cred.Marshal()
+	require.NoError(t, err)
+
+	cksum, err := (&gssapi.AuthenticatorChecksum{Deleg: deleg}).Marshal()
+	require.NoError(t, err)
+
+	return &messages.APReq{
+		Ticket: messages.Ticket{
+			Realm:            crealm,
+			SName:            types.PrincipalName{NameType: 1, NameString: []string{"HTTP", "host.test.gokrb5"}},
+			DecryptedEncPart: messages.EncTicketPart{Key: key},
+		},
+		Authenticator: types.Authenticator{
+			Cksum:  types.Checksum{CksumType: chksumtype.GSSAPI, Checksum: cksum},
+			SubKey: subkey,
+		},
+	}
+}
+
+// TestExtractDelegatedCredentialShouldDecryptWithTheSessionKey asserts the key RFC 4121 Section 4.1.1 mandates:
+// "The EncryptedData field of the KRB_CRED message MUST be encrypted in the session key of the ticket used to
+// authenticate the context."
+func TestExtractDelegatedCredentialShouldDecryptWithTheSessionKey(t *testing.T) {
+	t.Parallel()
+
+	key := types.EncryptionKey{KeyType: 18, KeyValue: bytes.Repeat([]byte{0x0B}, 32)}
+	cname := types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{"testuser1"}}
+
+	creds := credentials.NewFromPrincipalName(cname, "TEST.GOKRB5")
+
+	require.NoError(t, extractDelegatedCredential(testDelegatedAPReq(t, cname, "TEST.GOKRB5", key, types.EncryptionKey{}), creds))
+
+	cc, ok := creds.DelegatedCredentials()
+	require.True(t, ok)
+	assert.Equal(t, cname, cc.GetClientPrincipalName())
+	require.Len(t, cc.Credentials, 1)
+}
+
+// TestExtractDelegatedCredentialShouldFallBackToTheSubkey asserts we accept a peer that encrypts with the
+// authenticator subkey. MIT's rd_cred.c tries the receiving subkey first and falls back to the session key, so
+// tolerating both is what interoperating means here even though we always send the session key.
+func TestExtractDelegatedCredentialShouldFallBackToTheSubkey(t *testing.T) {
+	t.Parallel()
+
+	key := types.EncryptionKey{KeyType: 18, KeyValue: bytes.Repeat([]byte{0x0B}, 32)}
+	subkey := types.EncryptionKey{KeyType: 18, KeyValue: bytes.Repeat([]byte{0x0F}, 32)}
+	cname := types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{"testuser1"}}
+
+	creds := credentials.NewFromPrincipalName(cname, "TEST.GOKRB5")
+
+	require.NoError(t, extractDelegatedCredential(testDelegatedAPReq(t, cname, "TEST.GOKRB5", key, subkey), creds))
+
+	_, ok := creds.DelegatedCredentials()
+	assert.True(t, ok)
+}
+
+// TestExtractDelegatedCredentialShouldIgnoreARequestWithoutDelegation asserts the ordinary path costs nothing and
+// sets nothing.
+func TestExtractDelegatedCredentialShouldIgnoreARequestWithoutDelegation(t *testing.T) {
+	t.Parallel()
+
+	creds := credentials.New("testuser1", "TEST.GOKRB5")
+
+	require.NoError(t, extractDelegatedCredential(testAPReqWithChecksum(chksumtype.GSSAPI, testGSSAPIChecksum(nil)), creds))
+
+	_, ok := creds.DelegatedCredentials()
+	assert.False(t, ok)
+}
+
+// TestExtractDelegatedCredentialShouldIgnoreAnUninterpretableChecksum asserts a checksum whose Lgth moves every
+// field is not treated as a delegation failure. The parser cannot locate Flags, so it cannot know delegation was
+// claimed; reporting a delegation error would be a guess. This is also the property that keeps AP_REQs which
+// succeed today succeeding.
+func TestExtractDelegatedCredentialShouldIgnoreAnUninterpretableChecksum(t *testing.T) {
+	t.Parallel()
+
+	cksum := testGSSAPIChecksum(nil)
+	binary.LittleEndian.PutUint32(cksum[:4], 8)
+
+	creds := credentials.New("testuser1", "TEST.GOKRB5")
+
+	require.NoError(t, extractDelegatedCredential(testAPReqWithChecksum(chksumtype.GSSAPI, cksum), creds))
+
+	_, ok := creds.DelegatedCredentials()
+	assert.False(t, ok)
+}
+
+// TestExtractDelegatedCredentialShouldRejectABrokenDelegation asserts that a checksum which claims a delegation and
+// then fails to deliver one is fatal. An acceptor has no ret_flags channel on which to tell the initiator that its
+// credential was discarded, so continuing would leave the initiator believing a delegation happened.
+func TestExtractDelegatedCredentialShouldRejectABrokenDelegation(t *testing.T) {
+	t.Parallel()
+
+	key := types.EncryptionKey{KeyType: 18, KeyValue: bytes.Repeat([]byte{0x0B}, 32)}
+	cname := types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{"testuser1"}}
+
+	for _, tc := range []struct {
+		name    string
+		mutate  func(*messages.APReq)
+		wantMsg string
+	}{
+		{
+			name:    "WrongDlgOpt",
+			mutate:  func(r *messages.APReq) { binary.LittleEndian.PutUint16(r.Authenticator.Cksum.Checksum[24:26], 2) },
+			wantMsg: "delegation option identifier",
+		},
+		{
+			name: "UndecryptableCredential",
+			mutate: func(r *messages.APReq) {
+				r.Ticket.DecryptedEncPart.Key = types.EncryptionKey{KeyType: 18, KeyValue: bytes.Repeat([]byte{0x01}, 32)}
+			},
+			wantMsg: "could not decrypt",
+		},
+		{
+			// The last octet falls inside the HMAC that AES256-CTS-HMAC-SHA1-96 appends to the ciphertext, so
+			// flipping it reliably fails the integrity check regardless of how large the fixture's KRB_CRED is.
+			// An earlier fixed offset (such as 30) landed inside the outer KRB_CRED length octets instead, which
+			// this library's ASN.1 codec does not validate against the buffer size, so corrupting it changed
+			// nothing and the test passed the corrupted credential through undetected.
+			name: "CorruptCredential",
+			mutate: func(r *messages.APReq) {
+				cksum := r.Authenticator.Cksum.Checksum
+				cksum[len(cksum)-1] ^= 0xFF
+			},
+			wantMsg: "delegated credential",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			APReq := testDelegatedAPReq(t, cname, "TEST.GOKRB5", key, types.EncryptionKey{})
+			tc.mutate(APReq)
+
+			creds := credentials.New("testuser1", "TEST.GOKRB5")
+
+			err := extractDelegatedCredential(APReq, creds)
+
+			require.ErrorIs(t, err, ErrBadDelegation)
+			assert.Contains(t, err.Error(), tc.wantMsg)
+
+			var krberr messages.KRBError
+
+			require.ErrorAs(t, err, &krberr)
+			assert.Equal(t, errorcode.KRB_AP_ERR_INAPP_CKSUM, krberr.ErrorCode)
+
+			_, ok := creds.DelegatedCredentials()
+			assert.False(t, ok, "a failed extraction must leave no partial credential behind")
+		})
+	}
+}
+
+// TestDelegationShouldRoundTripFromInitiatorToAcceptor is the demonstration that the two halves agree. The
+// initiator's checksum construction and the acceptor's extraction were written against RFC 4121 Section 4.1.1
+// independently; this asserts they meet.
+//
+// The forwarded TGT is synthesised rather than fetched: what is under test is the KRB_CRED encoding, the checksum
+// layout and the key agreement, none of which involve the KDC. cl.ForwardedTGT has its own coverage in
+// client/forwarding_test.go.
+func TestDelegationShouldRoundTripFromInitiatorToAcceptor(t *testing.T) {
+	t.Parallel()
+
+	cname := types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{"testuser1"}}
+	sessionKey := types.EncryptionKey{KeyType: 18, KeyValue: bytes.Repeat([]byte{0x0B}, 32)}
+	fwdKey := types.EncryptionKey{KeyType: 18, KeyValue: bytes.Repeat([]byte{0x0C}, 32)}
+
+	dep := messages.EncKDCRepPart{
+		Key:      fwdKey,
+		Flags:    types.NewKrbFlags(),
+		AuthTime: time.Now().UTC().Add(-time.Hour),
+		EndTime:  time.Now().UTC().Add(time.Hour),
+		SRealm:   "TEST.GOKRB5",
+		SName:    types.PrincipalName{NameType: nametype.KRB_NT_SRV_INST, NameString: []string{"krbtgt", "TEST.GOKRB5"}},
+	}
+	fwdTkt := messages.Ticket{TktVNO: 5, Realm: "TEST.GOKRB5", SName: dep.SName}
+
+	cred, err := messages.NewKRBCred([]messages.Ticket{fwdTkt},
+		[]messages.KrbCredInfo{messages.NewKrbCredInfo(dep, cname, "TEST.GOKRB5")}, sessionKey)
+	require.NoError(t, err)
+
+	deleg, err := cred.Marshal()
+	require.NoError(t, err)
+
+	// The initiator half: the same layout spnego.newAuthenticatorChksum produces.
+	cksum, err := (&gssapi.AuthenticatorChecksum{Flags: gssapi.ContextFlagInteg, Deleg: deleg}).Marshal()
+	require.NoError(t, err)
+
+	APReq := &messages.APReq{
+		Ticket: messages.Ticket{
+			Realm:            "TEST.GOKRB5",
+			SName:            types.PrincipalName{NameType: 1, NameString: []string{"HTTP", "host.test.gokrb5"}},
+			DecryptedEncPart: messages.EncTicketPart{Key: sessionKey},
+		},
+		Authenticator: types.Authenticator{
+			Cksum: types.Checksum{CksumType: chksumtype.GSSAPI, Checksum: cksum},
+		},
+	}
+
+	// The acceptor half.
+	creds := credentials.NewFromPrincipalName(cname, "TEST.GOKRB5")
+	require.NoError(t, extractDelegatedCredential(APReq, creds))
+
+	cc, ok := creds.DelegatedCredentials()
+	require.True(t, ok, "the acceptor must have taken the delegated credential")
+
+	assert.Equal(t, cname, cc.GetClientPrincipalName())
+	assert.Equal(t, "TEST.GOKRB5", cc.GetClientRealm())
+	require.Len(t, cc.Credentials, 1)
+	assert.Equal(t, fwdKey, cc.Credentials[0].Key, "the forwarded TGT's session key must survive the round trip")
+	assert.Equal(t, []string{"krbtgt", "TEST.GOKRB5"}, cc.Credentials[0].Server.PrincipalName.NameString)
 }
 
 func newTestAuthenticator(t *testing.T, creds credentials.Credentials) types.Authenticator {

--- a/spnego/krb5_token.go
+++ b/spnego/krb5_token.go
@@ -2,7 +2,6 @@ package spnego
 
 import (
 	"context"
-	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -11,7 +10,6 @@ import (
 
 	"github.com/go-krb5/krb5/asn1tools"
 	"github.com/go-krb5/krb5/client"
-	"github.com/go-krb5/krb5/credentials"
 	"github.com/go-krb5/krb5/gssapi"
 	"github.com/go-krb5/krb5/iana/chksumtype"
 	"github.com/go-krb5/krb5/iana/msgtype"
@@ -137,6 +135,15 @@ func (m *KRB5Token) Verify() (bool, gssapi.Status) {
 				return false, gssapi.Status{Code: gssapi.StatusBadBindings, Message: err.Error()}
 			}
 
+			// RFC 2743 defines no GSS-API status more specific than a defective token for a delegated credential
+			// this acceptor could not read, so this maps to the same StatusDefectiveToken as the fallback below.
+			// The branch is kept explicit, matching ErrBadChannelBinding above, so that a future status more
+			// specific than "defective token" has one place to be added without re-deriving which sentinel means
+			// what.
+			if errors.Is(err, service.ErrBadDelegation) {
+				return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: err.Error()}
+			}
+
 			return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: err.Error()}
 		}
 
@@ -189,6 +196,7 @@ type KRB5TokenOption func(*krb5TokenOptions)
 // krb5TokenOptions holds the resolved options for creating a KRB5Token.
 type krb5TokenOptions struct {
 	channelBinding *gssapi.ChannelBinding
+	delegation     bool
 }
 
 // ChannelBinding configures the GSS-API channel binding to bind the AP_REQ to. The hash of the binding is carried in
@@ -204,6 +212,22 @@ func ChannelBinding(cb *gssapi.ChannelBinding) KRB5TokenOption {
 	}
 }
 
+// Delegation requests credential delegation: the AP_REQ will carry a forwarded ticket-granting ticket in the Deleg
+// field of the authenticator checksum described by RFC 4121 Section 4.1.1, letting the service act as the client.
+//
+// This requires a forwardable TGT. Set forwardable = true in the libdefaults section of krb5.conf before
+// authenticating, or the KDC will refuse to issue the forwarded ticket; this library defaults it to false.
+//
+// Delegation grants the service complete use of the client's identity, as RFC 4120 Section 2.6 describes. Request
+// it only against services trusted with that.
+//
+//	s := SPNEGOClient(cl, spn, Delegation()).
+func Delegation() KRB5TokenOption {
+	return func(o *krb5TokenOptions) {
+		o.delegation = true
+	}
+}
+
 // newKRB5TokenOptions resolves the options provided, applying them in order so that the last value wins.
 func newKRB5TokenOptions(opts ...KRB5TokenOption) *krb5TokenOptions {
 	o := new(krb5TokenOptions)
@@ -216,6 +240,11 @@ func newKRB5TokenOptions(opts ...KRB5TokenOption) *krb5TokenOptions {
 }
 
 // NewKRB5TokenAPREQ creates a new KRB5 token with AP_REQ.
+//
+// Delegation is requested either by the Delegation option or by gssapi.ContextFlagDeleg in flagsGSSAPI; the two are
+// reconciled here, which is the single place every caller passes through. Folding the option into the flags in a
+// caller instead would leave this entry point silently ignoring it and returning a non-delegating token to a caller
+// that believed it had delegated.
 func NewKRB5TokenAPREQ(cl *client.Client, tkt messages.Ticket, sessionKey types.EncryptionKey, flagsGSSAPI []int, optionsAP []int, opts ...KRB5TokenOption) (KRB5Token, error) {
 	// TODO consider providing the SPN rather than the specific tkt and key and get these from the krb client.
 	var m KRB5Token
@@ -224,7 +253,14 @@ func NewKRB5TokenAPREQ(cl *client.Client, tkt messages.Ticket, sessionKey types.
 	tb, _ := hex.DecodeString(TOK_ID_KRB_AP_REQ)
 	m.tokID = tb
 
-	auth, err := krb5TokenAuthenticator(cl.Credentials, flagsGSSAPI, newKRB5TokenOptions(opts...).channelBinding)
+	opt := newKRB5TokenOptions(opts...)
+
+	if opt.delegation && !delegationRequested(flagsGSSAPI) {
+		// Copied rather than appended in place: flagsGSSAPI belongs to the caller and may have spare capacity.
+		flagsGSSAPI = append(append([]int(nil), flagsGSSAPI...), gssapi.ContextFlagDeleg)
+	}
+
+	auth, err := krb5TokenAuthenticator(cl, tkt, sessionKey, flagsGSSAPI, opt.channelBinding)
 	if err != nil {
 		return m, err
 	}
@@ -247,15 +283,50 @@ func NewKRB5TokenAPREQ(cl *client.Client, tkt messages.Ticket, sessionKey types.
 	return m, nil
 }
 
+// newAuthenticatorChksum creates the authenticator checksum for a kerberos MechToken as described by RFC 4121
+// Section 4.1.1.
+//
+// A nil channel binding leaves Bnd as the sixteen zero bytes that mean no channel bindings. A nil deleg produces
+// the 24 octet checksum that carries no delegated credential.
+//
+// Requesting gssapi.ContextFlagDeleg without supplying deleg returns gssapi.ErrDelegationMissing: RFC 4121 Section
+// 4.1.1 makes the delegation fields present if and only if the flag is set, and a checksum claiming a delegation
+// it does not carry is rejected by MIT with GSS_S_FAILURE on reading DlgOpt as 0.
+func newAuthenticatorChksum(flags []int, cb *gssapi.ChannelBinding, deleg []byte) ([]byte, error) {
+	c := gssapi.AuthenticatorChecksum{
+		Bnd:   cb.Bnd(),
+		Deleg: deleg,
+	}
+
+	for _, i := range flags {
+		c.Flags |= uint32(i) //nolint:gosec // G115: the GSS-API context flags are small positive constants.
+	}
+
+	return c.Marshal()
+}
+
 // krb5TokenAuthenticator creates a new kerberos authenticator for kerberos MechToken.
-func krb5TokenAuthenticator(creds *credentials.Credentials, flags []int, cb *gssapi.ChannelBinding) (types.Authenticator, error) {
+//
+// When gssapi.ContextFlagDeleg is requested a forwarded TGT is obtained from the KDC and carried in the checksum as
+// a KRB_CRED, encrypted under the session key of the ticket authenticating the context. RFC 4121 Section 4.1.1
+// requires that key specifically: "The EncryptedData field of the KRB_CRED message MUST be encrypted in the session
+// key of the ticket used to authenticate the context."
+func krb5TokenAuthenticator(cl *client.Client, tkt messages.Ticket, sessionKey types.EncryptionKey, flags []int, cb *gssapi.ChannelBinding) (types.Authenticator, error) {
 	// RFC 4121 Section 4.1.1.
-	auth, err := types.NewAuthenticator(creds.Domain(), creds.CName())
+	auth, err := types.NewAuthenticator(cl.Credentials.Domain(), cl.Credentials.CName())
 	if err != nil {
 		return auth, krberror.Errorf(err, krberror.KRBMsgError, "error generating new authenticator")
 	}
 
-	chksum, err := newAuthenticatorChksum(flags, cb)
+	var deleg []byte
+
+	if delegationRequested(flags) {
+		if deleg, err = delegatedCredential(cl, tkt, sessionKey); err != nil {
+			return auth, err
+		}
+	}
+
+	chksum, err := newAuthenticatorChksum(flags, cb, deleg)
 	if err != nil {
 		return auth, err
 	}
@@ -268,44 +339,46 @@ func krb5TokenAuthenticator(creds *credentials.Credentials, flags []int, cb *gss
 	return auth, nil
 }
 
-// ErrDelegationUnimplemented is returned when gssapi.ContextFlagDeleg is requested. RFC 4121 Section 4.1.1 requires
-// the delegation option identifier in DlgOpt and a KRB_CRED in Deleg whenever the flag is set; this library
-// implements neither, so it refuses the request rather than emitting a checksum that claims a delegation it cannot
-// perform. Callers match against it with errors.Is.
-var ErrDelegationUnimplemented = errors.New("credential delegation is not implemented")
-
-// newAuthenticatorChksum creates the authenticator checksum for a kerberos MechToken as described by RFC 4121
-// Section 4.1.1: a four byte Lgth of 16, the sixteen byte Bnd channel bindings hash and the four byte context flags.
-// The result is always 24 bytes.
-//
-// A nil channel binding leaves Bnd as the sixteen zero bytes that mean no channel bindings.
-//
-// Requesting gssapi.ContextFlagDeleg returns ErrDelegationUnimplemented. Setting the flag obliges the initiator to
-// populate the DlgOpt, Dlgth and Deleg fields that follow Flags, and this library has no KRB_CRED to put there:
-// messages.KRBCred can be received but not emitted, and nothing acquires a forwarded TGT. Emitting the flag with
-// those fields zeroed is what this used to do, and MIT rejects it with GSS_S_FAILURE on reading DlgOpt as 0, so the
-// refusal costs no working deployment anything. Nothing in this library requests the flag: both SPNEGO paths ask for
-// ContextFlagInteg and ContextFlagConf only.
-func newAuthenticatorChksum(flags []int, cb *gssapi.ChannelBinding) ([]byte, error) {
+// delegationRequested reports whether any of the flags carries GSS_C_DELEG_FLAG. The bit is tested rather than the
+// value because callers may combine flags into a single slice element.
+func delegationRequested(flags []int) bool {
 	for _, i := range flags {
 		if i&gssapi.ContextFlagDeleg != 0 {
-			return nil, fmt.Errorf("%w: RFC 4121 Section 4.1.1 requires DlgOpt to carry the delegation option identifier 1 and Deleg to carry a KRB_CRED", ErrDelegationUnimplemented)
+			return true
 		}
 	}
 
-	a := make([]byte, 24)
-	binary.LittleEndian.PutUint32(a[:4], 16)
+	return false
+}
 
-	bnd := cb.Bnd()
-	copy(a[4:20], bnd[:])
-
-	for _, i := range flags {
-		f := binary.LittleEndian.Uint32(a[20:24])
-
-		f |= uint32(i)
-
-		binary.LittleEndian.PutUint32(a[20:24], f)
+// delegatedCredential obtains a forwarded TGT and marshals it as the KRB_CRED that RFC 4121 Section 4.1.1 carries
+// in the Deleg field of the authenticator checksum.
+//
+// Unlike MIT, which silently clears GSS_C_DELEG_FLAG when forwarding fails, a failure here is returned. This
+// library has no ret_flags plumbing, so a caller could not observe the downgrade and would believe a delegation had
+// happened that had not.
+//
+// Failures are wrapped with fmt.Errorf and %w rather than with krberror.Errorf. krberror.Krberror flattens what it
+// wraps into strings and exposes no Unwrap, which would break the chain and leave a caller unable to tell
+// client.ErrNotForwardable; the one failure with an operator-actionable remedy, from any other KDC error except by
+// matching on substrings.
+func delegatedCredential(cl *client.Client, tkt messages.Ticket, sessionKey types.EncryptionKey) ([]byte, error) {
+	ftgt, dep, err := cl.ForwardedTGT(tkt.SName, sessionKey)
+	if err != nil {
+		return nil, fmt.Errorf("error obtaining a forwarded TGT to delegate: %w", err)
 	}
 
-	return a, nil
+	info := messages.NewKrbCredInfo(dep, cl.Credentials.CName(), cl.Credentials.Domain())
+
+	cred, err := messages.NewKRBCred([]messages.Ticket{ftgt}, []messages.KrbCredInfo{info}, sessionKey)
+	if err != nil {
+		return nil, fmt.Errorf("error building the KRB_CRED to delegate: %w", err)
+	}
+
+	b, err := cred.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling the KRB_CRED to delegate: %w", err)
+	}
+
+	return b, nil
 }

--- a/spnego/krb5_token_test.go
+++ b/spnego/krb5_token_test.go
@@ -13,9 +13,11 @@ import (
 	"github.com/go-krb5/x/encoding/asn1"
 
 	"github.com/go-krb5/krb5/client"
+	"github.com/go-krb5/krb5/config"
 	"github.com/go-krb5/krb5/credentials"
 	"github.com/go-krb5/krb5/gssapi"
 	"github.com/go-krb5/krb5/iana/chksumtype"
+	"github.com/go-krb5/krb5/iana/flags"
 	"github.com/go-krb5/krb5/iana/msgtype"
 	"github.com/go-krb5/krb5/iana/nametype"
 	"github.com/go-krb5/krb5/keytab"
@@ -53,7 +55,7 @@ func TestKRB5Token_newAuthenticatorChksum(t *testing.T) {
 	b, err := hex.DecodeString(AuthChksum)
 	require.NoError(t, err)
 
-	cb, err := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, nil)
+	cb, err := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, b, cb)
 }
@@ -62,14 +64,12 @@ func TestKRB5Token_newAuthenticatorChksum(t *testing.T) {
 func TestKRB5Token_newAuthenticatorWithSubkeyGeneration(t *testing.T) {
 	t.Parallel()
 
-	creds := credentials.New("hftsai", testdata.TEST_REALM)
-	creds.SetCName(types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: testdata.TEST_PRINCIPALNAME_NAMESTRING})
-
 	var etypeID int32 = 18
 
 	keyLen := 32
 
-	a, err := krb5TokenAuthenticator(creds, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, nil)
+	a, err := krb5TokenAuthenticator(getClient(t), messages.Ticket{}, types.EncryptionKey{},
+		[]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, a.GenerateSeqNumberAndSubKey(etypeID, keyLen))
@@ -100,10 +100,8 @@ func TestKRB5Token_newAuthenticatorWithSubkeyGeneration(t *testing.T) {
 func TestKRB5Token_newAuthenticator(t *testing.T) {
 	t.Parallel()
 
-	creds := credentials.New("hftsai", testdata.TEST_REALM)
-	creds.SetCName(types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: testdata.TEST_PRINCIPALNAME_NAMESTRING})
-
-	a, err := krb5TokenAuthenticator(creds, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, nil)
+	a, err := krb5TokenAuthenticator(getClient(t), messages.Ticket{}, types.EncryptionKey{},
+		[]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(32771), a.Cksum.CksumType)
@@ -221,7 +219,7 @@ func TestNewAuthenticatorChksumShouldEmbedTheChannelBinding(t *testing.T) {
 
 	cb := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:test")}
 
-	c, err := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, cb)
+	c, err := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, cb, nil)
 	require.NoError(t, err)
 
 	require.Len(t, c, 24)
@@ -238,7 +236,7 @@ func TestNewAuthenticatorChksumShouldEmbedTheChannelBinding(t *testing.T) {
 func TestNewAuthenticatorChksumShouldZeroBndWithoutAChannelBinding(t *testing.T) {
 	t.Parallel()
 
-	c, err := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, nil)
+	c, err := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, nil, nil)
 	require.NoError(t, err)
 
 	require.Len(t, c, 24)
@@ -247,79 +245,66 @@ func TestNewAuthenticatorChksumShouldZeroBndWithoutAChannelBinding(t *testing.T)
 	assert.Equal(t, uint32(gssapi.ContextFlagInteg|gssapi.ContextFlagConf), binary.LittleEndian.Uint32(c[20:24]))
 }
 
-// TestNewAuthenticatorChksumShouldRefuseDelegation asserts the library refuses to claim a delegation it cannot
-// perform. RFC 4121 Section 4.1.1 requires DlgOpt to carry the delegation option identifier 1 and Deleg to carry a
-// KRB_CRED whenever the delegation flag is set. This library implements neither, and the 28 zeroed octets it used to
-// emit are rejected by MIT with GSS_S_FAILURE once it reads DlgOpt as 0. Failing here names the cause at the call
-// site instead.
-func TestNewAuthenticatorChksumShouldRefuseDelegation(t *testing.T) {
+// TestNewAuthenticatorChksumShouldCarryTheDelegatedCredential asserts the delegation fields of RFC 4121 Section
+// 4.1.1 follow Flags when a credential is supplied. The refusal this replaces existed because those fields used to
+// be emitted zeroed.
+func TestNewAuthenticatorChksumShouldCarryTheDelegatedCredential(t *testing.T) {
 	t.Parallel()
 
-	c, err := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg, gssapi.ContextFlagDeleg}, nil)
+	deleg := []byte("a marshalled KRB_CRED")
 
-	require.ErrorIs(t, err, ErrDelegationUnimplemented)
-	assert.Nil(t, c, "no checksum is returned when the flags cannot be honoured")
-	assert.Contains(t, err.Error(), "RFC 4121")
+	c, err := newAuthenticatorChksum([]int{gssapi.ContextFlagInteg}, nil, deleg)
+	require.NoError(t, err)
+
+	require.Len(t, c, 28+len(deleg))
+	assert.Equal(t, uint32(gssapi.ContextFlagInteg|gssapi.ContextFlagDeleg), binary.LittleEndian.Uint32(c[20:24]))
+	assert.Equal(t, uint16(1), binary.LittleEndian.Uint16(c[24:26]))
+	assert.Equal(t, deleg, c[28:])
 }
 
-// TestNewAuthenticatorChksumShouldRefuseCombinedDelegationBitmask asserts the guard tests the bit rather than the
-// value. The flags loop below the guard accumulates ORed values with f |= uint32(i), so a caller passing a combined
-// bitmask in a single slice element is an invited call style, not a misuse. A guard written as i ==
-// gssapi.ContextFlagDeleg misses that case: ContextFlagDeleg|ContextFlagInteg reaches the flags loop unrefused and
-// sets GSS_C_DELEG_FLAG in the emitted checksum with none of the delegation fields populated, which is exactly the
-// false claim of delegation this refusal exists to prevent.
-func TestNewAuthenticatorChksumShouldRefuseCombinedDelegationBitmask(t *testing.T) {
+// TestNewAuthenticatorChksumShouldStillRefuseTheFlagWithoutACredential asserts the original defect stays
+// unrepresentable now that the flag is honoured rather than refused.
+func TestNewAuthenticatorChksumShouldStillRefuseTheFlagWithoutACredential(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name        string
-		flags       []int
-		wantRefused bool
-	}{
-		{
-			name:        "DelegationAlone",
-			flags:       []int{gssapi.ContextFlagDeleg},
-			wantRefused: true,
-		},
-		{
-			name:        "DelegationCombinedWithIntegInOneElement",
-			flags:       []int{gssapi.ContextFlagDeleg | gssapi.ContextFlagInteg},
-			wantRefused: true,
-		},
-		{
-			name:        "IntegAndConfCombinedWithoutDelegationMustStillSucceed",
-			flags:       []int{gssapi.ContextFlagInteg | gssapi.ContextFlagConf},
-			wantRefused: false,
-		},
-	}
+	c, err := newAuthenticatorChksum([]int{gssapi.ContextFlagDeleg}, nil, nil)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			c, err := newAuthenticatorChksum(tt.flags, nil)
-
-			if tt.wantRefused {
-				require.ErrorIs(t, err, ErrDelegationUnimplemented)
-				assert.Nil(t, c, "no checksum is returned when the flags cannot be honoured")
-
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Len(t, c, 24)
-		})
-	}
+	require.ErrorIs(t, err, gssapi.ErrDelegationMissing)
+	assert.Nil(t, c)
 }
 
-// TestNewKRB5TokenAPREQShouldSurfaceDelegationRefusal covers the propagation hop rather than only the leaf: the error
-// has to travel newAuthenticatorChksum -> krb5TokenAuthenticator -> NewKRB5TokenAPREQ to reach a caller.
-func TestNewKRB5TokenAPREQShouldSurfaceDelegationRefusal(t *testing.T) {
+// TestNewKRB5TokenAPREQShouldSurfaceADelegationFailure covers the propagation hop rather than only the leaf: the
+// error has to travel delegatedCredential -> krb5TokenAuthenticator -> NewKRB5TokenAPREQ to reach a caller. This
+// matters because, unlike MIT, which silently clears GSS_C_DELEG_FLAG when forwarding fails, this library returns
+// the failure; a caller that never sees it would believe a delegation had happened that had not.
+//
+// A bare client.Client{Credentials: creds} literal cannot exercise this: its unexported *sessions field is a nil
+// pointer rather than a nil-safe map, so cl.ForwardedTGT panics inside sessions.get before it ever returns an
+// error. client.NewWithPassword initialises that field properly. To still fail locally, without a KDC round trip,
+// the realm's KDC list is cleared after parsing testdata.KRB5_CONF: client.Client.IsConfigured then rejects the
+// login synchronously with "client krb5 config does not have any defined KDCs for the default realm", before any
+// socket is opened. This is the same local-failure shape TestForwardedTGTShouldRefuseANonForwardableSession in
+// client/forwarding_test.go exploits, one layer up: the config check rather than the forwardable check.
+func TestNewKRB5TokenAPREQShouldSurfaceADelegationFailure(t *testing.T) {
 	t.Parallel()
 
-	creds := credentials.New("hftsai", testdata.TEST_REALM)
-	creds.SetCName(types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: testdata.TEST_PRINCIPALNAME_NAMESTRING})
-	cl := &client.Client{Credentials: creds}
+	c, err := config.NewFromString(testdata.KRB5_CONF)
+	require.NoError(t, err)
+
+	var cleared bool
+
+	for i := range c.Realms {
+		if c.Realms[i].Realm == "TEST.GOKRB5" {
+			c.Realms[i].KDC = nil
+			cleared = true
+
+			break
+		}
+	}
+
+	require.True(t, cleared, "test fixture must clear the KDC list of the realm it authenticates against")
+
+	cl := client.NewWithPassword("testuser1", "TEST.GOKRB5", "passwordvalue", c)
 
 	var tkt messages.Ticket
 
@@ -329,8 +314,207 @@ func TestNewKRB5TokenAPREQShouldSurfaceDelegationRefusal(t *testing.T) {
 
 	key := types.EncryptionKey{KeyType: 18, KeyValue: make([]byte, 32)}
 
-	_, err = NewKRB5TokenAPREQ(cl, tkt, key, []int{gssapi.ContextFlagDeleg}, []int{})
-	require.ErrorIs(t, err, ErrDelegationUnimplemented)
+	start := time.Now()
+	mt, err := NewKRB5TokenAPREQ(cl, tkt, key, []int{gssapi.ContextFlagDeleg}, []int{})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "obtaining a forwarded TGT to delegate",
+		"the error must name the propagation hop it travelled, not just any failure")
+	assert.ErrorContains(t, err, "does not have any defined KDCs",
+		"the error must name the underlying cause")
+	// The underlying failure is a configuration error with no sentinel of its own, so it is matched on its text.
+	// What errors.Is can say about it is that it is not the one delegation failure that does have a sentinel, which
+	// is what a caller deciding whether to tell the operator about forwardable = true needs to know.
+	assert.NotErrorIs(t, err, client.ErrNotForwardable,
+		"a missing KDC must not be classified as a non-forwardable TGT")
+	assert.Empty(t, mt.APReq.Ticket.Realm, "no usable token is returned alongside the error")
+	assert.Less(t, elapsed, 1*time.Second,
+		"a client with no KDCs configured must be rejected locally, without attempting a KDC round trip")
+}
+
+// ccacheClient builds a client the way a delegating caller does, from a credential cache, with the captured test
+// vector's credential times shifted forward so the TGT is currently valid and no KDC exchange is needed to establish
+// the session. forwardable selects whether the TGT keeps the FORWARDABLE flag the KDC issued it with.
+//
+// The realm's KDCs are cleared so that anything reaching the network fails locally rather than dialling.
+func ccacheClient(t *testing.T, forwardable bool) *client.Client {
+	t.Helper()
+
+	b, err := hex.DecodeString(testdata.CCACHE_TEST)
+	require.NoError(t, err)
+
+	cc := new(credentials.CCache)
+	require.NoError(t, cc.Unmarshal(b))
+
+	spn := types.PrincipalName{NameType: nametype.KRB_NT_SRV_INST, NameString: []string{"krbtgt", "TEST.GOKRB5"}}
+
+	tgt, ok := cc.GetEntry(spn)
+	require.True(t, ok, "the ccache test vector must contain a TGT")
+	require.True(t, types.IsFlagSet(&tgt.TicketFlags, flags.Forwardable),
+		"the ccache test vector's TGT must be forwardable for this fixture to control the flag")
+
+	if !forwardable {
+		types.UnsetFlag(&tgt.TicketFlags, flags.Forwardable)
+	}
+
+	offset := time.Now().UTC().Add(-1 * time.Hour).Sub(tgt.AuthTime)
+
+	for _, cred := range cc.Credentials {
+		cred.AuthTime = cred.AuthTime.Add(offset)
+		cred.StartTime = cred.StartTime.Add(offset)
+		cred.EndTime = cred.EndTime.Add(offset)
+		cred.RenewTill = cred.RenewTill.Add(offset)
+	}
+
+	c, err := config.NewFromString(testdata.KRB5_CONF)
+	require.NoError(t, err)
+
+	var cleared bool
+
+	for i := range c.Realms {
+		if c.Realms[i].Realm == "TEST.GOKRB5" {
+			c.Realms[i].KDC = nil
+			cleared = true
+
+			break
+		}
+	}
+
+	require.True(t, cleared, "test fixture must clear the KDC list of the realm it authenticates against")
+
+	cl, err := client.NewFromCCache(cc, c)
+	require.NoError(t, err)
+
+	return cl
+}
+
+// TestNewKRB5TokenAPREQShouldHonourTheDelegationOption pins the option on the entry point that consumes it. The
+// option used to be read only by NewNegTokenInitKRB5, so passing Delegation() here returned a perfectly valid
+// 24 octet non-delegating checksum and no error: an unobservable downgrade for a caller that believed it had
+// delegated. Reaching the forwarding exchange at all is the proof the option was honoured; the exchange itself
+// cannot succeed against a fixture with no KDCs.
+func TestNewKRB5TokenAPREQShouldHonourTheDelegationOption(t *testing.T) {
+	t.Parallel()
+
+	cl := ccacheClient(t, true)
+
+	var tkt messages.Ticket
+
+	b, err := hex.DecodeString(testdata.MarshaledKRB5ticket)
+	require.NoError(t, err)
+	require.NoError(t, tkt.Unmarshal(b))
+
+	key := types.EncryptionKey{KeyType: 18, KeyValue: make([]byte, 32)}
+
+	_, err = NewKRB5TokenAPREQ(cl, tkt, key, []int{gssapi.ContextFlagInteg}, nil, Delegation())
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "obtaining a forwarded TGT to delegate",
+		"Delegation() passed to NewKRB5TokenAPREQ must reach the forwarding exchange")
+}
+
+// TestNewKRB5TokenAPREQShouldNotDelegateWithoutTheOption is the counterpart: without Delegation() and without
+// gssapi.ContextFlagDeleg no forwarding is attempted and the checksum is the 24 octet form.
+func TestNewKRB5TokenAPREQShouldNotDelegateWithoutTheOption(t *testing.T) {
+	t.Parallel()
+
+	cl := ccacheClient(t, true)
+
+	var tkt messages.Ticket
+
+	b, err := hex.DecodeString(testdata.MarshaledKRB5ticket)
+	require.NoError(t, err)
+	require.NoError(t, tkt.Unmarshal(b))
+
+	key := types.EncryptionKey{KeyType: 18, KeyValue: make([]byte, 32)}
+
+	mt, err := NewKRB5TokenAPREQ(cl, tkt, key, []int{gssapi.ContextFlagInteg}, nil)
+	require.NoError(t, err)
+
+	// The authenticator is sealed under the same session key it was encrypted with, so the checksum has to be
+	// decrypted back out to be read.
+	require.NoError(t, mt.APReq.DecryptAuthenticator(key))
+
+	assert.Equal(t, chksumtype.GSSAPI, mt.APReq.Authenticator.Cksum.CksumType)
+	assert.Len(t, mt.APReq.Authenticator.Cksum.Checksum, 24,
+		"a token that was not asked to delegate must carry no delegation fields")
+}
+
+// TestNewKRB5TokenAPREQShouldReturnAMatchableErrNotForwardable asserts the one delegation failure with an
+// operator-actionable remedy stays classifiable at the outermost public call. It used to be wrapped with
+// krberror.Errorf, which flattens what it wraps into strings and has no Unwrap, so errors.Is failed and a caller
+// could only tell "the operator needs forwardable = true" from any other KDC failure by matching on substrings.
+func TestNewKRB5TokenAPREQShouldReturnAMatchableErrNotForwardable(t *testing.T) {
+	t.Parallel()
+
+	cl := ccacheClient(t, false)
+
+	var tkt messages.Ticket
+
+	b, err := hex.DecodeString(testdata.MarshaledKRB5ticket)
+	require.NoError(t, err)
+	require.NoError(t, tkt.Unmarshal(b))
+
+	key := types.EncryptionKey{KeyType: 18, KeyValue: make([]byte, 32)}
+
+	_, err = NewKRB5TokenAPREQ(cl, tkt, key, []int{gssapi.ContextFlagDeleg}, nil)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, client.ErrNotForwardable,
+		"the sentinel must survive every wrap between client.ForwardedTGT and NewKRB5TokenAPREQ")
+	assert.ErrorContains(t, err, "forwardable = true",
+		"the error must still name the setting that fixes it")
+}
+
+// TestNewNegTokenInitKRB5ShouldReturnAMatchableErrNotForwardable covers the SPNEGO entry point, which wraps once
+// more on the way out.
+func TestNewNegTokenInitKRB5ShouldReturnAMatchableErrNotForwardable(t *testing.T) {
+	t.Parallel()
+
+	cl := ccacheClient(t, false)
+
+	var tkt messages.Ticket
+
+	b, err := hex.DecodeString(testdata.MarshaledKRB5ticket)
+	require.NoError(t, err)
+	require.NoError(t, tkt.Unmarshal(b))
+
+	key := types.EncryptionKey{KeyType: 18, KeyValue: make([]byte, 32)}
+
+	_, err = NewNegTokenInitKRB5(cl, tkt, key, Delegation())
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, client.ErrNotForwardable)
+}
+
+// TestDelegationRequestedShouldTestTheBit pins that callers may combine GSS-API context flags into one slice
+// element, which is what the flags are: a bitmask. delegationRequested is the only thing deciding whether a KDC
+// round trip happens, so a value comparison here would silently skip the forwarding exchange for a caller passing
+// ContextFlagDeleg|ContextFlagInteg and produce the non-delegating token that this branch exists to prevent.
+func TestDelegationRequestedShouldTestTheBit(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		flags    []int
+		expected bool
+	}{
+		{"ShouldDetectTheFlagOnItsOwn", []int{gssapi.ContextFlagDeleg}, true},
+		{"ShouldDetectTheFlagCombinedIntoOneElement", []int{gssapi.ContextFlagDeleg | gssapi.ContextFlagInteg}, true},
+		{"ShouldDetectTheFlagAlongsideOthers", []int{gssapi.ContextFlagInteg, gssapi.ContextFlagDeleg}, true},
+		{"ShouldNotDetectOtherFlagsCombined", []int{gssapi.ContextFlagInteg | gssapi.ContextFlagConf}, false},
+		{"ShouldNotDetectOtherFlags", []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, false},
+		{"ShouldNotDetectAnythingInNoFlags", nil, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, delegationRequested(tc.flags))
+		})
+	}
 }
 
 func TestNewKRB5TokenOptionsShouldDefaultToNoChannelBinding(t *testing.T) {
@@ -389,7 +573,7 @@ func TestKRB5TokenVerifyShouldReportChannelBindingFailuresAsBadBindings(t *testi
 		require.NoError(t, err)
 		require.NoError(t, auth.GenerateSeqNumberAndSubKey(18, 32))
 
-		chksum, err := newAuthenticatorChksum(nil, cb)
+		chksum, err := newAuthenticatorChksum(nil, cb, nil)
 		require.NoError(t, err)
 
 		auth.Cksum = types.Checksum{CksumType: chksumtype.GSSAPI, Checksum: chksum}

--- a/spnego/negotiation_token.go
+++ b/spnego/negotiation_token.go
@@ -334,7 +334,11 @@ func UnmarshalNegToken(b []byte) (bool, any, error) {
 
 // NewNegTokenInitKRB5 creates new Init negotiation token for Kerberos 5.
 func NewNegTokenInitKRB5(cl *client.Client, tkt messages.Ticket, sessionKey types.EncryptionKey, opts ...KRB5TokenOption) (NegTokenInit, error) {
-	mt, err := NewKRB5TokenAPREQ(cl, tkt, sessionKey, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, []int{}, opts...)
+	// The Delegation option is not folded into these flags here: NewKRB5TokenAPREQ does that for every caller, so
+	// that the option means the same thing whichever entry point receives it.
+	flagsGSSAPI := []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}
+
+	mt, err := NewKRB5TokenAPREQ(cl, tkt, sessionKey, flagsGSSAPI, []int{}, opts...)
 	if err != nil {
 		return NegTokenInit{}, fmt.Errorf("error getting KRB5 token; %w", err)
 	}

--- a/types/kerberos_flags.go
+++ b/types/kerberos_flags.go
@@ -23,14 +23,21 @@ func SetFlags(f *asn1.BitString, j []int) {
 }
 
 // SetFlag sets a flag in an ASN1 BitString.
+//
+// The BitString is grown to hold the flag, so any i within the KrbFlags range of RFC 4120 Section 5.2.8 can be set
+// on a zero value. A negative i is ignored: it names no bit, and the index it would compute is out of range.
 func SetFlag(f *asn1.BitString, i int) {
-	for l := len(f.Bytes); l < 4; l++ {
-		f.Bytes = append(f.Bytes, byte(0))
-		f.BitLength = len(f.Bytes) * 8
+	if i < 0 {
+		return
 	}
 
 	b := i / 8
 	p := uint(7 - (i - 8*b))
+
+	for l := len(f.Bytes); l < b+1 || l < 4; l++ {
+		f.Bytes = append(f.Bytes, byte(0))
+		f.BitLength = len(f.Bytes) * 8
+	}
 
 	f.Bytes[b] |= 1 << p
 }
@@ -43,7 +50,14 @@ func UnsetFlags(f *asn1.BitString, j []int) {
 }
 
 // UnsetFlag unsets a flag in an ASN1 BitString.
+//
+// A flag beyond the end of the BitString is already unset, so it is left alone rather than growing the string to
+// clear a bit that is not there.
 func UnsetFlag(f *asn1.BitString, i int) {
+	if i < 0 {
+		return
+	}
+
 	for l := len(f.Bytes); l < 4; l++ {
 		f.Bytes = append(f.Bytes, byte(0))
 		f.BitLength = len(f.Bytes) * 8
@@ -52,13 +66,30 @@ func UnsetFlag(f *asn1.BitString, i int) {
 	b := i / 8
 	p := uint(7 - (i - 8*b))
 
+	if b >= len(f.Bytes) {
+		return
+	}
+
 	f.Bytes[b] = f.Bytes[b] &^ (1 << p)
 }
 
 // IsFlagSet tests if a flag is set in the ASN1 BitString.
+//
+// A BitString too short to hold the flag reports it unset rather than indexing past its end. BIT STRING is a
+// variable length type and its length is decided by whoever encoded it: a KrbCredInfo delegated by a peer, for
+// instance, reaches credentials.Credential.TicketFlags with whatever length the peer sent, including none at all.
+// A flag that was never encoded is not set.
 func IsFlagSet(f *asn1.BitString, i int) bool {
+	if i < 0 {
+		return false
+	}
+
 	b := i / 8
 	p := uint(7 - (i - 8*b))
+
+	if b >= len(f.Bytes) {
+		return false
+	}
 
 	return f.Bytes[b]&(1<<p) != 0
 }

--- a/types/kerberos_flags_test.go
+++ b/types/kerberos_flags_test.go
@@ -44,3 +44,81 @@ func TestKerberosFlags_IsFlagSet(t *testing.T) {
 	assert.True(t, IsFlagSet(&f, flags.RenewableOK))
 	assert.False(t, IsFlagSet(&f, flags.Proxiable))
 }
+
+// TestKerberosFlagsIsFlagSetShouldNotIndexPastAShortBitString covers flags that arrived from the wire rather than
+// from SetFlag. A BIT STRING carries its own length, so a peer can encode an empty or truncated one: the KrbCredInfo
+// of a delegated KRB_CRED reaches credentials.Credential.TicketFlags unaltered, and reading a flag out of it used to
+// index past the end and panic the process.
+func TestKerberosFlagsIsFlagSetShouldNotIndexPastAShortBitString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		flags asn1.BitString
+		flag  int
+	}{
+		{"ShouldReportUnsetForAZeroValue", asn1.BitString{}, flags.Forwardable},
+		{"ShouldReportUnsetForAnEmptyByteSlice", asn1.BitString{Bytes: []byte{}, BitLength: 0}, flags.Forwardable},
+		{"ShouldReportUnsetForAFlagPastTheEnd", asn1.BitString{Bytes: []byte{0xff}, BitLength: 8}, flags.RenewableOK},
+		{"ShouldReportUnsetForANegativeFlag", asn1.BitString{Bytes: []byte{0xff, 0xff, 0xff, 0xff}, BitLength: 32}, -1},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := tc.flags
+
+			assert.NotPanics(t, func() {
+				assert.False(t, IsFlagSet(&f, tc.flag))
+			})
+		})
+	}
+}
+
+// TestKerberosFlagsSetAndUnsetShouldNotIndexPastTheBitString covers the same exposure on the mutating helpers: a
+// flag number beyond the four octets they pad to, and a negative one, must not index out of range.
+func TestKerberosFlagsSetAndUnsetShouldNotIndexPastTheBitString(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SetFlagShouldGrowForAFlagPastFourOctets", func(t *testing.T) {
+		t.Parallel()
+
+		var f asn1.BitString
+
+		assert.NotPanics(t, func() { SetFlag(&f, 32) })
+		assert.Equal(t, []byte{0, 0, 0, 0, 128}, f.Bytes)
+		assert.Equal(t, 40, f.BitLength)
+		assert.True(t, IsFlagSet(&f, 32))
+	})
+
+	t.Run("SetFlagShouldIgnoreANegativeFlag", func(t *testing.T) {
+		t.Parallel()
+
+		var f asn1.BitString
+
+		assert.NotPanics(t, func() { SetFlag(&f, -1) })
+		assert.Empty(t, f.Bytes)
+	})
+
+	t.Run("UnsetFlagShouldIgnoreAFlagPastTheEnd", func(t *testing.T) {
+		t.Parallel()
+
+		var f asn1.BitString
+		SetFlag(&f, flags.Forwardable)
+
+		assert.NotPanics(t, func() { UnsetFlag(&f, 32) })
+		assert.Equal(t, []byte{64, 0, 0, 0}, f.Bytes)
+		assert.True(t, IsFlagSet(&f, flags.Forwardable))
+	})
+
+	t.Run("UnsetFlagShouldIgnoreANegativeFlag", func(t *testing.T) {
+		t.Parallel()
+
+		var f asn1.BitString
+		SetFlag(&f, flags.Forwardable)
+
+		assert.NotPanics(t, func() { UnsetFlag(&f, -1) })
+		assert.Equal(t, []byte{64, 0, 0, 0}, f.Bytes)
+	})
+}

--- a/types/supported_etypes.go
+++ b/types/supported_etypes.go
@@ -1,0 +1,182 @@
+package types
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/go-krb5/krb5/iana/etypeID"
+	"github.com/go-krb5/krb5/iana/patype"
+)
+
+// Supported encryption type bit flags, as carried in the msDS-SupportedEncryptionTypes attribute and in the
+// PA-SUPPORTED-ENCTYPES pre-authentication data described by MS-KILE Section 2.2.7. The letters in the comments are
+// the labels MS-KILE gives each bit in its diagram.
+//
+// Only the first eight bits describe encryption types. The remainder advertise unrelated capabilities and are
+// preserved but never intersected, since ANDing "claims supported" with another party's value says nothing about
+// encryption.
+const (
+	SupportedETypeDESCBCCRC              uint32 = 0x00000001 // A.
+	SupportedETypeDESCBCMD5              uint32 = 0x00000002 // B.
+	SupportedETypeRC4HMAC                uint32 = 0x00000004 // C.
+	SupportedETypeAES128CTSHMACSHA196    uint32 = 0x00000008 // D.
+	SupportedETypeAES256CTSHMACSHA196    uint32 = 0x00000010 // E.
+	SupportedETypeAES256CTSHMACSHA196SK  uint32 = 0x00000020 // J.
+	SupportedETypeAES128CTSHMACSHA256128 uint32 = 0x00000040 // K.
+	SupportedETypeAES256CTSHMACSHA384192 uint32 = 0x00000080 // L.
+
+	SupportedETypeFAST                           uint32 = 0x00010000 // F.
+	SupportedETypeCompoundIdentity               uint32 = 0x00020000 // G.
+	SupportedETypeClaims                         uint32 = 0x00040000 // H.
+	SupportedETypeResourceSIDCompressionDisabled uint32 = 0x00080000 // I.
+)
+
+// supportedETypeMask selects the bits that name an encryption type. It excludes AES256CTSHMACSHA196SK, which
+// MS-KILE Section 2.2.7 describes as a policy instruction; "Enforce AES session keys when legacy ciphers are in
+// use"; rather than as an encryption type the peer can decrypt with. Treating it as one would advertise an
+// encryption type that does not exist.
+const supportedETypeMask = SupportedETypeDESCBCCRC | SupportedETypeDESCBCMD5 | SupportedETypeRC4HMAC |
+	SupportedETypeAES128CTSHMACSHA196 | SupportedETypeAES256CTSHMACSHA196 |
+	SupportedETypeAES128CTSHMACSHA256128 | SupportedETypeAES256CTSHMACSHA384192
+
+// supportedETypeLen is the width MS-KILE Section 2.2.7 fixes for the value: a 32 bit unsigned integer.
+const supportedETypeLen = 4
+
+// supportedETypeIDs maps each encryption type bit to the encryption type it names.
+var supportedETypeIDs = map[uint32]int32{
+	SupportedETypeDESCBCCRC:              etypeID.DES_CBC_CRC,
+	SupportedETypeDESCBCMD5:              etypeID.DES_CBC_MD5,
+	SupportedETypeRC4HMAC:                etypeID.RC4_HMAC,
+	SupportedETypeAES128CTSHMACSHA196:    etypeID.AES128_CTS_HMAC_SHA1_96,
+	SupportedETypeAES256CTSHMACSHA196:    etypeID.AES256_CTS_HMAC_SHA1_96,
+	SupportedETypeAES128CTSHMACSHA256128: etypeID.AES128_CTS_HMAC_SHA256_128,
+	SupportedETypeAES256CTSHMACSHA384192: etypeID.AES256_CTS_HMAC_SHA384_192,
+}
+
+// SupportedETypes is the value of the PA-SUPPORTED-ENCTYPES pre-authentication data of MS-KILE Section 2.2.7: a
+// bitmask of the encryption types and capabilities a party supports.
+//
+// The zero value means "not advertised", which is distinct from "supports nothing". A party that never sent the
+// pre-authentication data cannot be intersected with, so callers check IsZero before acting on one.
+type SupportedETypes uint32
+
+// NewSupportedETypesFromIDs builds a bitmask advertising the encryption types given. Encryption types with no bit
+// assigned by MS-KILE Section 2.2.7 are skipped: the specification requires that all other bits be zero when sent.
+func NewSupportedETypesFromIDs(ids []int32) SupportedETypes {
+	var s SupportedETypes
+
+	for _, id := range ids {
+		for bit, etype := range supportedETypeIDs {
+			if etype == id {
+				s |= SupportedETypes(bit)
+			}
+		}
+	}
+
+	return s
+}
+
+// UnmarshalSupportedETypes reads the four octet little-endian value MS-KILE Section 2.2.7 defines.
+func UnmarshalSupportedETypes(b []byte) (SupportedETypes, error) {
+	if len(b) != supportedETypeLen {
+		return 0, fmt.Errorf("PA-SUPPORTED-ENCTYPES is %d octets rather than %d", len(b), supportedETypeLen)
+	}
+
+	return SupportedETypes(binary.LittleEndian.Uint32(b)), nil
+}
+
+// SupportedETypesFromPAData returns the value of the PA-SUPPORTED-ENCTYPES entry in the sequence, or zero when
+// there is none. A malformed entry is treated as absent: the data is advisory, used only to hint to a KDC which
+// encryption types two other parties share, so refusing the exchange over it would trade a working authentication
+// for a hint.
+func SupportedETypesFromPAData(pas PADataSequence) SupportedETypes {
+	for _, pa := range pas {
+		if pa.PADataType != patype.PA_SUPPORTED_ETYPES {
+			continue
+		}
+
+		s, err := UnmarshalSupportedETypes(pa.PADataValue)
+		if err != nil {
+			return 0
+		}
+
+		return s
+	}
+
+	return 0
+}
+
+// PAData returns the pre-authentication data entry advertising these encryption types.
+func (s SupportedETypes) PAData() PAData {
+	return PAData{
+		PADataType:  patype.PA_SUPPORTED_ETYPES,
+		PADataValue: s.Marshal(),
+	}
+}
+
+// Marshal returns the four octet little-endian encoding.
+func (s SupportedETypes) Marshal() []byte {
+	b := make([]byte, supportedETypeLen)
+	binary.LittleEndian.PutUint32(b, uint32(s))
+
+	return b
+}
+
+// IsZero reports whether nothing was advertised. MS-KILE draws no distinction between an absent
+// PA-SUPPORTED-ENCTYPES and one advertising no encryption types, so both mean "unknown" rather than "none".
+func (s SupportedETypes) IsZero() bool {
+	return s == 0
+}
+
+// Contains reports whether the encryption type given is advertised.
+func (s SupportedETypes) Contains(id int32) bool {
+	for bit, etype := range supportedETypeIDs {
+		if etype == id {
+			return uint32(s)&bit != 0
+		}
+	}
+
+	return false
+}
+
+// ETypeIDs returns the encryption types advertised, in the order iana/etypeID assigns them so that the result is
+// deterministic. Capability bits that name no encryption type are omitted.
+func (s SupportedETypes) ETypeIDs() []int32 {
+	ids := make([]int32, 0, len(supportedETypeIDs))
+
+	for _, id := range []int32{
+		etypeID.DES_CBC_CRC,
+		etypeID.DES_CBC_MD5,
+		etypeID.AES128_CTS_HMAC_SHA1_96,
+		etypeID.AES256_CTS_HMAC_SHA1_96,
+		etypeID.AES128_CTS_HMAC_SHA256_128,
+		etypeID.AES256_CTS_HMAC_SHA384_192,
+		etypeID.RC4_HMAC,
+	} {
+		if s.Contains(id) {
+			ids = append(ids, id)
+		}
+	}
+
+	return ids
+}
+
+// Intersect returns the encryption types both parties advertise.
+//
+// Only the encryption type bits participate; the capability bits of MS-KILE Section 2.2.7 are dropped, because
+// they describe what each party can do rather than what they have in common, and this library advertises none of
+// them.
+//
+// A zero receiver or argument means that party advertised nothing, so there is nothing to intersect and the other
+// party's encryption types are returned unchanged. Returning an empty intersection instead would advertise that no
+// encryption type is common, which is a stronger claim than the absence of the data supports.
+func (s SupportedETypes) Intersect(o SupportedETypes) SupportedETypes {
+	switch {
+	case s.IsZero():
+		return o & SupportedETypes(supportedETypeMask)
+	case o.IsZero():
+		return s & SupportedETypes(supportedETypeMask)
+	default:
+		return s & o & SupportedETypes(supportedETypeMask)
+	}
+}

--- a/types/supported_etypes_test.go
+++ b/types/supported_etypes_test.go
@@ -1,0 +1,152 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/krb5/iana/etypeID"
+)
+
+// TestSupportedETypesShouldRoundTripTheWireFormat pins the encoding MS-KILE Section 2.2.7 fixes: a 32 bit unsigned
+// integer in little-endian format. Getting the byte order wrong would advertise DES where AES was meant.
+func TestSupportedETypesShouldRoundTripTheWireFormat(t *testing.T) {
+	t.Parallel()
+
+	s := SupportedETypes(SupportedETypeAES256CTSHMACSHA196 | SupportedETypeAES128CTSHMACSHA196)
+
+	b := s.Marshal()
+	require.Len(t, b, 4)
+	assert.Equal(t, []byte{0x18, 0x00, 0x00, 0x00}, b, "AES128 (0x08) and AES256 (0x10) little-endian")
+
+	out, err := UnmarshalSupportedETypes(b)
+	require.NoError(t, err)
+	assert.Equal(t, s, out)
+}
+
+// TestUnmarshalSupportedETypesShouldRejectAWrongWidth asserts a value that is not four octets is refused rather
+// than read from whatever is present. MS-KILE Section 2.2.7 fixes the width.
+func TestUnmarshalSupportedETypesShouldRejectAWrongWidth(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		in   []byte
+	}{
+		{"Empty", nil},
+		{"Short", []byte{0x18, 0x00, 0x00}},
+		{"Long", []byte{0x18, 0x00, 0x00, 0x00, 0x00}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := UnmarshalSupportedETypes(tc.in)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "rather than 4")
+		})
+	}
+}
+
+// TestSupportedETypesBitValues pins every bit MS-KILE Section 2.2.7 assigns. These are the values an Active
+// Directory KDC reads; a wrong one silently advertises a different encryption type.
+func TestSupportedETypesBitValues(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, uint32(0x00000001), SupportedETypeDESCBCCRC)
+	assert.Equal(t, uint32(0x00000002), SupportedETypeDESCBCMD5)
+	assert.Equal(t, uint32(0x00000004), SupportedETypeRC4HMAC)
+	assert.Equal(t, uint32(0x00000008), SupportedETypeAES128CTSHMACSHA196)
+	assert.Equal(t, uint32(0x00000010), SupportedETypeAES256CTSHMACSHA196)
+	assert.Equal(t, uint32(0x00000020), SupportedETypeAES256CTSHMACSHA196SK)
+	assert.Equal(t, uint32(0x00000040), SupportedETypeAES128CTSHMACSHA256128)
+	assert.Equal(t, uint32(0x00000080), SupportedETypeAES256CTSHMACSHA384192)
+	assert.Equal(t, uint32(0x00010000), SupportedETypeFAST)
+	assert.Equal(t, uint32(0x00020000), SupportedETypeCompoundIdentity)
+	assert.Equal(t, uint32(0x00040000), SupportedETypeClaims)
+	assert.Equal(t, uint32(0x00080000), SupportedETypeResourceSIDCompressionDisabled)
+}
+
+// TestSupportedETypesShouldMapBitsToEncryptionTypes asserts each encryption type bit names the right encryption
+// type, in both directions.
+func TestSupportedETypesShouldMapBitsToEncryptionTypes(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		bit  uint32
+		id   int32
+	}{
+		{"DESCBCCRC", SupportedETypeDESCBCCRC, etypeID.DES_CBC_CRC},
+		{"DESCBCMD5", SupportedETypeDESCBCMD5, etypeID.DES_CBC_MD5},
+		{"RC4HMAC", SupportedETypeRC4HMAC, etypeID.RC4_HMAC},
+		{"AES128SHA196", SupportedETypeAES128CTSHMACSHA196, etypeID.AES128_CTS_HMAC_SHA1_96},
+		{"AES256SHA196", SupportedETypeAES256CTSHMACSHA196, etypeID.AES256_CTS_HMAC_SHA1_96},
+		{"AES128SHA256128", SupportedETypeAES128CTSHMACSHA256128, etypeID.AES128_CTS_HMAC_SHA256_128},
+		{"AES256SHA384192", SupportedETypeAES256CTSHMACSHA384192, etypeID.AES256_CTS_HMAC_SHA384_192},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.True(t, SupportedETypes(tc.bit).Contains(tc.id))
+			assert.Equal(t, []int32{tc.id}, SupportedETypes(tc.bit).ETypeIDs())
+			assert.Equal(t, SupportedETypes(tc.bit), NewSupportedETypesFromIDs([]int32{tc.id}))
+		})
+	}
+}
+
+// TestSupportedETypesShouldNotTreatTheSessionKeyPolicyBitAsAnEncryptionType asserts the J bit is excluded.
+// MS-KILE Section 2.2.7 describes AES256-CTS-HMAC-SHA1-96-SK as an instruction to the KDC to enforce AES session
+// keys when legacy ciphers are in use, not as an encryption type a peer can decrypt with. Reporting it as one
+// would advertise an encryption type that does not exist.
+func TestSupportedETypesShouldNotTreatTheSessionKeyPolicyBitAsAnEncryptionType(t *testing.T) {
+	t.Parallel()
+
+	s := SupportedETypes(SupportedETypeAES256CTSHMACSHA196SK)
+
+	assert.Empty(t, s.ETypeIDs())
+	assert.False(t, s.Contains(etypeID.AES256_CTS_HMAC_SHA1_96))
+}
+
+// TestSupportedETypesIntersectShouldDropCapabilityBits asserts that only encryption type bits survive an
+// intersection. The capability bits describe what a party can do rather than what two parties share, and this
+// library advertises none of them.
+func TestSupportedETypesIntersectShouldDropCapabilityBits(t *testing.T) {
+	t.Parallel()
+
+	kdc := SupportedETypes(SupportedETypeAES256CTSHMACSHA196 | SupportedETypeAES128CTSHMACSHA196 |
+		SupportedETypeRC4HMAC | SupportedETypeFAST | SupportedETypeClaims)
+	server := SupportedETypes(SupportedETypeAES256CTSHMACSHA196 | SupportedETypeRC4HMAC |
+		SupportedETypeCompoundIdentity)
+
+	got := kdc.Intersect(server)
+
+	assert.Equal(t, SupportedETypes(SupportedETypeAES256CTSHMACSHA196|SupportedETypeRC4HMAC), got)
+	assert.Equal(t, []int32{etypeID.AES256_CTS_HMAC_SHA1_96, etypeID.RC4_HMAC}, got.ETypeIDs())
+}
+
+// TestSupportedETypesIntersectShouldTreatZeroAsUnknown asserts an absent advertisement does not collapse the
+// result to nothing. MS-KILE gives no way to distinguish "advertised none" from "did not advertise", so a zero
+// value cannot be read as a claim that no encryption type is common.
+func TestSupportedETypesIntersectShouldTreatZeroAsUnknown(t *testing.T) {
+	t.Parallel()
+
+	known := SupportedETypes(SupportedETypeAES256CTSHMACSHA196 | SupportedETypeFAST)
+	want := SupportedETypes(SupportedETypeAES256CTSHMACSHA196)
+
+	assert.Equal(t, want, known.Intersect(0), "an unknown peer leaves our own types standing")
+	assert.Equal(t, want, SupportedETypes(0).Intersect(known), "and the same in the other direction")
+	assert.True(t, SupportedETypes(0).Intersect(0).IsZero())
+}
+
+// TestNewSupportedETypesFromIDsShouldSkipUnassignedEncryptionTypes asserts an encryption type with no bit assigned
+// by MS-KILE Section 2.2.7 is dropped rather than mapped to an arbitrary bit. The specification requires all other
+// bits to be zero when sent.
+func TestNewSupportedETypesFromIDsShouldSkipUnassignedEncryptionTypes(t *testing.T) {
+	t.Parallel()
+
+	s := NewSupportedETypesFromIDs([]int32{etypeID.AES256_CTS_HMAC_SHA1_96, etypeID.DES3_CBC_SHA1_KD})
+
+	assert.Equal(t, SupportedETypes(SupportedETypeAES256CTSHMACSHA196), s)
+	assert.Equal(t, []int32{etypeID.AES256_CTS_HMAC_SHA1_96}, s.ETypeIDs())
+}


### PR DESCRIPTION
Requesting gssapi.ContextFlagDeleg, or the new spnego.Delegation() option, obtains a forwarded TGT and carries it as a KRB_CRED in the AP-REQ authenticator checksum per RFC4121 4.1.1. Acceptors extract it into a credentials.CCache reached via Credentials.DelegatedCredentials.

The checksum layout moves into gssapi.AuthenticatorChecksum, shared by the initiator and acceptor paths. The forwarded TGT request follows MS-KILE: the etype is pinned to the service ticket's session key, and PA-SUPPORTED-ENCTYPES advertises the encryption types the KDC and the application server share. Delegation needs forwardable = true in krb5.conf before the AS exchange.

Also guards a remotely reachable panic in authenticatorKeyUsage, the short ciphertext decryption paths, and the ticket flag helpers.

BREAKING CHANGE: spnego.ErrDelegationUnimplemented is removed and requesting delegation now performs it, adding a TGS exchange per context. Acceptors reject a requesting-delegation client whose credential they cannot process, where previously they authenticated it without delegation.