### PR TITLE
feat: kile channel binding advertisement and delegation policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ The following section contains some implementation specific information.
 RFC 4121 Section 4.1.1 lets a client forward a ticket-granting ticket to the service it authenticates to, so the
 service can act as the client against a third party. This library implements both halves.
 
+`gssapi.ContextFlagDeleg` forwards unconditionally. `gssapi.ContextFlagDelegPolicy` forwards only where the KDC
+said the service may receive it, by setting `OK-AS-DELEGATE` on the service ticket; where the two disagree the
+policy flag wins, and a service ticket that is not in the client's cache is treated as not permitted. Prefer the
+policy flag against Active Directory, where `OK-AS-DELEGATE` reflects whether the account is trusted for
+delegation. Note that neither flag reports back whether forwarding actually happened, since this library has no
+`ret_flags` equivalent.
+
 As an initiator, request it with `gssapi.ContextFlagDeleg` or, for the SPNEGO client, the `spnego.Delegation()`
 option:
 

--- a/client/cache.go
+++ b/client/cache.go
@@ -7,8 +7,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-krb5/krb5/iana/flags"
 	"github.com/go-krb5/krb5/messages"
 	"github.com/go-krb5/krb5/types"
+	"github.com/go-krb5/x/encoding/asn1"
 )
 
 // Cache for service tickets held by the client.
@@ -35,6 +37,11 @@ type CacheEntry struct {
 	// Excluded from the JSON rendering, like Ticket and SessionKey, so that Client.Diagnostics keeps the output
 	// it had before delegation existed.
 	SupportedETypes types.SupportedETypes `json:"-"`
+
+	// TicketFlags are the flags the KDC reported for this ticket in the TGS-REP. The client cannot read them from
+	// the ticket itself, which is encrypted to the service, so the reply is the only source. Excluded from the
+	// JSON rendering for the same reason as the fields above.
+	TicketFlags asn1.BitString `json:"-"`
 }
 
 // NewCache creates a new client ticket cache instance.
@@ -81,7 +88,7 @@ func (c *Cache) JSON() (string, error) {
 }
 
 // addEntry adds a ticket to the cache.
-func (c *Cache) addEntry(tkt messages.Ticket, authTime, startTime, endTime, renewTill time.Time, sessionKey types.EncryptionKey, supported types.SupportedETypes) CacheEntry {
+func (c *Cache) addEntry(tkt messages.Ticket, authTime, startTime, endTime, renewTill time.Time, sessionKey types.EncryptionKey, supported types.SupportedETypes, ticketFlags asn1.BitString) CacheEntry {
 	spn := tkt.SName.PrincipalNameString()
 
 	c.mux.Lock()
@@ -97,6 +104,7 @@ func (c *Cache) addEntry(tkt messages.Ticket, authTime, startTime, endTime, rene
 		SessionKey: sessionKey,
 
 		SupportedETypes: supported,
+		TicketFlags:     ticketFlags,
 	}
 
 	return c.Entries[spn]
@@ -164,4 +172,19 @@ func (cl *Client) renewTicket(e CacheEntry) (CacheEntry, error) {
 	cl.Log("ticket renewed for %s (EndTime: %v)", spn.PrincipalNameString(), e.EndTime)
 
 	return e, nil
+}
+
+// OKAsDelegate reports whether the cached service ticket for the principal given was issued with the
+// OK-AS-DELEGATE flag, which RFC 4120 Section 2.8 defines and MS-KILE Section 3.3.1.1 has the KDC set when the
+// service account is trusted for delegation.
+//
+// A ticket that is not cached reports false. The flag gates handing a service the client's whole identity, so an
+// unknown answer is treated as a refusal rather than as permission.
+func (cl *Client) OKAsDelegate(spn types.PrincipalName) bool {
+	e, ok := cl.cache.getEntry(spn.PrincipalNameString())
+	if !ok {
+		return false
+	}
+
+	return types.IsFlagSet(&e.TicketFlags, flags.OKAsDelegate)
 }

--- a/client/cache_test.go
+++ b/client/cache_test.go
@@ -9,10 +9,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-krb5/krb5/config"
 	"github.com/go-krb5/krb5/iana/etypeID"
+	"github.com/go-krb5/krb5/iana/flags"
 	"github.com/go-krb5/krb5/iana/nametype"
 	"github.com/go-krb5/krb5/messages"
+	"github.com/go-krb5/krb5/test/testdata"
 	"github.com/go-krb5/krb5/types"
+	"github.com/go-krb5/x/encoding/asn1"
 )
 
 func TestCache_addEntry_getEntry_remove_clear(t *testing.T) {
@@ -37,7 +41,7 @@ func TestCache_addEntry_getEntry_remove_clear(t *testing.T) {
 			KeyValue: []byte{byte(i)},
 		}
 		go func(i int) {
-			e := c.addEntry(tkt, time.Unix(int64(0+i), 0).UTC(), time.Unix(int64(10+i), 0).UTC(), time.Unix(int64(20+i), 0).UTC(), time.Unix(int64(30+i), 0).UTC(), key, 0)
+			e := c.addEntry(tkt, time.Unix(int64(0+i), 0).UTC(), time.Unix(int64(10+i), 0).UTC(), time.Unix(int64(20+i), 0).UTC(), time.Unix(int64(30+i), 0).UTC(), key, 0, asn1.BitString{})
 			assert.Equal(t, fmt.Sprintf("%d/test.cache", i), e.SPN)
 			wg.Done()
 		}(i)
@@ -133,7 +137,7 @@ func TestCache_JSON(t *testing.T) {
 			KeyType:  1,
 			KeyValue: []byte{byte(i)},
 		}
-		e := c.addEntry(tkt, time.Unix(int64(0+i), 0).UTC(), time.Unix(int64(10+i), 0).UTC(), time.Unix(int64(20+i), 0).UTC(), time.Unix(int64(30+i), 0).UTC(), key, 0)
+		e := c.addEntry(tkt, time.Unix(int64(0+i), 0).UTC(), time.Unix(int64(10+i), 0).UTC(), time.Unix(int64(20+i), 0).UTC(), time.Unix(int64(30+i), 0).UTC(), key, 0, asn1.BitString{})
 		assert.Equal(t, fmt.Sprintf("%d/test.cache", i), e.SPN)
 	}
 
@@ -181,9 +185,37 @@ func TestCacheShouldRetainTheServerSupportedEncryptionTypes(t *testing.T) {
 	}
 
 	c.addEntry(tkt, time.Unix(0, 0).UTC(), time.Unix(10, 0).UTC(), time.Unix(20, 0).UTC(), time.Unix(30, 0).UTC(),
-		types.EncryptionKey{}, want)
+		types.EncryptionKey{}, want, asn1.BitString{})
 
 	e, ok := c.getEntry("HTTP/host.test.gokrb5")
 	require.True(t, ok)
 	assert.Equal(t, want, e.SupportedETypes)
+}
+
+// TestOKAsDelegateShouldReportTheCachedTicketFlag asserts the gate ContextFlagDelegPolicy consults. The flag lives
+// in the ticket's encrypted part, which the client cannot read, so the TGS-REP is the only source and it has to
+// survive into the cache.
+func TestOKAsDelegateShouldReportTheCachedTicketFlag(t *testing.T) {
+	t.Parallel()
+
+	c, err := config.NewFromString(testdata.KRB5_CONF)
+	require.NoError(t, err)
+
+	cl := NewWithPassword("testuser1", "TEST.GOKRB5", "passwordvalue", c)
+	spn := types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{"HTTP", "host.test.gokrb5"}}
+
+	assert.False(t, cl.OKAsDelegate(spn), "a ticket that is not cached must not be treated as delegable")
+
+	tkt := messages.Ticket{SName: spn}
+
+	cl.cache.addEntry(tkt, time.Unix(0, 0).UTC(), time.Unix(10, 0).UTC(), time.Unix(20, 0).UTC(),
+		time.Unix(30, 0).UTC(), types.EncryptionKey{}, 0, types.NewKrbFlags())
+	assert.False(t, cl.OKAsDelegate(spn))
+
+	okFlags := types.NewKrbFlags()
+	types.SetFlag(&okFlags, flags.OKAsDelegate)
+
+	cl.cache.addEntry(tkt, time.Unix(0, 0).UTC(), time.Unix(10, 0).UTC(), time.Unix(20, 0).UTC(),
+		time.Unix(30, 0).UTC(), types.EncryptionKey{}, 0, okFlags)
+	assert.True(t, cl.OKAsDelegate(spn))
 }

--- a/client/client.go
+++ b/client/client.go
@@ -123,6 +123,7 @@ func NewFromCCache(c *credentials.CCache, krb5conf *config.Config, settings ...f
 			// A ccache records no PA-SUPPORTED-ENCTYPES, so the application server's advertised encryption
 			// types are unknown for tickets loaded from one.
 			0,
+			cred.TicketFlags,
 		)
 	}
 

--- a/client/tgs_exchange.go
+++ b/client/tgs_exchange.go
@@ -85,6 +85,7 @@ func (cl *Client) TGSExchange(tgsReq messages.TGSReq, kdcRealm string, tgt messa
 		tgsRep.DecryptedEncPart.RenewTill,
 		tgsRep.DecryptedEncPart.Key,
 		types.SupportedETypesFromPAData(tgsRep.DecryptedEncPart.EncPAData),
+		tgsRep.DecryptedEncPart.Flags,
 	)
 	cl.Log("ticket added to cache for %s (EndTime: %v)", tgsRep.Ticket.SName.PrincipalNameString(), tgsRep.DecryptedEncPart.EndTime)
 

--- a/gssapi/context_flags.go
+++ b/gssapi/context_flags.go
@@ -11,6 +11,12 @@ const (
 	ContextFlagConf     = 16
 	ContextFlagInteg    = 32
 	ContextFlagAnon     = 64
+
+	// ContextFlagDelegPolicy requests delegation only where the KDC has said the service may receive it, by
+	// setting OK-AS-DELEGATE on the service ticket. It is not an IANA assignment: it originates with Microsoft's
+	// SSPI and is implemented by MIT, and its value falls in the 4096 to 524288 range RFC 4121 Section 4.1.1.1
+	// reserves for legacy vendor-specific extensions, which is why the authenticator checksum may carry it.
+	ContextFlagDelegPolicy = 0x8000
 )
 
 // ContextFlags flags for GSSAPI

--- a/iana/adtype/constants.go
+++ b/iana/adtype/constants.go
@@ -20,4 +20,9 @@ const (
 	ADWin2KPAC                    int32 = 128
 	ADEtypeNegotiation            int32 = 129
 	// Reserved values                   9-63.
+
+	// ADAuthDataAPOptions carries the KILE AP options of MS-KILE Section 2.2.5. A client that expects its
+	// applications to supply channel bindings sends it inside the first AD-IF-RELEVANT element of the AP-REQ
+	// authenticator, per MS-KILE Section 3.2.5.2. It is a Microsoft assignment, not an IANA one.
+	ADAuthDataAPOptions int32 = 143
 )

--- a/service/ap_exchange.go
+++ b/service/ap_exchange.go
@@ -32,6 +32,10 @@ func VerifyAPREQ(APReq *messages.APReq, s *Settings) (bool, *credentials.Credent
 		if err = verifyChannelBinding(APReq, cb); err != nil {
 			return false, creds, err
 		}
+	} else if s.RequireChannelBindingSupport() {
+		if err = verifyChannelBindingSupport(APReq); err != nil {
+			return false, creds, err
+		}
 	}
 
 	// Check for replay.
@@ -254,4 +258,41 @@ func decryptDelegatedCredential(cred *messages.KRBCred, APReq *messages.APReq) e
 	}
 
 	return fmt.Errorf("could not decrypt the delegated credential with the authenticator subkey or the ticket session key: %w", err)
+}
+
+// verifyChannelBindingSupport applies the rule MS-KILE Section 3.4.5.3 gives an application server whose
+// ApplicationRequiresCBT parameter is set: "return GSS_S_BAD_BINDINGS whenever the AP exchange request message
+// contains an all-zero channel binding value and does not contain the AD-IF-RELEVANT element
+// KERB_AP_OPTIONS_CBT".
+//
+// Both conditions must hold for a rejection, which makes this strictly weaker than verifyChannelBinding: a peer
+// that advertises KERB_AP_OPTIONS_CBT and then supplies no binding passes here and would fail there. That is
+// Microsoft's compatibility compromise, not an equivalent check, and the setting that reaches this documents the
+// difference.
+//
+// A binding that is present but wrong is not this function's concern. It cannot be: this mode has no binding to
+// compare against, which is the other reason it is weaker.
+func verifyChannelBindingSupport(APReq *messages.APReq) error {
+	cksum := APReq.Authenticator.Cksum.Checksum
+
+	if APReq.Authenticator.Cksum.CksumType != chksumtype.GSSAPI || len(cksum) < gssapi.ChecksumMinLen {
+		return newBadChannelBindingError(APReq, "authenticator does not contain a GSSAPI checksum carrying channel bindings")
+	}
+
+	var c gssapi.AuthenticatorChecksum
+
+	if err := c.Unmarshal(cksum); err != nil {
+		return newBadChannelBindingError(APReq, fmt.Sprintf("authenticator GSSAPI checksum could not be read: %s", err.Error()))
+	}
+
+	if c.Bnd != ([16]byte{}) {
+		return nil
+	}
+
+	if types.ADAPOptionsFromAuthorizationData(APReq.Authenticator.AuthorizationData).Has(types.ADAPOptionsCBT) {
+		return nil
+	}
+
+	return newBadChannelBindingError(APReq,
+		"authenticator carries no channel binding and does not advertise KERB_AP_OPTIONS_CBT, so the client cannot bind to the outer channel")
 }

--- a/service/ap_exchange_test.go
+++ b/service/ap_exchange_test.go
@@ -943,3 +943,76 @@ func getClient(t *testing.T) *client.Client {
 
 	return cl
 }
+
+// testAPReqAdvertisingCBT builds an AP_REQ whose checksum carries the binding given and whose authenticator
+// advertises KERB_AP_OPTIONS_CBT, as MS-KILE Section 3.2.5.2 has a binding-capable client do.
+func testAPReqAdvertisingCBT(t *testing.T, cb *gssapi.ChannelBinding) *messages.APReq {
+	t.Helper()
+
+	r := testAPReqWithChecksum(chksumtype.GSSAPI, testGSSAPIChecksum(cb))
+
+	ad, err := types.ADAPOptions(types.ADAPOptionsCBT).AuthorizationData()
+	require.NoError(t, err)
+
+	r.Authenticator.AuthorizationData = ad
+
+	return r
+}
+
+// TestVerifyChannelBindingSupportShouldRejectOnlyWhenBothConditionsHold pins the MS-KILE Section 3.4.5.3 rule this
+// mode implements: reject when the binding is all zero AND the client does not advertise KERB_AP_OPTIONS_CBT.
+// Either condition alone is not a rejection, which is exactly what makes this weaker than verifyChannelBinding.
+func TestVerifyChannelBindingSupportShouldRejectOnlyWhenBothConditionsHold(t *testing.T) {
+	t.Parallel()
+
+	bound := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:test")}
+
+	t.Run("UnboundAndUnadvertisedIsRejected", func(t *testing.T) {
+		t.Parallel()
+
+		err := verifyChannelBindingSupport(testAPReqWithChecksum(chksumtype.GSSAPI, testGSSAPIChecksum(nil)))
+		require.ErrorIs(t, err, ErrBadChannelBinding)
+		assert.Contains(t, err.Error(), "KERB_AP_OPTIONS_CBT")
+	})
+
+	t.Run("UnboundButAdvertisedIsAccepted", func(t *testing.T) {
+		t.Parallel()
+
+		// This is the case that separates this mode from RequireChannelBinding, which refuses it.
+		assert.NoError(t, verifyChannelBindingSupport(testAPReqAdvertisingCBT(t, nil)))
+	})
+
+	t.Run("BoundIsAcceptedEvenWithoutTheAdvertisement", func(t *testing.T) {
+		t.Parallel()
+
+		assert.NoError(t, verifyChannelBindingSupport(testAPReqWithChecksum(chksumtype.GSSAPI, testGSSAPIChecksum(bound))))
+	})
+
+	t.Run("BoundAndAdvertisedIsAccepted", func(t *testing.T) {
+		t.Parallel()
+
+		assert.NoError(t, verifyChannelBindingSupport(testAPReqAdvertisingCBT(t, bound)))
+	})
+}
+
+// TestVerifyChannelBindingShouldStillRefuseAnAdvertisedButUnboundRequest is the guard on the distinction between
+// the two modes. The strict setting must NOT inherit MS-KILE's leniency: a peer that advertises CBT and then sends
+// no binding is the stripped-binding downgrade RequireChannelBinding exists to prevent.
+func TestVerifyChannelBindingShouldStillRefuseAnAdvertisedButUnboundRequest(t *testing.T) {
+	t.Parallel()
+
+	want := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:want")}
+
+	err := verifyChannelBinding(testAPReqAdvertisingCBT(t, nil), want)
+
+	require.ErrorIs(t, err, ErrBadChannelBinding)
+	assert.Contains(t, err.Error(), "channel binding mismatch")
+}
+
+// TestSettingsRequireChannelBindingSupportShouldDefaultToFalse asserts the weaker mode is opt-in.
+func TestSettingsRequireChannelBindingSupportShouldDefaultToFalse(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, NewSettings(nil).RequireChannelBindingSupport())
+	assert.True(t, NewSettings(nil, RequireChannelBindingSupport(true)).RequireChannelBindingSupport())
+}

--- a/service/settings.go
+++ b/service/settings.go
@@ -12,16 +12,17 @@ import (
 
 // Settings defines service side configuration settings.
 type Settings struct {
-	Keytab             *keytab.Keytab
-	ktprinc            *types.PrincipalName
-	sname              string
-	requireHostAddr    bool
-	disablePACDecoding bool
-	cAddr              types.HostAddress
-	maxClockSkew       time.Duration
-	logger             *log.Logger
-	sessionMgr         SessionMgr
-	channelBinding     *gssapi.ChannelBinding
+	Keytab                *keytab.Keytab
+	ktprinc               *types.PrincipalName
+	sname                 string
+	requireHostAddr       bool
+	disablePACDecoding    bool
+	cAddr                 types.HostAddress
+	maxClockSkew          time.Duration
+	logger                *log.Logger
+	sessionMgr            SessionMgr
+	channelBinding        *gssapi.ChannelBinding
+	channelBindingSupport bool
 }
 
 // NewSettings creates a new service Settings.
@@ -178,6 +179,33 @@ func RequireChannelBinding(cb *gssapi.ChannelBinding) func(*Settings) {
 // RequireChannelBinding returns the channel binding the service requires, or nil if it does not require one.
 func (s *Settings) RequireChannelBinding() *gssapi.ChannelBinding {
 	return s.channelBinding
+}
+
+// RequireChannelBindingSupport applies the weaker rule MS-KILE Section 3.4.5.3 gives an application server whose
+// ApplicationRequiresCBT parameter is set: reject a request whose channel binding is all zero AND which does not
+// advertise KERB_AP_OPTIONS_CBT, and accept everything else.
+//
+// This is deliberately NOT what RequireChannelBinding does, and the two are not interchangeable.
+// RequireChannelBinding demands that the binding match, so a stripped binding is refused. This setting only
+// demands that the peer be capable of binding, so a client that advertises KERB_AP_OPTIONS_CBT and then sends no
+// binding is accepted — which is the stripped-binding downgrade RequireChannelBinding exists to prevent. It is
+// offered for parity with Windows deployments that must still admit such clients, and is the weaker of the two.
+//
+// Prefer RequireChannelBinding. Reach for this one only when a peer you cannot change forces it.
+//
+// If both are configured RequireChannelBinding is applied and this is ignored, since a binding that must match
+// already satisfies a rule asking only that the peer could have bound.
+//
+//	s := NewSettings(kt, RequireChannelBindingSupport(true)).
+func RequireChannelBindingSupport(b bool) func(*Settings) {
+	return func(s *Settings) {
+		s.channelBindingSupport = b
+	}
+}
+
+// RequireChannelBindingSupport indicates whether the service requires peers to advertise channel binding support.
+func (s *Settings) RequireChannelBindingSupport() bool {
+	return s.channelBindingSupport
 }
 
 // SessionMgr must provide a ways to:

--- a/spnego/krb5_token.go
+++ b/spnego/krb5_token.go
@@ -255,7 +255,7 @@ func NewKRB5TokenAPREQ(cl *client.Client, tkt messages.Ticket, sessionKey types.
 
 	opt := newKRB5TokenOptions(opts...)
 
-	if opt.delegation && !delegationRequested(flagsGSSAPI) {
+	if opt.delegation && !delegationFlagged(flagsGSSAPI) {
 		// Copied rather than appended in place: flagsGSSAPI belongs to the caller and may have spare capacity.
 		flagsGSSAPI = append(append([]int(nil), flagsGSSAPI...), gssapi.ContextFlagDeleg)
 	}
@@ -320,7 +320,7 @@ func krb5TokenAuthenticator(cl *client.Client, tkt messages.Ticket, sessionKey t
 
 	var deleg []byte
 
-	if delegationRequested(flags) {
+	if delegationRequested(cl, tkt, flags) {
 		if deleg, err = delegatedCredential(cl, tkt, sessionKey); err != nil {
 			return auth, err
 		}
@@ -336,19 +336,58 @@ func krb5TokenAuthenticator(cl *client.Client, tkt messages.Ticket, sessionKey t
 		Checksum:  chksum,
 	}
 
+	// MS-KILE Section 3.2.5.2 has a client that supplies channel bindings also advertise KERB_AP_OPTIONS_CBT in
+	// the authenticator's authorization data, which is how a Windows acceptor with ApplicationRequiresCBT tells a
+	// binding-capable client from one predating the feature. The Bnd field alone does not carry that: an unbound
+	// request and a request from a client that cannot bind at all look identical there.
+	if cb != nil {
+		if auth.AuthorizationData, err = types.ADAPOptions(types.ADAPOptionsCBT).AuthorizationData(); err != nil {
+			return auth, krberror.Errorf(err, krberror.EncodingError, "error generating authenticator authorization data")
+		}
+	}
+
 	return auth, nil
 }
 
 // delegationRequested reports whether any of the flags carries GSS_C_DELEG_FLAG. The bit is tested rather than the
 // value because callers may combine flags into a single slice element.
-func delegationRequested(flags []int) bool {
+func delegationRequested(cl *client.Client, tkt messages.Ticket, flags []int) bool {
+	deleg, policy := delegationFlags(flags)
+
+	// ContextFlagDelegPolicy asks that the KDC's opinion be honoured, so wherever it appears the ticket decides.
+	// MIT differs here: because its flag mask sets GSS_C_DELEG_FLAG unconditionally, a caller passing both flags
+	// delegates whether or not the ticket permits it, and only its enforce_ok_as_delegate configuration, which
+	// replaces one flag with the other, produces the gate. A caller that names the policy flag at all has asked
+	// for the gate, so honouring it is the reading that cannot surprise anyone into over-delegating.
+	if policy {
+		return cl.OKAsDelegate(tkt.SName)
+	}
+
+	return deleg
+}
+
+// delegationFlagged reports whether any delegation is being asked for, ignoring whether policy would permit it.
+// It exists to keep the option plumbing from adding a flag the caller already supplied.
+func delegationFlagged(flags []int) bool {
+	deleg, policy := delegationFlags(flags)
+
+	return deleg || policy
+}
+
+// delegationFlags reports which delegation flags appear. The bits are tested rather than the values, because
+// callers may combine flags into a single slice element.
+func delegationFlags(flags []int) (deleg, policy bool) {
 	for _, i := range flags {
 		if i&gssapi.ContextFlagDeleg != 0 {
-			return true
+			deleg = true
+		}
+
+		if i&gssapi.ContextFlagDelegPolicy != 0 {
+			policy = true
 		}
 	}
 
-	return false
+	return deleg, policy
 }
 
 // delegatedCredential obtains a forwarded TGT and marshals it as the KRB_CRED that RFC 4121 Section 4.1.1 carries

--- a/spnego/krb5_token_test.go
+++ b/spnego/krb5_token_test.go
@@ -492,7 +492,7 @@ func TestNewNegTokenInitKRB5ShouldReturnAMatchableErrNotForwardable(t *testing.T
 // element, which is what the flags are: a bitmask. delegationRequested is the only thing deciding whether a KDC
 // round trip happens, so a value comparison here would silently skip the forwarding exchange for a caller passing
 // ContextFlagDeleg|ContextFlagInteg and produce the non-delegating token that this branch exists to prevent.
-func TestDelegationRequestedShouldTestTheBit(t *testing.T) {
+func TestDelegationFlaggedShouldTestTheBit(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -506,13 +506,15 @@ func TestDelegationRequestedShouldTestTheBit(t *testing.T) {
 		{"ShouldNotDetectOtherFlagsCombined", []int{gssapi.ContextFlagInteg | gssapi.ContextFlagConf}, false},
 		{"ShouldNotDetectOtherFlags", []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, false},
 		{"ShouldNotDetectAnythingInNoFlags", nil, false},
+		{"ShouldDetectThePolicyFlagOnItsOwn", []int{gssapi.ContextFlagDelegPolicy}, true},
+		{"ShouldDetectThePolicyFlagCombinedIntoOneElement", []int{gssapi.ContextFlagDelegPolicy | gssapi.ContextFlagInteg}, true},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, tc.expected, delegationRequested(tc.flags))
+			assert.Equal(t, tc.expected, delegationFlagged(tc.flags))
 		})
 	}
 }
@@ -643,4 +645,28 @@ func TestKRB5TokenVerifyShouldReportChannelBindingFailuresAsBadBindings(t *testi
 		assert.Equal(t, gssapi.StatusDefectiveToken, status.Code)
 		assert.NotEqual(t, gssapi.StatusBadBindings, status.Code)
 	})
+}
+
+// TestKrb5TokenAuthenticatorShouldAdvertiseCBTWhenBound asserts MS-KILE Section 3.2.5.2: a client supplying
+// channel bindings also sends AD-AUTH-DATA-AP-OPTIONS with KERB_AP_OPTIONS_CBT in the first AD-IF-RELEVANT
+// element. That advertisement, not the Bnd field, is what a Windows acceptor with ApplicationRequiresCBT uses to
+// tell a binding-capable client from one predating the feature.
+func TestKrb5TokenAuthenticatorShouldAdvertiseCBTWhenBound(t *testing.T) {
+	t.Parallel()
+
+	cl := getClient(t)
+	cb := &gssapi.ChannelBinding{ApplicationData: []byte("tls-server-end-point:test")}
+
+	bound, err := krb5TokenAuthenticator(cl, messages.Ticket{}, types.EncryptionKey{},
+		[]int{gssapi.ContextFlagInteg}, cb)
+	require.NoError(t, err)
+
+	assert.True(t, types.ADAPOptionsFromAuthorizationData(bound.AuthorizationData).Has(types.ADAPOptionsCBT))
+
+	// Without a binding there is nothing to advertise, and the authenticator must be what it was before.
+	unbound, err := krb5TokenAuthenticator(cl, messages.Ticket{}, types.EncryptionKey{},
+		[]int{gssapi.ContextFlagInteg}, nil)
+	require.NoError(t, err)
+
+	assert.Empty(t, unbound.AuthorizationData)
 }

--- a/types/ad_ap_options.go
+++ b/types/ad_ap_options.go
@@ -1,0 +1,101 @@
+package types
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/go-krb5/x/encoding/asn1"
+
+	"github.com/go-krb5/krb5/iana/adtype"
+)
+
+// KILE AP option bit flags, carried in the AD-AUTH-DATA-AP-OPTIONS authorization data of MS-KILE Section 2.2.5.
+const (
+	// ADAPOptionsCBT indicates that the client expects the applications running on it to include channel binding
+	// information in AP requests whenever Kerberos authentication takes place over an outer channel such as TLS.
+	// It says nothing about whether this particular request carries a binding.
+	ADAPOptionsCBT uint32 = 0x4000
+
+	// ADAPOptionsUnverifiedTargetName indicates the client could not verify the service principal name it is
+	// authenticating to. This library never sets it and is declared for completeness of MS-KILE Section 2.2.5.
+	ADAPOptionsUnverifiedTargetName uint32 = 0x8000
+)
+
+// adAPOptionsLen is the width MS-KILE Section 3.2.5.2 fixes for the value: four octets, little-endian.
+const adAPOptionsLen = 4
+
+// ADAPOptions is the value of the AD-AUTH-DATA-AP-OPTIONS authorization data described by MS-KILE Section 2.2.5.
+//
+// The zero value means the peer sent no such element, which for ADAPOptionsCBT is the state a Kerberos
+// implementation predating KILE's channel binding support is in. It is not a claim that the peer rejects channel
+// bindings.
+type ADAPOptions uint32
+
+// UnmarshalADAPOptions reads the four octet little-endian value.
+func UnmarshalADAPOptions(b []byte) (ADAPOptions, error) {
+	if len(b) != adAPOptionsLen {
+		return 0, fmt.Errorf("AD-AUTH-DATA-AP-OPTIONS is %d octets rather than %d", len(b), adAPOptionsLen)
+	}
+
+	return ADAPOptions(binary.LittleEndian.Uint32(b)), nil
+}
+
+// Marshal returns the four octet little-endian encoding.
+func (o ADAPOptions) Marshal() []byte {
+	b := make([]byte, adAPOptionsLen)
+	binary.LittleEndian.PutUint32(b, uint32(o))
+
+	return b
+}
+
+// Has reports whether the option given is set.
+func (o ADAPOptions) Has(opt uint32) bool {
+	return uint32(o)&opt != 0
+}
+
+// AuthorizationData wraps the options in the AD-IF-RELEVANT element MS-KILE Section 3.2.5.2 requires: "the client
+// sends the Authorization Data Type AD-AUTH-DATA-AP-OPTIONS (143) data in the first AD-IF-RELEVANT element".
+//
+// AD-IF-RELEVANT is the right container because RFC 4120 Section 5.2.6.1 lets a receiver that does not understand
+// the enclosed elements ignore them, which is what any non-KILE acceptor will do with these.
+func (o ADAPOptions) AuthorizationData() (AuthorizationData, error) {
+	inner := AuthorizationData{
+		{ADType: adtype.ADAuthDataAPOptions, ADData: o.Marshal()},
+	}
+
+	b, err := asn1.Marshal(inner, asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling AD-AUTH-DATA-AP-OPTIONS: %w", err)
+	}
+
+	return AuthorizationData{{ADType: adtype.ADIfRelevant, ADData: b}}, nil
+}
+
+// ADAPOptionsFromAuthorizationData returns the KILE AP options an authenticator carries, or zero when it carries
+// none.
+//
+// Both the AD-IF-RELEVANT nesting MS-KILE specifies and a bare top level entry are accepted, because the value is
+// read to learn what a peer supports rather than to make an authorization decision, and a peer that placed it one
+// level out has still told us the same thing. A malformed entry is treated as absent for the same reason.
+func ADAPOptionsFromAuthorizationData(ad AuthorizationData) ADAPOptions {
+	for _, e := range ad {
+		switch e.ADType {
+		case adtype.ADAuthDataAPOptions:
+			if o, err := UnmarshalADAPOptions(e.ADData); err == nil {
+				return o
+			}
+		case adtype.ADIfRelevant:
+			var inner AuthorizationData
+
+			if _, err := asn1.Unmarshal(e.ADData, &inner); err != nil {
+				continue
+			}
+
+			if o := ADAPOptionsFromAuthorizationData(inner); o != 0 {
+				return o
+			}
+		}
+	}
+
+	return 0
+}

--- a/types/ad_ap_options_test.go
+++ b/types/ad_ap_options_test.go
@@ -1,0 +1,105 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/krb5/iana/adtype"
+)
+
+// TestADAPOptionsShouldRoundTripTheWireFormat pins the encoding MS-KILE Section 3.2.5.2 fixes: the ad-data of
+// KERB_AP_OPTIONS_CBT "encoded as a four byte little-endian unsigned integer".
+func TestADAPOptionsShouldRoundTripTheWireFormat(t *testing.T) {
+	t.Parallel()
+
+	b := ADAPOptions(ADAPOptionsCBT).Marshal()
+
+	require.Len(t, b, 4)
+	assert.Equal(t, []byte{0x00, 0x40, 0x00, 0x00}, b, "0x4000 little-endian")
+
+	o, err := UnmarshalADAPOptions(b)
+	require.NoError(t, err)
+	assert.True(t, o.Has(ADAPOptionsCBT))
+	assert.False(t, o.Has(ADAPOptionsUnverifiedTargetName))
+}
+
+// TestUnmarshalADAPOptionsShouldRejectAWrongWidth asserts a value that is not four octets is refused rather than
+// read from whatever is present.
+func TestUnmarshalADAPOptionsShouldRejectAWrongWidth(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		in   []byte
+	}{
+		{"Empty", nil},
+		{"Short", []byte{0x00, 0x40, 0x00}},
+		{"Long", []byte{0x00, 0x40, 0x00, 0x00, 0x00}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := UnmarshalADAPOptions(tc.in)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "rather than 4")
+		})
+	}
+}
+
+// TestADAPOptionsAuthorizationDataShouldNestInADIfRelevant asserts the container MS-KILE Section 3.2.5.2 requires:
+// the element goes "in the first AD-IF-RELEVANT element". A bare top level entry would be read by acceptors that
+// do not understand it as mandatory authorization data rather than as advisory.
+func TestADAPOptionsAuthorizationDataShouldNestInADIfRelevant(t *testing.T) {
+	t.Parallel()
+
+	ad, err := ADAPOptions(ADAPOptionsCBT).AuthorizationData()
+	require.NoError(t, err)
+
+	require.Len(t, ad, 1)
+	assert.Equal(t, adtype.ADIfRelevant, ad[0].ADType)
+
+	assert.True(t, ADAPOptionsFromAuthorizationData(ad).Has(ADAPOptionsCBT),
+		"what we write must be what we read")
+}
+
+// TestADAPOptionsFromAuthorizationDataShouldToleratePlacement asserts the reader accepts the value nested as
+// MS-KILE specifies and bare at the top level. The value says what a peer supports; a peer that placed it one
+// level out has still said it.
+func TestADAPOptionsFromAuthorizationDataShouldToleratePlacement(t *testing.T) {
+	t.Parallel()
+
+	nested, err := ADAPOptions(ADAPOptionsCBT).AuthorizationData()
+	require.NoError(t, err)
+	assert.True(t, ADAPOptionsFromAuthorizationData(nested).Has(ADAPOptionsCBT))
+
+	bare := AuthorizationData{
+		{ADType: adtype.ADAuthDataAPOptions, ADData: ADAPOptions(ADAPOptionsCBT).Marshal()},
+	}
+	assert.True(t, ADAPOptionsFromAuthorizationData(bare).Has(ADAPOptionsCBT))
+}
+
+// TestADAPOptionsFromAuthorizationDataShouldReturnZeroWhenAbsentOrMalformed asserts the absence of the element and
+// a corrupt one are both reported as "not advertised" rather than as an error. The value is read to learn what a
+// peer supports, so failing the exchange over it would trade a working authentication for a hint.
+func TestADAPOptionsFromAuthorizationDataShouldReturnZeroWhenAbsentOrMalformed(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		in   AuthorizationData
+	}{
+		{"Nil", nil},
+		{"Empty", AuthorizationData{}},
+		{"OtherType", AuthorizationData{{ADType: adtype.ADWin2KPAC, ADData: []byte{1, 2, 3, 4}}}},
+		{"MalformedValue", AuthorizationData{{ADType: adtype.ADAuthDataAPOptions, ADData: []byte{1, 2}}}},
+		{"MalformedNesting", AuthorizationData{{ADType: adtype.ADIfRelevant, ADData: []byte{0xFF, 0xFF}}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Zero(t, ADAPOptionsFromAuthorizationData(tc.in))
+		})
+	}
+}


### PR DESCRIPTION
An initiator supplying channel bindings now also advertises KERB_AP_OPTIONS_CBT in the authenticator's authorization data, per MS-KILE 3.2.5.2. The Bnd field cannot carry that on its own: an unbound request and a request from a client that cannot bind look identical there, which is what a Windows acceptor with ApplicationRequiresCBT needs to tell apart.

Acceptors gain service.RequireChannelBindingSupport, implementing the MS-KILE 3.4.5.3 rule of rejecting only a request that is both unbound and unadvertised. It is deliberately a second, weaker setting rather than a relaxation of RequireChannelBinding: it accepts a peer that advertises CBT and then sends no binding, which is the stripped-binding downgrade the strict setting exists to refuse. A test pins that the strict path did not inherit the leniency.

gssapi.ContextFlagDelegPolicy forwards a TGT only where the service ticket carries OK-AS-DELEGATE. The flag lives in the ticket's encrypted part, so the TGS-REP is the only source and its flags now ride on the cache entry. Where both delegation flags appear the policy wins, which is stricter than MIT, whose mask sets GSS_C_DELEG_FLAG unconditionally and gates only through enforce_ok_as_delegate. An uncached ticket counts as not permitted.