### PR TITLE
fix(spnego): unhandled panic in neg token init

### DIFF
--- a/spnego/negotiation_token.go
+++ b/spnego/negotiation_token.go
@@ -303,6 +303,13 @@ func UnmarshalNegToken(b []byte) (bool, any, error) {
 			return false, nil, fmt.Errorf("error unmarshalling NegotiationToken type %d (Init): %w", a.Tag, err)
 		}
 
+		// MechTypeList is a SEQUENCE OF, so a token carrying a zero length one decodes without error. RFC 4178
+		// Section 4.2.1 defines the field as "one or more security mechanisms available for the initiator", so a
+		// token offering none is malformed: there is no mechanism to negotiate.
+		if len(n.MechTypes) == 0 {
+			return false, nil, errors.New("NegTokenInit does not contain any mechanism types")
+		}
+
 		nt := NegTokenInit{
 			MechTypes:      n.MechTypes,
 			ReqFlags:       n.ReqFlags,

--- a/spnego/negotiation_token_test.go
+++ b/spnego/negotiation_token_test.go
@@ -102,3 +102,14 @@ func TestUnmarshal_negTokenInitWithReqFlags(t *testing.T) {
 
 	assert.Equal(t, 3, len(m.MechTokenBytes))
 }
+
+func TestUnmarshal_negTokenInitEmptyMechTypes(t *testing.T) {
+	t.Parallel()
+
+	// A NegTokenInit whose mechTypes is a zero length SEQUENCE OF. RFC 4178 Section 4.2.1 defines the field as
+	// "one or more security mechanisms available for the initiator", so an empty list is malformed.
+	b := []byte{0xa0, 0x06, 0x30, 0x04, 0xa0, 0x02, 0x30, 0x00}
+
+	_, _, err := UnmarshalNegToken(b)
+	assert.EqualError(t, err, "NegTokenInit does not contain any mechanism types")
+}

--- a/spnego/spnego.go
+++ b/spnego/spnego.go
@@ -90,6 +90,10 @@ func (s *SPNEGO) AcceptSecContext(ct gssapi.ContextToken) (bool, context.Context
 
 	var oid asn1.ObjectIdentifier
 	if t.Init {
+		if len(t.NegTokenInit.MechTypes) == 0 {
+			return false, ctx, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: "SPNEGO NegTokenInit does not contain any mechanism types"}
+		}
+
 		oid = t.NegTokenInit.MechTypes[0]
 	}
 

--- a/spnego/spnego_test.go
+++ b/spnego/spnego_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-krb5/x/encoding/asn1"
 
 	"github.com/go-krb5/krb5/gssapi"
+	"github.com/go-krb5/krb5/keytab"
 )
 
 const (
@@ -115,4 +116,30 @@ func TestSPNEGOClientShouldDefaultToNoTokenOptions(t *testing.T) {
 
 	assert.Empty(t, s.tokenOptions)
 	assert.Nil(t, newKRB5TokenOptions(s.tokenOptions...).channelBinding)
+}
+
+func TestUnmarshal_SPNEGO_InitEmptyMechTypes(t *testing.T) {
+	t.Parallel()
+
+	// The SPNEGO OID followed by a NegTokenInit whose mechTypes is a zero length SEQUENCE OF.
+	b := []byte{
+		0x60, 0x10,
+		0x06, 0x06, 0x2b, 0x06, 0x01, 0x05, 0x05, 0x02,
+		0xa0, 0x06, 0x30, 0x04, 0xa0, 0x02, 0x30, 0x00,
+	}
+
+	var s SPNEGOToken
+
+	assert.EqualError(t, s.Unmarshal(b), "NegTokenInit does not contain any mechanism types")
+}
+
+func TestAcceptSecContext_InitWithNoMechTypes(t *testing.T) {
+	t.Parallel()
+
+	s := SPNEGOService(keytab.New())
+
+	ok, _, status := s.AcceptSecContext(&SPNEGOToken{Init: true})
+
+	assert.False(t, ok)
+	assert.Equal(t, gssapi.StatusDefectiveToken, status.Code)
 }


### PR DESCRIPTION
This fixes an issue where a malformed NegTokenInit could cause a panic.