### PR TITLE
fix(pac): unhandled panic upn dns info unmarshall

### DIFF
--- a/pac/upn_dns_info.go
+++ b/pac/upn_dns_info.go
@@ -2,6 +2,7 @@ package pac
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/go-krb5/x/rpc/mstypes"
 )
@@ -51,36 +52,35 @@ func (k *UPNDNSInfo) Unmarshal(b []byte) (err error) {
 		return err
 	}
 
-	ub := mstypes.NewReader(bytes.NewReader(b[k.UPNOffset : k.UPNOffset+k.UPNLength]))
-	db := mstypes.NewReader(bytes.NewReader(b[k.DNSDomainNameOffset : k.DNSDomainNameOffset+k.DNSDomainNameLength]))
-
-	u := make([]rune, k.UPNLength/2)
-	for i := 0; i < len(u); i++ {
-		var r uint16
-
-		r, err = ub.Uint16()
-		if err != nil {
-			return
-		}
-
-		u[i] = rune(r)
+	if k.UPN, err = utf16StringAt(b, k.UPNOffset, k.UPNLength, "UPN"); err != nil {
+		return err
 	}
 
-	k.UPN = string(u)
-
-	d := make([]rune, k.DNSDomainNameLength/2)
-	for i := 0; i < len(d); i++ {
-		var r uint16
-
-		r, err = db.Uint16()
-		if err != nil {
-			return
-		}
-
-		d[i] = rune(r)
+	if k.DNSDomain, err = utf16StringAt(b, k.DNSDomainNameOffset, k.DNSDomainNameLength, "DNS domain name"); err != nil {
+		return err
 	}
 
-	k.DNSDomain = string(d)
+	return nil
+}
 
-	return
+// utf16StringAt reads the UTF-16 string of length octets that begins at offset within b.
+func utf16StringAt(b []byte, offset, length uint16, name string) (string, error) {
+	if int(offset)+int(length) > len(b) {
+		return "", fmt.Errorf("UPN_DNS_INFO %s lies outside the buffer: offset %d, length %d, buffer is %d bytes",
+			name, offset, length, len(b))
+	}
+
+	r := mstypes.NewReader(bytes.NewReader(b[offset : int(offset)+int(length)]))
+	s := make([]rune, length/2)
+
+	for i := range s {
+		u, err := r.Uint16()
+		if err != nil {
+			return "", err
+		}
+
+		s[i] = rune(u)
+	}
+
+	return string(s), nil
 }

--- a/pac/upn_dns_info_test.go
+++ b/pac/upn_dns_info_test.go
@@ -1,6 +1,7 @@
 package pac
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"testing"
 
@@ -27,4 +28,37 @@ func TestUPN_DNSInfo_Unmarshal(t *testing.T) {
 	assert.Equal(t, "testuser1@test.gokrb5", k.UPN)
 	assert.Equal(t, "TEST.GOKRB5", k.DNSDomain)
 	assert.Equal(t, uint32(0), k.Flags)
+}
+
+func TestUPN_DNSInfo_UnmarshalRejectsFieldOutsideBuffer(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		header []uint16
+	}{
+		{"UPN offset beyond the buffer", []uint16{0x0100, 0x0100, 0, 0}},
+		{"UPN length runs past the end", []uint16{0xFFFF, 16, 0, 0}},
+		{"UPN offset and length sum wraps a uint16", []uint16{0xFFF0, 0x0020, 0, 0}},
+		{"DNS domain name offset beyond the buffer", []uint16{0, 16, 0x0100, 0x0100}},
+		{"DNS domain name length runs past the end", []uint16{0, 16, 0xFFFF, 16}},
+		{"DNS domain name offset and length sum wraps a uint16", []uint16{0, 16, 0xFFF0, 0x0020}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := make([]byte, 24)
+			for i, v := range tc.header {
+				binary.LittleEndian.PutUint16(b[i*2:], v)
+			}
+
+			var k UPNDNSInfo
+
+			require.NotPanics(t, func() {
+				assert.ErrorContains(t, k.Unmarshal(b), "lies outside")
+			})
+		})
+	}
 }


### PR DESCRIPTION
This fixes an issue where a malformed UPN_DNS_INFO could cause a panic.