### PR TITLE
fix: add bounds checks to several public inputs

### DIFF
--- a/asn1tools/tools.go
+++ b/asn1tools/tools.go
@@ -35,11 +35,21 @@ func MarshalLengthBytes(l int) []byte {
 
 // GetLengthFromASN returns the length of a slice of ASN1 encoded bytes from the ASN1 length header it contains.
 func GetLengthFromASN(b []byte) int {
+	if len(b) < 2 {
+		return 0
+	}
+
 	if int(b[1]) <= 127 {
 		return int(b[1])
 	}
+
+	n := int(b[1]) - 128
+	if len(b) < 2+n {
+		return 0
+	}
+
 	// The bytes that indicate the length.
-	lb := b[2 : 2+int(b[1])-128]
+	lb := b[2 : 2+n]
 	base := 1
 
 	l := 0
@@ -53,11 +63,21 @@ func GetLengthFromASN(b []byte) int {
 
 // GetNumberBytesInLengthHeader returns the number of bytes in the ASn1 header that indicate the length.
 func GetNumberBytesInLengthHeader(b []byte) int {
+	if len(b) < 2 {
+		return 0
+	}
+
 	if int(b[1]) <= 127 {
 		return 1
 	}
+
+	n := 1 + int(b[1]) - 128
+	if len(b) < 1+n {
+		return 0
+	}
+
 	// The bytes that indicate the length.
-	return 1 + int(b[1]) - 128
+	return n
 }
 
 // AddASNAppTag adds an ASN1 encoding application tag value to the raw bytes provided.

--- a/client/as_xchange.go
+++ b/client/as_xchange.go
@@ -163,48 +163,49 @@ func setPAData(cl *Client, krberr *messages.KRBError, req *messages.ASReq) error
 }
 
 // preAuthEType establishes what encryption type to use for pre-authentication from the KRBError returned from the KDC.
-func preAuthEType(krberr *messages.KRBError) (etype etype.EType, err error) {
-	// RFC 4120 5.2.7.5 covers the preference order of ETYPE-INFO2 and ETYPE-INFO.
-	var (
-		etypeID int32
-		pas     types.PADataSequence
-	)
+func preAuthEType(krberr *messages.KRBError) (etype.EType, error) {
+	var pas types.PADataSequence
 
-	e := pas.Unmarshal(krberr.EData)
-	if e != nil {
-		err = krberror.Errorf(e, krberror.EncodingError, "error unmarshalling KRBError data")
-		return
+	if err := pas.Unmarshal(krberr.EData); err != nil {
+		return nil, krberror.Errorf(err, krberror.EncodingError, "error unmarshalling KRBError data")
 	}
 
-Loop:
+	// RFC 4120 5.2.7.5 covers the preference order of ETYPE-INFO2 and ETYPE-INFO.
+	var preferred, fallback []int32
+
 	for _, pa := range pas {
 		switch pa.PADataType {
 		case patype.PA_ETYPE_INFO2:
-			info, e := pa.GetETypeInfo2()
-			if e != nil {
-				err = krberror.Errorf(e, krberror.EncodingError, "error unmarshalling ETYPE-INFO2 data")
-				return
+			info, err := pa.GetETypeInfo2()
+			if err != nil {
+				return nil, krberror.Errorf(err, krberror.EncodingError, "error unmarshalling ETYPE-INFO2 data")
 			}
 
-			etypeID = info[0].EType
-
-			break Loop
+			for _, e := range info {
+				preferred = append(preferred, e.EType)
+			}
 		case patype.PA_ETYPE_INFO:
-			info, e := pa.GetETypeInfo()
-			if e != nil {
-				err = krberror.Errorf(e, krberror.EncodingError, "error unmarshalling ETYPE-INFO data")
-				return
+			info, err := pa.GetETypeInfo()
+			if err != nil {
+				return nil, krberror.Errorf(err, krberror.EncodingError, "error unmarshalling ETYPE-INFO data")
 			}
 
-			etypeID = info[0].EType
+			for _, e := range info {
+				fallback = append(fallback, e.EType)
+			}
 		}
 	}
 
-	etype, e = crypto.GetEType(etypeID)
-	if e != nil {
-		err = krberror.Errorf(e, krberror.EncryptingError, "error creating etype")
-		return
+	candidates := make([]int32, 0, len(preferred)+len(fallback))
+	candidates = append(candidates, preferred...)
+	candidates = append(candidates, fallback...)
+
+	for _, id := range candidates {
+		if et, err := crypto.GetEType(id); err == nil {
+			return et, nil
+		}
 	}
 
-	return etype, nil
+	return nil, krberror.NewErrorf(krberror.EncryptingError,
+		"no encryption type offered by the KDC for pre-authentication is supported: %v", candidates)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3,10 +3,17 @@ package client
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-krb5/x/encoding/asn1"
+
 	"github.com/go-krb5/krb5/config"
+	"github.com/go-krb5/krb5/iana/etypeID"
+	"github.com/go-krb5/krb5/iana/patype"
 	"github.com/go-krb5/krb5/keytab"
+	"github.com/go-krb5/krb5/messages"
+	"github.com/go-krb5/krb5/types"
 )
 
 func TestAssumePreauthentication(t *testing.T) {
@@ -16,4 +23,61 @@ func TestAssumePreauthentication(t *testing.T) {
 
 	require.True(t, cl.settings.assumePreAuthentication)
 	require.True(t, cl.settings.AssumePreAuthentication())
+}
+
+func TestPreAuthETypeRejectsEmptyETypeInfo(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		patyp int32
+		value any
+	}{
+		{"empty ETYPE-INFO2", patype.PA_ETYPE_INFO2, types.ETypeInfo2{}},
+		{"empty ETYPE-INFO", patype.PA_ETYPE_INFO, types.ETypeInfo{}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			v, err := asn1.Marshal(tc.value,
+				asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
+			require.NoError(t, err)
+
+			pas, err := asn1.Marshal(types.PADataSequence{{PADataType: tc.patyp, PADataValue: v}},
+				asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
+			require.NoError(t, err)
+
+			krberr := messages.KRBError{EData: pas}
+
+			require.NotPanics(t, func() {
+				_, err := preAuthEType(&krberr)
+				assert.Error(t, err)
+			})
+		})
+	}
+}
+
+func TestPreAuthETypeSkipsUnsupportedEntries(t *testing.T) {
+	t.Parallel()
+
+	info := types.ETypeInfo2{
+		{EType: etypeID.RC4_HMAC},
+		{EType: etypeID.AES256_CTS_HMAC_SHA1_96, Salt: "TEST.GOKRB5testuser"},
+	}
+
+	v, err := asn1.Marshal(info, asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
+	require.NoError(t, err)
+
+	pas, err := asn1.Marshal(types.PADataSequence{{PADataType: patype.PA_ETYPE_INFO2, PADataValue: v}},
+		asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
+	require.NoError(t, err)
+
+	krberr := messages.KRBError{EData: pas}
+
+	et, err := preAuthEType(&krberr)
+
+	require.NoError(t, err)
+	assert.Equal(t, etypeID.AES256_CTS_HMAC_SHA1_96, et.GetETypeID())
 }

--- a/credentials/ccache.go
+++ b/credentials/ccache.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -83,6 +84,13 @@ func LoadCCache(cpath string) (*CCache, error) {
 func (c *CCache) Unmarshal(b []byte) error {
 	p := 0
 
+	// A credential cache is read from a path the process does not necessarily control, and this method is
+	// exported for arbitrary bytes. Every length and count below is taken from the data itself, so none of them
+	// is trusted to index it.
+	if len(b) < 2 {
+		return fmt.Errorf("invalid credential cache data: %d bytes is shorter than the two byte version header", len(b))
+	}
+
 	if int8(b[p]) != 5 {
 		return errors.New("Invalid credential cache data. First byte does not equal 5")
 	}
@@ -110,7 +118,12 @@ func (c *CCache) Unmarshal(b []byte) error {
 		}
 	}
 
-	c.DefaultPrincipal = parsePrincipal(b, &p, c, &endian)
+	var err error
+
+	if c.DefaultPrincipal, err = parsePrincipal(b, &p, c, &endian); err != nil {
+		return err
+	}
+
 	for p < len(b) {
 		cred, err := parseCredential(b, &p, c, &endian)
 		if err != nil {
@@ -130,15 +143,39 @@ func parseHeader(b []byte, p *int, c *CCache, e *binary.ByteOrder) error {
 
 	h := header{}
 
-	h.length = uint16(readInt16(b, p, e))
+	l, err := readInt16(b, p, e)
+	if err != nil {
+		return err
+	}
+
+	h.length = uint16(l)
+
 	endOfHeader := *p + int(h.length)
+	if endOfHeader > len(b) {
+		return fmt.Errorf("credential cache header of %d bytes extends beyond the %d bytes available", h.length, len(b)-*p)
+	}
+
 	for *p <= endOfHeader-4 {
 		f := headerField{}
-		f.tag = uint16(readInt16(b, p, e))
-		f.length = uint16(readInt16(b, p, e))
-		if *p+int(f.length) > len(b) {
+
+		t, err := readInt16(b, p, e)
+		if err != nil {
+			return err
+		}
+
+		f.tag = uint16(t)
+
+		fl, err := readInt16(b, p, e)
+		if err != nil {
+			return err
+		}
+
+		f.length = uint16(fl)
+
+		if *p+int(f.length) > endOfHeader {
 			return errors.New("credential cache header field extends beyond buffer")
 		}
+
 		f.value = b[*p : *p+int(f.length)]
 
 		*p += int(f.length)
@@ -156,71 +193,147 @@ func parseHeader(b []byte, p *int, c *CCache, e *binary.ByteOrder) error {
 }
 
 // Parse the Keytab bytes of a principal into a Keytab entry's principal.
-func parsePrincipal(b []byte, p *int, c *CCache, e *binary.ByteOrder) (princ principal) {
+func parsePrincipal(b []byte, p *int, c *CCache, e *binary.ByteOrder) (princ principal, err error) {
 	if c.Version != 1 {
 		// Name Type is omitted in version 1.
-		princ.PrincipalName.NameType = readInt32(b, p, e)
+		if princ.PrincipalName.NameType, err = readInt32(b, p, e); err != nil {
+			return princ, err
+		}
 	}
 
-	nc := int(readInt32(b, p, e))
+	n, err := readInt32(b, p, e)
+	if err != nil {
+		return princ, err
+	}
+
+	nc := int(n)
 	if c.Version == 1 {
 		// In version 1 the number of components includes the realm. Minus 1 to make consistent with version 2.
 		nc--
 	}
 
-	lenRealm := readInt32(b, p, e)
-
-	princ.Realm = string(readBytes(b, p, int(lenRealm), e))
-	for i := 0; i < nc; i++ {
-		l := readInt32(b, p, e)
-		princ.PrincipalName.NameString = append(princ.PrincipalName.NameString, string(readBytes(b, p, int(l), e)))
+	if nc < 0 {
+		return princ, fmt.Errorf("credential cache principal declares %d name components", nc)
 	}
 
-	return princ
+	realm, err := readData(b, p, e)
+	if err != nil {
+		return princ, err
+	}
+
+	princ.Realm = string(realm)
+
+	// The components are appended rather than pre-allocated from nc, so that a count larger than the remaining
+	// data can supply fails on the first read past the end instead of sizing an allocation of its own choosing.
+	for i := 0; i < nc; i++ {
+		comp, err := readData(b, p, e)
+		if err != nil {
+			return princ, err
+		}
+
+		princ.PrincipalName.NameString = append(princ.PrincipalName.NameString, string(comp))
+	}
+
+	return princ, nil
 }
 
 func parseCredential(b []byte, p *int, c *CCache, e *binary.ByteOrder) (cred *Credential, err error) {
 	cred = new(Credential)
-	cred.Client = parsePrincipal(b, p, c, e)
-	cred.Server = parsePrincipal(b, p, c, e)
+
+	if cred.Client, err = parsePrincipal(b, p, c, e); err != nil {
+		return nil, err
+	}
+
+	if cred.Server, err = parsePrincipal(b, p, c, e); err != nil {
+		return nil, err
+	}
+
 	key := types.EncryptionKey{}
 
-	key.KeyType = int32(readInt16(b, p, e))
+	kt, err := readInt16(b, p, e)
+	if err != nil {
+		return nil, err
+	}
+
+	key.KeyType = int32(kt)
+
 	if c.Version == 3 {
-		key.KeyType = int32(readInt16(b, p, e))
+		if kt, err = readInt16(b, p, e); err != nil {
+			return nil, err
+		}
+
+		key.KeyType = int32(kt)
 	}
 
-	key.KeyValue = readData(b, p, e)
+	if key.KeyValue, err = readData(b, p, e); err != nil {
+		return nil, err
+	}
+
 	cred.Key = key
-	cred.AuthTime = readTimestamp(b, p, e)
-	cred.StartTime = readTimestamp(b, p, e)
-	cred.EndTime = readTimestamp(b, p, e)
 
-	cred.RenewTill = readTimestamp(b, p, e)
-	if ik := readInt8(b, p, e); ik == 0 {
-		cred.IsSKey = false
-	} else {
-		cred.IsSKey = true
+	for _, t := range []*time.Time{&cred.AuthTime, &cred.StartTime, &cred.EndTime, &cred.RenewTill} {
+		if *t, err = readTimestamp(b, p, e); err != nil {
+			return nil, err
+		}
 	}
+
+	ik, err := readInt8(b, p, e)
+	if err != nil {
+		return nil, err
+	}
+
+	cred.IsSKey = ik != 0
 
 	cred.TicketFlags = types.NewKrbFlags()
-	cred.TicketFlags.Bytes = readBytes(b, p, 4, e)
-	l := int(readInt32(b, p, e))
-
-	cred.Addresses = make([]types.HostAddress, l)
-	for i := range cred.Addresses {
-		cred.Addresses[i] = readAddress(b, p, e)
+	if cred.TicketFlags.Bytes, err = readBytes(b, p, 4, e); err != nil {
+		return nil, err
 	}
 
-	l = int(readInt32(b, p, e))
-
-	cred.AuthData = make([]types.AuthorizationDataEntry, l)
-	for i := range cred.AuthData {
-		cred.AuthData[i] = readAuthDataEntry(b, p, e)
+	// The addresses and authorization data are appended rather than pre-allocated from their counts. Both counts
+	// are read from the cache, and the largest asks for a slice of two billion elements; appending makes an
+	// unsatisfiable count fail on the first read past the end instead.
+	l, err := readInt32(b, p, e)
+	if err != nil {
+		return nil, err
 	}
 
-	cred.Ticket = readData(b, p, e)
-	cred.SecondTicket = readData(b, p, e)
+	if l < 0 {
+		return nil, fmt.Errorf("credential cache credential declares %d addresses", l)
+	}
+
+	for i := 0; i < int(l); i++ {
+		a, err := readAddress(b, p, e)
+		if err != nil {
+			return nil, err
+		}
+
+		cred.Addresses = append(cred.Addresses, a)
+	}
+
+	if l, err = readInt32(b, p, e); err != nil {
+		return nil, err
+	}
+
+	if l < 0 {
+		return nil, fmt.Errorf("credential cache credential declares %d authorization data entries", l)
+	}
+
+	for i := 0; i < int(l); i++ {
+		ad, err := readAuthDataEntry(b, p, e)
+		if err != nil {
+			return nil, err
+		}
+
+		cred.AuthData = append(cred.AuthData, ad)
+	}
+
+	if cred.Ticket, err = readData(b, p, e); err != nil {
+		return nil, err
+	}
+
+	if cred.SecondTicket, err = readData(b, p, e); err != nil {
+		return nil, err
+	}
 
 	return cred, nil
 }
@@ -307,70 +420,133 @@ func (h *headerField) valid() bool {
 	return false
 }
 
-func readData(b []byte, p *int, e *binary.ByteOrder) []byte {
-	l := readInt32(b, p, e)
+// readData reads a length prefixed byte string.
+func readData(b []byte, p *int, e *binary.ByteOrder) ([]byte, error) {
+	l, err := readInt32(b, p, e)
+	if err != nil {
+		return nil, err
+	}
+
 	return readBytes(b, p, int(l), e)
 }
 
-func readAddress(b []byte, p *int, e *binary.ByteOrder) types.HostAddress {
+func readAddress(b []byte, p *int, e *binary.ByteOrder) (types.HostAddress, error) {
 	a := types.HostAddress{}
-	a.AddrType = int32(readInt16(b, p, e))
-	a.Address = readData(b, p, e)
 
-	return a
+	t, err := readInt16(b, p, e)
+	if err != nil {
+		return a, err
+	}
+
+	a.AddrType = int32(t)
+
+	if a.Address, err = readData(b, p, e); err != nil {
+		return a, err
+	}
+
+	return a, nil
 }
 
-func readAuthDataEntry(b []byte, p *int, e *binary.ByteOrder) types.AuthorizationDataEntry {
+func readAuthDataEntry(b []byte, p *int, e *binary.ByteOrder) (types.AuthorizationDataEntry, error) {
 	a := types.AuthorizationDataEntry{}
-	a.ADType = int32(readInt16(b, p, e))
-	a.ADData = readData(b, p, e)
 
-	return a
+	t, err := readInt16(b, p, e)
+	if err != nil {
+		return a, err
+	}
+
+	a.ADType = int32(t)
+
+	if a.ADData, err = readData(b, p, e); err != nil {
+		return a, err
+	}
+
+	return a, nil
 }
 
 // Read bytes representing a timestamp.
-func readTimestamp(b []byte, p *int, e *binary.ByteOrder) time.Time {
-	return time.Unix(int64(readInt32(b, p, e)), 0)
+func readTimestamp(b []byte, p *int, e *binary.ByteOrder) (time.Time, error) {
+	i, err := readInt32(b, p, e)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return time.Unix(int64(i), 0), nil
 }
 
 // Read bytes representing an eight bit integer.
-func readInt8(b []byte, p *int, e *binary.ByteOrder) (i int8) {
+func readInt8(b []byte, p *int, e *binary.ByteOrder) (i int8, err error) {
+	if err = checkBounds(b, *p, 1); err != nil {
+		return 0, err
+	}
+
 	buf := bytes.NewBuffer(b[*p : *p+1])
-	binary.Read(buf, *e, &i)
+	if err = binary.Read(buf, *e, &i); err != nil {
+		return 0, err
+	}
 
 	*p++
 
-	return
+	return i, nil
 }
 
 // Read bytes representing a sixteen bit integer.
-func readInt16(b []byte, p *int, e *binary.ByteOrder) (i int16) {
+func readInt16(b []byte, p *int, e *binary.ByteOrder) (i int16, err error) {
+	if err = checkBounds(b, *p, 2); err != nil {
+		return 0, err
+	}
+
 	buf := bytes.NewBuffer(b[*p : *p+2])
-	binary.Read(buf, *e, &i)
+	if err = binary.Read(buf, *e, &i); err != nil {
+		return 0, err
+	}
 
 	*p += 2
 
-	return
+	return i, nil
 }
 
 // Read bytes representing a thirty two bit integer.
-func readInt32(b []byte, p *int, e *binary.ByteOrder) (i int32) {
+func readInt32(b []byte, p *int, e *binary.ByteOrder) (i int32, err error) {
+	if err = checkBounds(b, *p, 4); err != nil {
+		return 0, err
+	}
+
 	buf := bytes.NewBuffer(b[*p : *p+4])
-	binary.Read(buf, *e, &i)
+	if err = binary.Read(buf, *e, &i); err != nil {
+		return 0, err
+	}
 
 	*p += 4
 
-	return
+	return i, nil
 }
 
-func readBytes(b []byte, p *int, s int, e *binary.ByteOrder) []byte {
-	buf := bytes.NewBuffer(b[*p : *p+s])
+func readBytes(b []byte, p *int, s int, e *binary.ByteOrder) ([]byte, error) {
+	if err := checkBounds(b, *p, s); err != nil {
+		return nil, err
+	}
+
 	r := make([]byte, s)
-	binary.Read(buf, *e, &r)
+	copy(r, b[*p:*p+s])
 
 	*p += s
 
-	return r
+	return r, nil
+}
+
+// checkBounds reports whether n bytes can be read from b at offset p.
+func checkBounds(b []byte, p, n int) error {
+	if p < 0 || n < 0 {
+		return fmt.Errorf("invalid credential cache data: cannot read %d bytes at offset %d", n, p)
+	}
+
+	if n > len(b)-p {
+		return fmt.Errorf("invalid credential cache data: %d bytes needed at offset %d but only %d remain",
+			n, p, len(b)-p)
+	}
+
+	return nil
 }
 
 // TODO: Investigate why this is used and determine if it's necessary and safe.

--- a/credentials/ccache_test.go
+++ b/credentials/ccache_test.go
@@ -2,6 +2,7 @@ package credentials
 
 import (
 	"encoding/hex"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -126,4 +127,93 @@ func TestCCache_GetEntries(t *testing.T) {
 
 	creds := c.GetEntries()
 	assert.Equal(t, 2, len(creds))
+}
+
+func TestCCacheUnmarshalRejectsMalformedData(t *testing.T) {
+	t.Parallel()
+
+	valid, err := hex.DecodeString(testdata.CCACHE_TEST)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name string
+		b    []byte
+	}{
+		{"empty", []byte{}},
+		{"first byte only", valid[:1]},
+		{"version byte only", valid[:2]},
+		{"truncated header length", valid[:3]},
+		{"truncated header field", valid[:6]},
+		{"truncated default principal", valid[:20]},
+		{"truncated mid credential", valid[:len(valid)/2]},
+		{"truncated one byte short", valid[:len(valid)-1]},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var c CCache
+
+			require.NotPanics(t, func() {
+				assert.Error(t, c.Unmarshal(tc.b))
+			})
+		})
+	}
+}
+
+func TestCCacheUnmarshalRejectsNegativeLength(t *testing.T) {
+	t.Parallel()
+
+	b := []byte{
+		0x05, 0x04, // version 4
+		0x00, 0x00, // zero length header
+		0x00, 0x00, 0x00, 0x01, // default principal: name type
+		0x00, 0x00, 0x00, 0x01, // one component
+		0xFF, 0xFF, 0xFF, 0xFF, // realm length of -1
+		0x41,
+	}
+
+	var c CCache
+
+	require.NotPanics(t, func() {
+		assert.Error(t, c.Unmarshal(b))
+	})
+}
+
+func TestCCacheUnmarshalRejectsImplausibleCounts(t *testing.T) {
+	t.Parallel()
+
+	principal := []byte{
+		0x00, 0x00, 0x00, 0x01, // name type
+		0x00, 0x00, 0x00, 0x00, // no components
+		0x00, 0x00, 0x00, 0x00, // zero length realm
+	}
+
+	b := []byte{0x05, 0x04, 0x00, 0x00}
+	b = append(b, principal...)           // default principal
+	b = append(b, principal...)           // credential client
+	b = append(b, principal...)           // credential server
+	b = append(b, 0x00, 0x12)             // keyblock type
+	b = append(b, 0x00, 0x00, 0x00, 0x00) // zero length key
+	b = append(b, make([]byte, 16)...)    // four timestamps
+	b = append(b, 0x00)                   // is skey
+	b = append(b, 0x00, 0x00, 0x00, 0x00) // ticket flags
+	b = append(b, 0x7F, 0xFF, 0xFF, 0xFF) // address count of 2147483647
+
+	var c CCache
+
+	var before, after runtime.MemStats
+
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	require.NotPanics(t, func() {
+		assert.Error(t, c.Unmarshal(b))
+	})
+
+	runtime.ReadMemStats(&after)
+
+	assert.Less(t, after.TotalAlloc-before.TotalAlloc, uint64(1<<20),
+		"the address count was allocated before it was validated")
 }

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -46,14 +46,22 @@ func GetKeyFromPassword(passwd string, cname types.PrincipalName, realm string, 
 				return key, et, fmt.Errorf("error unmarshaling PA Data to PA-ETYPE-INFO2: %w", err)
 			}
 
-			if etypeID != eti[0].EType {
-				et, err = GetEType(eti[0].EType)
+			// ETYPE-INFO is a SEQUENCE OF and reaches here from an unauthenticated KRB-ERROR, so an empty one
+			// decodes to no entries rather than to an error. The first entry whose encryption type this library
+			// supports is taken, rather than the first entry outright.
+			i := firstSupported(eti.ETypes())
+			if i < 0 {
+				continue
+			}
+
+			if etypeID != eti[i].EType {
+				et, err = GetEType(eti[i].EType)
 				if err != nil {
 					return key, et, fmt.Errorf("error getting encryption type: %w", err)
 				}
 			}
 
-			salt = string(eti[0].Salt)
+			salt = string(eti[i].Salt)
 			paID = pa.PADataType
 		case patype.PA_ETYPE_INFO2:
 			if paID > pa.PADataType {
@@ -66,18 +74,23 @@ func GetKeyFromPassword(passwd string, cname types.PrincipalName, realm string, 
 				return key, et, fmt.Errorf("error unmarshalling PA Data to PA-ETYPE-INFO2: %w", err)
 			}
 
-			if etypeID != et2[0].EType {
-				et, err = GetEType(et2[0].EType)
+			i := firstSupported(et2.ETypes())
+			if i < 0 {
+				continue
+			}
+
+			if etypeID != et2[i].EType {
+				et, err = GetEType(et2[i].EType)
 				if err != nil {
 					return key, et, fmt.Errorf("error getting encryption type: %w", err)
 				}
 			}
 
-			if len(et2[0].S2KParams) == 4 {
-				sk2p = hex.EncodeToString(et2[0].S2KParams)
+			if len(et2[i].S2KParams) == 4 {
+				sk2p = hex.EncodeToString(et2[i].S2KParams)
 			}
 
-			salt = et2[0].Salt
+			salt = et2[i].Salt
 			paID = pa.PADataType
 		}
 	}
@@ -97,6 +110,17 @@ func GetKeyFromPassword(passwd string, cname types.PrincipalName, realm string, 
 	}
 
 	return key, et, nil
+}
+
+// firstSupported returns the index of the first encryption type in ids that is registered, or -1 when none is.
+func firstSupported(ids []int32) int {
+	for i, id := range ids {
+		if _, err := GetEType(id); err == nil {
+			return i
+		}
+	}
+
+	return -1
 }
 
 // GetEncryptedData encrypts the data provided and returns and EncryptedData type.

--- a/kadmin/message.go
+++ b/kadmin/message.go
@@ -1,7 +1,6 @@
 package kadmin
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -89,8 +88,19 @@ func (m *Request) Marshal() (b []byte, err error) {
 	return b, nil
 }
 
+// replyHeaderLen is the width of the fixed part of a kpasswd reply: the message length, the protocol version
+// number and the AP-REP length, each a two octet big-endian integer. RFC 3244 Section 2.
+const replyHeaderLen = 6
+
+// resultCodeLen is the width of the result code that begins the user data of a kpasswd reply. RFC 3244 Section 2.
+const resultCodeLen = 2
+
 // Unmarshal a byte slice into a Reply.
 func (m *Reply) Unmarshal(b []byte) error {
+	if len(b) < replyHeaderLen {
+		return fmt.Errorf("kadmin reply is %d bytes, shorter than its %d byte header", len(b), replyHeaderLen)
+	}
+
 	m.MessageLength = int(binary.BigEndian.Uint16(b[0:2]))
 
 	m.Version = int(binary.BigEndian.Uint16(b[2:4]))
@@ -99,6 +109,17 @@ func (m *Reply) Unmarshal(b []byte) error {
 	}
 
 	m.APREPLength = int(binary.BigEndian.Uint16(b[4:6]))
+
+	if m.MessageLength < replyHeaderLen || m.MessageLength > len(b) {
+		return fmt.Errorf("kadmin reply declares a message length of %d, which is not between %d and the %d bytes received",
+			m.MessageLength, replyHeaderLen, len(b))
+	}
+
+	if replyHeaderLen+m.APREPLength > m.MessageLength {
+		return fmt.Errorf("kadmin reply declares an AP_REP of %d bytes, which does not fit within its %d byte message",
+			m.APREPLength, m.MessageLength)
+	}
+
 	if m.APREPLength != 0 {
 		err := m.APREP.Unmarshal(b[6 : 6+m.APREPLength])
 		if err != nil {
@@ -112,25 +133,31 @@ func (m *Reply) Unmarshal(b []byte) error {
 	} else {
 		m.IsKRBError = true
 
-		// TODO: Figure out the reason for ignoring the error and document it. It's probably because the error is
-		//       already indicated by the struct values.
-		_ = m.KRBError.Unmarshal(b[6:m.MessageLength])
-		m.ResultCode, m.Result = parseResponse(m.KRBError.EData)
+		// The error from unmarshalling is discarded because the reply being a KRB-ERROR is itself the outcome:
+		// Decrypt returns m.KRBError to the caller whether or not its contents could be read.
+		_ = m.KRBError.Unmarshal(b[replyHeaderLen:m.MessageLength])
+
+		// EData is attacker supplied and need not carry a result code. When it does not, ResultCode and Result
+		// are left unset rather than defaulted, and Decrypt still reports the KRB-ERROR.
+		if c, r, err := parseResponse(m.KRBError.EData); err == nil {
+			m.ResultCode, m.Result = c, r
+		}
 	}
 
 	return nil
 }
 
-func parseResponse(b []byte) (c uint16, s string) {
-	c = binary.BigEndian.Uint16(b[0:2])
+// parseResponse splits the result code from the message that follows it in a kpasswd reply's user data.
+//
+// A caller must not treat an unreadable response as a successful one: KRB5_KPASSWD_SUCCESS is zero, so defaulting
+// the code would report a password change that never happened as having succeeded.
+func parseResponse(b []byte) (c uint16, s string, err error) {
+	if len(b) < resultCodeLen {
+		return 0, "", fmt.Errorf("kadmin response is %d bytes, too short to carry its %d byte result code",
+			len(b), resultCodeLen)
+	}
 
-	buf := bytes.NewBuffer(b[2:])
-
-	m := make([]byte, len(b)-2)
-
-	binary.Read(buf, binary.BigEndian, &m)
-
-	return c, string(m)
+	return binary.BigEndian.Uint16(b[:resultCodeLen]), string(b[resultCodeLen:]), nil
 }
 
 // Decrypt the encrypted part of the KRBError within the change password Reply.
@@ -144,7 +171,9 @@ func (m *Reply) Decrypt(key types.EncryptionKey) error {
 		return err
 	}
 
-	m.ResultCode, m.Result = parseResponse(m.KRBPriv.DecryptedEncPart.UserData)
+	if m.ResultCode, m.Result, err = parseResponse(m.KRBPriv.DecryptedEncPart.UserData); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/kadmin/message_test.go
+++ b/kadmin/message_test.go
@@ -1,6 +1,7 @@
 package kadmin
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"testing"
 
@@ -9,7 +10,9 @@ import (
 
 	"github.com/go-krb5/krb5/iana"
 	"github.com/go-krb5/krb5/iana/msgtype"
+	"github.com/go-krb5/krb5/messages"
 	"github.com/go-krb5/krb5/test/testdata"
+	"github.com/go-krb5/krb5/types"
 )
 
 func TestUnmarshalReply(t *testing.T) {
@@ -34,3 +37,67 @@ func TestUnmarshalReply(t *testing.T) {
 }
 
 // Request marshal is tested via integration test in the client package due to the dynamic keys and encryption.
+
+func TestReplyUnmarshalRejectsMalformedReply(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		b    []byte
+	}{
+		{
+			"shorter than the fixed header",
+			[]byte{0x00, 0x06, 0x00, 0x01},
+		},
+		{
+			"AP-REP length runs past the end",
+			[]byte{0xFF, 0xFF, 0x00, 0x01, 0xFF, 0xFF, 0x00, 0x00},
+		},
+		{
+			"message length runs past the end",
+			[]byte{0xFF, 0xFF, 0x00, 0x01, 0x00, 0x00},
+		},
+		{
+			"message length is shorter than the header it follows",
+			[]byte{0x00, 0x02, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00},
+		},
+		{
+			"empty",
+			[]byte{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var r Reply
+
+			require.NotPanics(t, func() {
+				assert.Error(t, r.Unmarshal(tc.b))
+			})
+		})
+	}
+}
+
+func TestReplyUnmarshalRejectsErrorReplyWithShortEData(t *testing.T) {
+	t.Parallel()
+
+	krbErr := messages.NewKRBError(types.PrincipalName{}, "TEST.GOKRB5", 0, "")
+
+	eb, err := krbErr.Marshal()
+	require.NoError(t, err)
+
+	b := make([]byte, 6, 6+len(eb))
+	binary.BigEndian.PutUint16(b[0:2], uint16(6+len(eb)))
+	binary.BigEndian.PutUint16(b[2:4], 1)
+	binary.BigEndian.PutUint16(b[4:6], 0)
+	b = append(b, eb...)
+
+	var r Reply
+
+	require.NotPanics(t, func() {
+		_ = r.Unmarshal(b)
+		assert.True(t, r.IsKRBError)
+	})
+}

--- a/pac/pac_type.go
+++ b/pac/pac_type.go
@@ -27,6 +27,14 @@ const (
 	infoTypePACDeviceClaimsInfo    uint32 = 15
 )
 
+const (
+	// pacHeaderLen is the width of the cBuffers and Version fields that precede the info buffer descriptors.
+	pacHeaderLen = 8
+
+	// infoBufferLen is the width of one info buffer descriptor on the wire: ULType, CBBufferSize and Offset.
+	infoBufferLen = 16
+)
+
 // PACType implements: https://msdn.microsoft.com/en-us/library/cc237950.aspx
 type PACType struct {
 	CBuffers           uint32
@@ -85,6 +93,11 @@ func (pac *PACType) Unmarshal(b []byte) (err error) {
 	pac.Version, err = r.Uint32()
 	if err != nil {
 		return err
+	}
+
+	if maxBuffers := (len(b) - pacHeaderLen) / infoBufferLen; int64(pac.CBuffers) > int64(maxBuffers) {
+		return fmt.Errorf("PAC declares %d info buffers, which %d bytes cannot hold: at most %d fit",
+			pac.CBuffers, len(b), maxBuffers)
 	}
 
 	buf := make([]InfoBuffer, pac.CBuffers)

--- a/pac/pac_type_test.go
+++ b/pac/pac_type_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"log"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -164,4 +165,28 @@ func TestProcessPACInfoBuffersWithNilLogger(t *testing.T) {
 	require.NotPanics(t, func() {
 		assert.Error(t, pac.ProcessPACInfoBuffers(types.EncryptionKey{}, nil))
 	})
+}
+
+func TestPACTypeUnmarshalRejectsImplausibleBufferCount(t *testing.T) {
+	t.Parallel()
+
+	b := make([]byte, 32)
+	binary.LittleEndian.PutUint32(b[0:4], 0xFFFFFFFF)
+
+	var pac PACType
+
+	var before, after runtime.MemStats
+
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	err := pac.Unmarshal(b)
+
+	runtime.ReadMemStats(&after)
+
+	assert.ErrorContains(t, err, "declares 4294967295 info buffers")
+
+	// 4294967295 InfoBuffer values are about 68GB. The guard has to fire before the allocation, not after it.
+	assert.Less(t, after.TotalAlloc-before.TotalAlloc, uint64(1<<20),
+		"the buffer count was allocated before it was validated")
 }

--- a/pac/upn_dns_info.go
+++ b/pac/upn_dns_info.go
@@ -2,6 +2,7 @@ package pac
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/go-krb5/x/rpc/mstypes"
 )
@@ -51,36 +52,35 @@ func (k *UPNDNSInfo) Unmarshal(b []byte) (err error) {
 		return err
 	}
 
-	ub := mstypes.NewReader(bytes.NewReader(b[k.UPNOffset : k.UPNOffset+k.UPNLength]))
-	db := mstypes.NewReader(bytes.NewReader(b[k.DNSDomainNameOffset : k.DNSDomainNameOffset+k.DNSDomainNameLength]))
-
-	u := make([]rune, k.UPNLength/2)
-	for i := 0; i < len(u); i++ {
-		var r uint16
-
-		r, err = ub.Uint16()
-		if err != nil {
-			return
-		}
-
-		u[i] = rune(r)
+	if k.UPN, err = utf16StringAt(b, k.UPNOffset, k.UPNLength, "UPN"); err != nil {
+		return err
 	}
 
-	k.UPN = string(u)
-
-	d := make([]rune, k.DNSDomainNameLength/2)
-	for i := 0; i < len(d); i++ {
-		var r uint16
-
-		r, err = db.Uint16()
-		if err != nil {
-			return
-		}
-
-		d[i] = rune(r)
+	if k.DNSDomain, err = utf16StringAt(b, k.DNSDomainNameOffset, k.DNSDomainNameLength, "DNS domain name"); err != nil {
+		return err
 	}
 
-	k.DNSDomain = string(d)
+	return nil
+}
 
-	return
+// utf16StringAt reads the UTF-16 string of length octets that begins at offset within b.
+func utf16StringAt(b []byte, offset, length uint16, name string) (string, error) {
+	if int(offset)+int(length) > len(b) {
+		return "", fmt.Errorf("UPN_DNS_INFO %s lies outside the buffer: offset %d, length %d, buffer is %d bytes",
+			name, offset, length, len(b))
+	}
+
+	r := mstypes.NewReader(bytes.NewReader(b[offset : int(offset)+int(length)]))
+	s := make([]rune, length/2)
+
+	for i := range s {
+		u, err := r.Uint16()
+		if err != nil {
+			return "", err
+		}
+
+		s[i] = rune(u)
+	}
+
+	return string(s), nil
 }

--- a/pac/upn_dns_info_test.go
+++ b/pac/upn_dns_info_test.go
@@ -1,6 +1,7 @@
 package pac
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"testing"
 
@@ -27,4 +28,37 @@ func TestUPN_DNSInfo_Unmarshal(t *testing.T) {
 	assert.Equal(t, "testuser1@test.gokrb5", k.UPN)
 	assert.Equal(t, "TEST.GOKRB5", k.DNSDomain)
 	assert.Equal(t, uint32(0), k.Flags)
+}
+
+func TestUPN_DNSInfo_UnmarshalRejectsFieldOutsideBuffer(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		header []uint16
+	}{
+		{"UPN offset beyond the buffer", []uint16{0x0100, 0x0100, 0, 0}},
+		{"UPN length runs past the end", []uint16{0xFFFF, 16, 0, 0}},
+		{"UPN offset and length sum wraps a uint16", []uint16{0xFFF0, 0x0020, 0, 0}},
+		{"DNS domain name offset beyond the buffer", []uint16{0, 16, 0x0100, 0x0100}},
+		{"DNS domain name length runs past the end", []uint16{0, 16, 0xFFFF, 16}},
+		{"DNS domain name offset and length sum wraps a uint16", []uint16{0, 16, 0xFFF0, 0x0020}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := make([]byte, 24)
+			for i, v := range tc.header {
+				binary.LittleEndian.PutUint16(b[i*2:], v)
+			}
+
+			var k UPNDNSInfo
+
+			require.NotPanics(t, func() {
+				assert.ErrorContains(t, k.Unmarshal(b), "lies outside")
+			})
+		})
+	}
 }

--- a/service/authenticator.go
+++ b/service/authenticator.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -101,21 +102,26 @@ func (a KRB5BasicAuthenticator) Mechanism() string {
 	return "Kerberos Basic"
 }
 
+// parseBasicHeaderValue splits a base64 encoded HTTP Basic credential into its realm, user name and password.
 func parseBasicHeaderValue(s string) (domain, username, password string, err error) {
 	b, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {
 		return domain, username, password, err
 	}
 
-	v := string(b)
-	vc := strings.SplitN(v, ":", 2)
+	vc := strings.SplitN(string(b), ":", 2)
+	if len(vc) != 2 {
+		return domain, username, password,
+			errors.New("basic authentication header value does not contain a colon separating the user name from the password")
+	}
+
 	password = vc[1]
 	// Domain and username can be specified in 2 formats:
 	// <Username> - no domain specified
 	// <Domain>\<Username>
 	// <Username>@<Domain>.
 	switch {
-	case strings.Contains(vc[0], `\'`):
+	case strings.Contains(vc[0], `\`):
 		u := strings.SplitN(vc[0], `\`, 2)
 		domain = u[0]
 		username = u[1]
@@ -127,5 +133,5 @@ func parseBasicHeaderValue(s string) (domain, username, password string, err err
 		username = vc[0]
 	}
 
-	return
+	return domain, username, password, nil
 }

--- a/service/authenticator_test.go
+++ b/service/authenticator_test.go
@@ -1,9 +1,11 @@
 package service
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/go-krb5/x/identity"
 )
@@ -15,4 +17,45 @@ func TestImplementsInterface(t *testing.T) {
 
 	a := new(identity.Authenticator)
 	assert.Implements(t, a, s)
+}
+
+func TestParseBasicHeaderValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		value    string
+		domain   string
+		username string
+		password string
+		err      bool
+	}{
+		{name: "username only", value: "testuser:passwd", username: "testuser", password: "passwd"},
+		{name: "domain qualified", value: `TEST.GOKRB5\testuser:passwd`, domain: "TEST.GOKRB5", username: "testuser", password: "passwd"},
+		{name: "user principal name", value: "testuser@TEST.GOKRB5:passwd", domain: "TEST.GOKRB5", username: "testuser", password: "passwd"},
+		{name: "password containing a colon", value: "testuser:pass:wd", username: "testuser", password: "pass:wd"},
+		{name: "empty password", value: "testuser:", username: "testuser"},
+		{name: "no colon", value: "nocolonhere", err: true},
+		{name: "empty", value: "", err: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.NotPanics(t, func() {
+				domain, username, password, err := parseBasicHeaderValue(base64.StdEncoding.EncodeToString([]byte(tc.value)))
+
+				if tc.err {
+					assert.Error(t, err)
+					return
+				}
+
+				require.NoError(t, err)
+				assert.Equal(t, tc.domain, domain)
+				assert.Equal(t, tc.username, username)
+				assert.Equal(t, tc.password, password)
+			})
+		})
+	}
 }

--- a/types/pad_data.go
+++ b/types/pad_data.go
@@ -161,3 +161,23 @@ func (pa *PAData) GetETypeInfo2() (d ETypeInfo2, err error) {
 
 	return
 }
+
+// ETypes returns the encryption types of the entries, in the order the KDC listed them.
+func (a ETypeInfo) ETypes() []int32 {
+	ids := make([]int32, len(a))
+	for i, e := range a {
+		ids[i] = e.EType
+	}
+
+	return ids
+}
+
+// ETypes returns the encryption types of the entries, in the order the KDC listed them.
+func (a ETypeInfo2) ETypes() []int32 {
+	ids := make([]int32, len(a))
+	for i, e := range a {
+		ids[i] = e.EType
+	}
+
+	return ids
+}


### PR DESCRIPTION
This fixes several major memory consumption issues that are publicly controllable.