### PR TITLE
fix(crypto): correct and bound the string-to-key iteration count

### DIFF
--- a/crypto/aes256-cts-hmac-sha1-96_test.go
+++ b/crypto/aes256-cts-hmac-sha1-96_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,4 +42,13 @@ func TestAes256CtsHmacSha196_StringToKey(t *testing.T) {
 			HandleTestRFC3962AppendixB(t, e, tc)
 		})
 	}
+}
+
+func TestAes256CtsHmacSha96_StringToKeyRejectsUnboundedIterations(t *testing.T) {
+	t.Parallel()
+
+	var e Aes256CtsHmacSha96
+
+	_, err := e.StringToKey("password", "ATHENA.MIT.EDUraeburn", "00000000")
+	assert.Error(t, err)
 }

--- a/crypto/common/common.go
+++ b/crypto/common/common.go
@@ -12,6 +12,10 @@ import (
 	"github.com/go-krb5/krb5/crypto/etype"
 )
 
+// MaxS2KIterations bounds the PBKDF2 iteration count that string-to-key will accept from a string-to-key
+// parameter.
+const MaxS2KIterations = 5000000
+
 // ZeroPad pads bytes with zeros to nearest multiple of message size m.
 func ZeroPad(b []byte, m int) ([]byte, error) {
 	if m <= 0 {

--- a/crypto/rfc3962/key_derivation.go
+++ b/crypto/rfc3962/key_derivation.go
@@ -4,14 +4,20 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"fmt"
 
 	"github.com/go-crypt/x/pbkdf2"
 
+	"github.com/go-krb5/krb5/crypto/common"
 	"github.com/go-krb5/krb5/crypto/etype"
 )
 
 const (
-	s2kParamsZero = 4294967296
+	// s2kParamsZeroIterations is the count RFC 3962 Section 4 assigns to a parameter of 00 00 00 00.
+	s2kParamsZeroIterations = 1 << 32
+
+	// s2kParamsHexLen is the width of the parameter in hex digits: four octets.
+	s2kParamsHexLen = 8
 )
 
 // StringToKey returns a key derived from the string provided according to the definition in RFC 3961.
@@ -37,21 +43,24 @@ func StringToKeyIter(secret, salt string, iterations int64, e etype.EType) ([]by
 
 // S2KparamsToItertions converts the string representation of iterations to an integer.
 func S2KparamsToItertions(s2kparams string) (int64, error) {
-	// The s2kparams string should be hex string representing 4 bytes
-	// The 4 bytes represent a number in big endian order
-	// If the value is zero then the number of iterations should be 4,294,967,296 (2^32).
-	var i uint32
-
-	if len(s2kparams) != 8 {
-		return int64(s2kParamsZero), errors.New("invalid s2kparams length")
+	if len(s2kparams) != s2kParamsHexLen {
+		return 0, errors.New("invalid s2kparams length")
 	}
 
 	b, err := hex.DecodeString(s2kparams)
 	if err != nil {
-		return int64(s2kParamsZero), errors.New("invalid s2kparams, cannot decode string to bytes")
+		return 0, errors.New("invalid s2kparams, cannot decode string to bytes")
 	}
 
-	i = binary.BigEndian.Uint32(b)
+	i := int64(binary.BigEndian.Uint32(b))
+	if i == 0 {
+		i = s2kParamsZeroIterations
+	}
 
-	return int64(i), nil
+	if i > common.MaxS2KIterations {
+		return 0, fmt.Errorf("s2kparams requests %d iterations, which exceeds the maximum of %d",
+			i, common.MaxS2KIterations)
+	}
+
+	return i, nil
 }

--- a/crypto/rfc3962/key_derivation_test.go
+++ b/crypto/rfc3962/key_derivation_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/krb5/crypto/common"
 )
 
 func TestS2KparamsToItertions(t *testing.T) {
@@ -13,4 +16,48 @@ func TestS2KparamsToItertions(t *testing.T) {
 
 	_, err := S2KparamsToItertions(invalidLengthParams)
 	assert.Contains(t, err.Error(), "invalid s2kparams length", "Error message should mention s2kparams length")
+}
+
+func TestS2KparamsToItertionsZeroMeansTwoToThe32(t *testing.T) {
+	t.Parallel()
+
+	_, err := S2KparamsToItertions("00000000")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "4294967296")
+	assert.Contains(t, err.Error(), "exceeds")
+}
+
+func TestS2KparamsToItertionsBounds(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		s2kparams  string
+		iterations int64
+		err        bool
+	}{
+		{name: "the RFC 3962 default of 4096", s2kparams: "00001000", iterations: 4096},
+		{name: "the minimum expressible count", s2kparams: "00000001", iterations: 1},
+		{name: "the maximum accepted count", s2kparams: common.IterationsToS2Kparams(common.MaxS2KIterations), iterations: int64(common.MaxS2KIterations)},
+		{name: "one past the maximum", s2kparams: common.IterationsToS2Kparams(common.MaxS2KIterations + 1), err: true},
+		{name: "not eight hex digits", s2kparams: "0000", err: true},
+		{name: "not hex", s2kparams: "zzzzzzzz", err: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			i, err := S2KparamsToItertions(tc.s2kparams)
+
+			if tc.err {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.iterations, i)
+		})
+	}
 }

--- a/crypto/rfc8009/key_derivation.go
+++ b/crypto/rfc8009/key_derivation.go
@@ -6,17 +6,21 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"fmt"
 
 	"golang.org/x/crypto/pbkdf2"
 
+	"github.com/go-krb5/krb5/crypto/common"
 	"github.com/go-krb5/krb5/crypto/etype"
 )
 
 const (
-	s2kParamsZero = 32768
-	kerberosLabel = "kerberos"
-	labelSuffixKe = 0xAA
-	prfLabel      = "prf"
+	defaultIterations = 32768
+	s2kParamsZeroIterations = 1 << 32
+	s2kParamsHexLen = 8
+	kerberosLabel   = "kerberos"
+	labelSuffixKe   = 0xAA
+	prfLabel        = "prf"
 )
 
 // DeriveRandom for key derivation as defined in RFC 8009.
@@ -108,18 +112,24 @@ func GetSaltP(salt, ename string) string {
 
 // S2KparamsToItertions converts the string representation of iterations to an integer for RFC 8009.
 func S2KparamsToItertions(s2kparams string) (int, error) {
-	var i uint32
-
-	if len(s2kparams) != 8 {
-		return s2kParamsZero, errors.New("Invalid s2kparams length")
+	if len(s2kparams) != s2kParamsHexLen {
+		return 0, errors.New("invalid s2kparams length")
 	}
 
 	b, err := hex.DecodeString(s2kparams)
 	if err != nil {
-		return s2kParamsZero, errors.New("Invalid s2kparams, cannot decode string to bytes")
+		return 0, errors.New("invalid s2kparams, cannot decode string to bytes")
 	}
 
-	i = binary.BigEndian.Uint32(b)
+	i := int64(binary.BigEndian.Uint32(b))
+	if i == 0 {
+		i = s2kParamsZeroIterations
+	}
+
+	if i > common.MaxS2KIterations {
+		return 0, fmt.Errorf("s2kparams requests %d iterations, which exceeds the maximum of %d",
+			i, common.MaxS2KIterations)
+	}
 
 	return int(i), nil
 }


### PR DESCRIPTION
RFC 3962 section 4 defines a string-to-key parameter of 00 00 00 00 as 2**32 iterations, not as zero. Reading it as zero left PBKDF2 performing a single pass, and the parameter reaches string-to-key from the EData of a KRB-ERROR, which carries no integrity protection: a spoofed pre-authentication error made the client derive its long-term key with no work factor and then encrypt its PA-ENC-TIMESTAMP under it.

The count is now also bounded by common.MaxS2KIterations, which the same section permits, because 2**32 iterations is roughly fourteen minutes of CPU per derivation. A count above the bound is refused rather than clamped, since a clamped count derives a key the KDC will not match and would fail later and less legibly. S2KparamsToItertions therefore now returns an error for counts it previously accepted.

RFC 8009 section 4 adopts the same parameter rules by reference and had the same defect.