### PR TITLE
fix: keytab kvno, renew lifetime, config values, referrals

### DIFF
--- a/client/as_xchange.go
+++ b/client/as_xchange.go
@@ -5,6 +5,7 @@ import (
 	"github.com/go-krb5/krb5/crypto/etype"
 	"github.com/go-krb5/krb5/iana/errorcode"
 	"github.com/go-krb5/krb5/iana/keyusage"
+	"github.com/go-krb5/krb5/iana/nametype"
 	"github.com/go-krb5/krb5/iana/patype"
 	"github.com/go-krb5/krb5/krberror"
 	"github.com/go-krb5/krb5/messages"
@@ -64,7 +65,7 @@ func (cl *Client) ASExchange(realm string, ASReq messages.ASReq, referral int) (
 
 				referral++
 
-				return cl.ASExchange(e.CRealm, ASReq, referral)
+				return cl.ASExchange(e.CRealm, referralASReq(ASReq, e.CRealm), referral)
 			default:
 				return messages.ASRep{}, krberror.Errorf(err, krberror.KDCError, "AS Exchange Error: kerberos error response from KDC")
 			}
@@ -83,6 +84,21 @@ func (cl *Client) ASExchange(realm string, ASReq messages.ASReq, referral int) (
 	}
 
 	return ASRep, nil
+}
+
+// referralASReq returns the AS-REQ reissued against the realm a KDC referred the client to.
+func referralASReq(req messages.ASReq, realm string) messages.ASReq {
+	req.ReqBody.Realm = realm
+	req.PAData = types.PADataSequence{}
+
+	if len(req.ReqBody.SName.NameString) > 0 && req.ReqBody.SName.NameString[0] == "krbtgt" {
+		req.ReqBody.SName = types.PrincipalName{
+			NameType:   nametype.KRB_NT_SRV_INST,
+			NameString: []string{"krbtgt", realm},
+		}
+	}
+
+	return req
 }
 
 // setPAData adds pre-authentication data to the AS_REQ.

--- a/client/as_xchange_test.go
+++ b/client/as_xchange_test.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/krb5/config"
+	"github.com/go-krb5/krb5/iana/nametype"
+	"github.com/go-krb5/krb5/iana/patype"
+	"github.com/go-krb5/krb5/messages"
+	"github.com/go-krb5/krb5/types"
+)
+
+func TestReferralASReqIsReissuedAgainstTheNewRealm(t *testing.T) {
+	t.Parallel()
+
+	cname := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, "testuser")
+
+	req, err := messages.NewASReqForTGT("OLD.GOKRB5", config.New(), cname)
+	require.NoError(t, err)
+
+	req.PAData = types.PADataSequence{{PADataType: patype.PA_ENC_TIMESTAMP, PADataValue: []byte("stale")}}
+
+	referred := referralASReq(req, "NEW.GOKRB5")
+
+	assert.Equal(t, "NEW.GOKRB5", referred.ReqBody.Realm)
+	assert.Equal(t, []string{"krbtgt", "NEW.GOKRB5"}, referred.ReqBody.SName.NameString)
+
+	assert.Empty(t, referred.PAData)
+
+	assert.Equal(t, cname, referred.ReqBody.CName)
+	assert.Equal(t, req.ReqBody.Nonce, referred.ReqBody.Nonce)
+}
+
+func TestReferralASReqLeavesANonTGTServiceNameAlone(t *testing.T) {
+	t.Parallel()
+
+	cname := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, "testuser")
+
+	req, err := messages.NewASReqForChgPasswd("OLD.GOKRB5", config.New(), cname)
+	require.NoError(t, err)
+
+	referred := referralASReq(req, "NEW.GOKRB5")
+
+	assert.Equal(t, "NEW.GOKRB5", referred.ReqBody.Realm)
+	assert.Equal(t, []string{"kadmin", "changepw"}, referred.ReqBody.SName.NameString)
+}

--- a/config/krb5conf.go
+++ b/config/krb5conf.go
@@ -213,7 +213,7 @@ func (l *LibDefaults) parseLines(lines []string) error {
 			return InvalidErrorf("libdefaults section line (%s)", line)
 		}
 
-		p := strings.Split(line, "=")
+		p := strings.SplitN(line, "=", 2)
 
 		key := strings.TrimSpace(strings.ToLower(p[0]))
 		switch key {
@@ -508,7 +508,7 @@ func (r *Realm) parseLines(name string, lines []string) (err error) {
 			}
 		}
 
-		p := strings.Split(line, "=")
+		p := strings.SplitN(line, "=", 2)
 		key := strings.TrimSpace(strings.ToLower(p[0]))
 		v := strings.TrimSpace(p[1])
 
@@ -571,7 +571,7 @@ func parseRealms(lines []string) (realms []Realm, err error) {
 
 			if c == 1 {
 				start = i
-				p := strings.Split(l, "=")
+				p := strings.SplitN(l, "=", 2)
 				name = strings.TrimSpace(p[0])
 			}
 		}
@@ -622,7 +622,7 @@ func (d *DomainRealm) parseLines(lines []string) error {
 			return InvalidErrorf("realm line (%s)", line)
 		}
 
-		p := strings.Split(line, "=")
+		p := strings.SplitN(line, "=", 2)
 		domain := strings.TrimSpace(strings.ToLower(p[0]))
 		realm := strings.TrimSpace(p[1])
 		d.addMapping(domain, realm)

--- a/config/krb5conf_test.go
+++ b/config/krb5conf_test.go
@@ -753,3 +753,12 @@ func TestDefaultEnctypesIncludeRFC8009(t *testing.T) {
 		assert.Contains(t, l.ids, etypeID.AES128_CTS_HMAC_SHA1_96, l.name)
 	}
 }
+
+func TestParseValuesContainingAnEqualsSign(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewFromString("[libdefaults]\n default_realm = TEST.GOKRB5\n default_keytab_name = FILE:/etc/krb5.keytab?a=b\n")
+	require.NoError(t, err)
+
+	assert.Equal(t, "FILE:/etc/krb5.keytab?a=b", c.LibDefaults.DefaultKeytabName)
+}

--- a/crypto/rfc8009/key_derivation.go
+++ b/crypto/rfc8009/key_derivation.go
@@ -15,12 +15,12 @@ import (
 )
 
 const (
-	defaultIterations = 32768
+	defaultIterations       = 32768
 	s2kParamsZeroIterations = 1 << 32
-	s2kParamsHexLen = 8
-	kerberosLabel   = "kerberos"
-	labelSuffixKe   = 0xAA
-	prfLabel        = "prf"
+	s2kParamsHexLen         = 8
+	kerberosLabel           = "kerberos"
+	labelSuffixKe           = 0xAA
+	prfLabel                = "prf"
 )
 
 // DeriveRandom for key derivation as defined in RFC 8009.

--- a/keytab/keytab.go
+++ b/keytab/keytab.go
@@ -72,38 +72,56 @@ func New() *Keytab {
 // If the kvno is zero then the latest kvno will be returned. The kvno is also returned.
 func (kt *Keytab) GetEncryptionKey(princName types.PrincipalName, realm string, kvno int, etype int32) (types.EncryptionKey, int, error) {
 	var (
-		key types.EncryptionKey
-		t   time.Time
-		kv  int
+		key   types.EncryptionKey
+		t     time.Time
+		kv    int
+		found bool
 	)
 
 	for _, k := range kt.Entries {
-		if k.Principal.Realm == realm && len(k.Principal.Components) == len(princName.NameString) &&
-			k.Key.KeyType == etype &&
-			(k.KVNO == uint32(kvno) || kvno == 0) &&
-			k.Timestamp.After(t) {
-			p := true
-
-			for i, n := range k.Principal.Components {
-				if princName.NameString[i] != n {
-					p = false
-					break
-				}
-			}
-
-			if p {
-				key = k.Key
-				kv = int(k.KVNO)
-				t = k.Timestamp
-			}
+		if k.Principal.Realm != realm || k.Key.KeyType != etype {
+			continue
 		}
+
+		if kvno != 0 && k.KVNO != uint32(kvno) {
+			continue
+		}
+
+		if !k.Principal.equal(princName) {
+			continue
+		}
+
+		// The highest key version wins, and the timestamp only breaks a tie between entries that share one.
+		// Selecting on the timestamp alone returns an arbitrary entry for a keytab written in a single
+		// operation, because ktutil and kadmin ktadd give every entry of one the same timestamp.
+		if found && (int(k.KVNO) < kv || (int(k.KVNO) == kv && !k.Timestamp.After(t))) {
+			continue
+		}
+
+		key, kv, t, found = k.Key, int(k.KVNO), k.Timestamp, true
 	}
 
-	if len(key.KeyValue) < 1 {
+	if !found {
 		return key, 0, fmt.Errorf("matching key not found in keytab. Looking for %q realm: %v kvno: %v etype: %v", princName.PrincipalNameString(), realm, kvno, etype)
 	}
 
 	return key, kv, nil
+}
+
+// equal reports whether the principal names the same components as the PrincipalName given. RFC 4120 Section 6.2
+// makes the name type insignificant when comparing principal names, so only the components are compared.
+func (p principal) equal(n types.PrincipalName) bool {
+	if len(p.Components) != len(n.NameString) {
+		return false
+	}
+
+	for i, c := range p.Components {
+		if n.NameString[i] != c {
+			return false
+		}
+	}
+
+	return true
 }
 
 // Create a new Keytab entry.

--- a/keytab/keytab_test.go
+++ b/keytab/keytab_test.go
@@ -234,12 +234,32 @@ func TestKeytab_GetEncryptionKey(t *testing.T) {
 		t.Error(err)
 	}
 
-	assert.Equal(t, 4, kvno)
+	assert.Equal(t, 5, kvno)
 
 	_, kvno, err = kt.GetEncryptionKey(pn, realm, 3, 18)
 	if err != nil {
 		t.Error(err)
 	}
 
+	assert.Equal(t, 3, kvno)
+}
+
+func TestKeytab_GetEncryptionKeyWithIdenticalTimestamps(t *testing.T) {
+	t.Parallel()
+
+	princ := "HTTP/princ.test.gokrb5"
+	realm := "TEST.GOKRB5"
+	ts := time.Unix(1000, 0)
+
+	kt := New()
+	require.NoError(t, kt.AddEntry(princ, realm, "abcdefg", ts, 1, 18))
+	require.NoError(t, kt.AddEntry(princ, realm, "abcdefg", ts, 2, 18))
+	require.NoError(t, kt.AddEntry(princ, realm, "abcdefg", ts, 3, 18))
+
+	pn := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, princ)
+
+	_, kvno, err := kt.GetEncryptionKey(pn, realm, 0, 18)
+
+	require.NoError(t, err)
 	assert.Equal(t, 3, kvno)
 }

--- a/messages/kdc_req.go
+++ b/messages/kdc_req.go
@@ -148,7 +148,6 @@ func NewASReq(realm string, c *config.Config, cname, sname types.PrincipalName) 
 	if c.LibDefaults.RenewLifetime != 0 {
 		types.SetFlag(&a.ReqBody.KDCOptions, flags.Renewable)
 		a.ReqBody.RTime = t.Add(c.LibDefaults.RenewLifetime)
-		a.ReqBody.RTime = t.Add(time.Duration(48) * time.Hour)
 	}
 
 	if !c.LibDefaults.NoAddresses {

--- a/messages/kdc_req_test.go
+++ b/messages/kdc_req_test.go
@@ -587,3 +587,22 @@ func TestNewForwardedTGSReqShouldAdvertiseSupportedEncryptionTypes(t *testing.T)
 	assert.False(t, none.PAData.Contains(patype.PA_SUPPORTED_ETYPES))
 	assert.True(t, none.PAData.Contains(patype.PA_TGS_REQ))
 }
+
+func TestNewASReqHonoursTheConfiguredRenewLifetime(t *testing.T) {
+	t.Parallel()
+
+	c := config.New()
+	c.LibDefaults.RenewLifetime = 72 * time.Hour
+
+	cname := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, "testuser")
+
+	before := time.Now().UTC()
+
+	a, err := NewASReqForTGT("TEST.GOKRB5", c, cname)
+	require.NoError(t, err)
+
+	assert.True(t, types.IsFlagSet(&a.ReqBody.KDCOptions, flags.Renewable), "the renewable option should be set")
+
+	// The renew till should follow renew_lifetime, not a value fixed in the source.
+	assert.WithinDuration(t, before.Add(72*time.Hour), a.ReqBody.RTime, 10*time.Second)
+}


### PR DESCRIPTION
GetEncryptionKey picked by timestamp, so a ktutil written keytab whose entries share one returned the oldest key. NewASReq overwrote renew_lifetime with 48 hours. The config parser truncated values at the first equals sign. A WRONG_REALM referral resent the request still naming the old realm.