### PR TITLE
fix(spnego): honour dns_canonicalize_hostname

### DIFF
--- a/config/krb5conf.go
+++ b/config/krb5conf.go
@@ -87,7 +87,11 @@ type LibDefaults struct {
 	// des3-cbc-sha1 arcfour-hmac-md5 camellia256-cts-cmac camellia128-cts-cmac des-cbc-crc des-cbc-md5 des-cbc-md4.
 	DefaultTktEnctypeIDs []int32
 
-	// DNSCanonicalizeHostname has a default value of true.
+	// DNSCanonicalizeHostname governs whether DNS is consulted to canonicalize a hostname when deriving a
+	// service principal name. It has a default value of true.
+	//
+	// This decides which service key the KDC encrypts the ticket to, so leaving it enabled lets DNS choose that
+	// principal. Set it to false where the resolver is not trusted to.
 	DNSCanonicalizeHostname bool
 
 	// DNSLookupKDC has a default value of false.
@@ -133,6 +137,10 @@ type LibDefaults struct {
 	Proxiable bool
 
 	// RDNS has a default value of true.
+	//
+	// It governs whether reverse name lookup is used in addition to forward lookup when canonicalizing a
+	// hostname. This library performs no reverse lookup, so the setting is parsed and has no effect; forward
+	// canonicalization is governed by DNSCanonicalizeHostname.
 	RDNS bool
 
 	// RealmTryDomains has a default value of -1.

--- a/spnego/http.go
+++ b/spnego/http.go
@@ -25,7 +25,7 @@ import (
 	"github.com/go-krb5/krb5/types"
 )
 
-// Client side functionality.
+var lookupCNAME = net.LookupCNAME
 
 // DefaultMaxRedirects is the number of redirects the SPNEGO client will follow when no other limit is configured.
 const DefaultMaxRedirects = 10
@@ -262,45 +262,58 @@ func respUnauthorizedNegotiate(resp *http.Response) bool {
 	return false
 }
 
-func setRequestSPN(r *http.Request) (types.PrincipalName, error) {
+// setRequestSPN derives the service principal name for the request and updates the request's Host to match.
+//
+// canonicalize is the dns_canonicalize_hostname setting of krb5.conf. It is a security control as much as a
+// convenience: the service principal name decides which service key the KDC encrypts the ticket to, so a client
+// that canonicalizes is letting DNS choose that principal. An attacker able to influence the answer can steer the
+// ticket to a principal it holds a key for, which is why the setting exists and why MIT moved its default.
+func setRequestSPN(r *http.Request, canonicalize bool) (types.PrincipalName, error) {
 	h := strings.TrimSuffix(r.URL.Host, ".")
+
 	// This if statement checks if the host includes a port number.
 	if strings.LastIndex(r.URL.Host, ":") > strings.LastIndex(r.URL.Host, "]") {
-		// There is a port number in the URL.
 		h, p, err := net.SplitHostPort(h)
 		if err != nil {
 			return types.PrincipalName{}, err
 		}
 
-		name, err := net.LookupCNAME(h)
-		if name != "" && err == nil {
-			// Underlyng canonical name should be used for SPN.
-			h = strings.ToLower(name)
-		}
+		h = canonicalHost(h, canonicalize)
 
-		h = strings.TrimSuffix(h, ".")
 		r.Host = fmt.Sprintf("%s:%s", h, p)
 
 		return types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, "HTTP/"+h), nil
 	}
 
-	name, err := net.LookupCNAME(h)
-	if name != "" && err == nil {
-		// Underlyng canonical name should be used for SPN.
-		h = strings.ToLower(name)
-	}
-
-	h = strings.TrimSuffix(h, ".")
+	h = canonicalHost(h, canonicalize)
 	r.Host = h
 
 	return types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, "HTTP/"+h), nil
+}
+
+func canonicalHost(h string, canonicalize bool) string {
+	if canonicalize {
+		if name, err := lookupCNAME(h); err == nil && name != "" {
+			h = strings.ToLower(name)
+		}
+	}
+
+	return strings.TrimSuffix(h, ".")
+}
+
+func canonicalizeHostname(cl *client.Client) bool {
+	if cl == nil || cl.Config == nil {
+		return true
+	}
+
+	return cl.Config.LibDefaults.DNSCanonicalizeHostname
 }
 
 // SetSPNEGOHeader gets the service ticket and sets it as the SPNEGO authorization header on HTTP request object.
 // To auto generate the SPN from the request object pass a null string "".
 func SetSPNEGOHeader(cl *client.Client, r *http.Request, spn string, opts ...KRB5TokenOption) error {
 	if spn == "" {
-		pn, err := setRequestSPN(r)
+		pn, err := setRequestSPN(r, canonicalizeHostname(cl))
 		if err != nil {
 			return err
 		}

--- a/spnego/spn_test.go
+++ b/spnego/spn_test.go
@@ -1,0 +1,128 @@
+package spnego
+
+import (
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/krb5/client"
+	"github.com/go-krb5/krb5/config"
+)
+
+// stubCNAME replaces the resolver for the duration of a test and reports which hosts it was asked about.
+func stubCNAME(t *testing.T, canonical string) *[]string {
+	t.Helper()
+
+	var asked []string
+
+	original := lookupCNAME
+	lookupCNAME = func(host string) (string, error) {
+		asked = append(asked, host)
+
+		if canonical == "" {
+			return "", &net.DNSError{Err: "no such host", Name: host, IsNotFound: true}
+		}
+
+		return canonical, nil
+	}
+
+	t.Cleanup(func() { lookupCNAME = original })
+
+	return &asked
+}
+
+func TestSetRequestSPNDoesNotConsultDNSWhenCanonicalizationIsDisabled(t *testing.T) {
+	// The SPN decides which service key the ticket is encrypted to, so canonicalizing through DNS trusts the
+	// resolver to choose that principal. krb5.conf's dns_canonicalize_hostname exists to turn that off, and it
+	// was parsed and then ignored.
+	asked := stubCNAME(t, "elsewhere.attacker.example.")
+
+	r, err := http.NewRequest(http.MethodGet, "http://host.test.gokrb5/path", nil)
+	require.NoError(t, err)
+
+	pn, err := setRequestSPN(r, false)
+	require.NoError(t, err)
+
+	assert.Empty(t, *asked, "the resolver must not be consulted when canonicalization is disabled")
+	assert.Equal(t, "HTTP/host.test.gokrb5", pn.PrincipalNameString())
+	assert.Equal(t, "host.test.gokrb5", r.Host)
+}
+
+func TestSetRequestSPNCanonicalizesWhenEnabled(t *testing.T) {
+	asked := stubCNAME(t, "canonical.test.gokrb5.")
+
+	r, err := http.NewRequest(http.MethodGet, "http://host.test.gokrb5/path", nil)
+	require.NoError(t, err)
+
+	pn, err := setRequestSPN(r, true)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"host.test.gokrb5"}, *asked)
+	assert.Equal(t, "HTTP/canonical.test.gokrb5", pn.PrincipalNameString())
+	assert.Equal(t, "canonical.test.gokrb5", r.Host)
+}
+
+func TestSetRequestSPNWithAPortDoesNotConsultDNSWhenDisabled(t *testing.T) {
+	asked := stubCNAME(t, "elsewhere.attacker.example.")
+
+	r, err := http.NewRequest(http.MethodGet, "http://host.test.gokrb5:8080/path", nil)
+	require.NoError(t, err)
+
+	pn, err := setRequestSPN(r, false)
+	require.NoError(t, err)
+
+	assert.Empty(t, *asked, "the resolver must not be consulted when canonicalization is disabled")
+
+	// The port is not part of the service principal name, but it is kept on the request Host.
+	assert.Equal(t, "HTTP/host.test.gokrb5", pn.PrincipalNameString())
+	assert.Equal(t, "host.test.gokrb5:8080", r.Host)
+}
+
+func TestSetRequestSPNKeepsTheHostWhenTheLookupFails(t *testing.T) {
+	stubCNAME(t, "")
+
+	r, err := http.NewRequest(http.MethodGet, "http://host.test.gokrb5/path", nil)
+	require.NoError(t, err)
+
+	pn, err := setRequestSPN(r, true)
+	require.NoError(t, err)
+
+	assert.Equal(t, "HTTP/host.test.gokrb5", pn.PrincipalNameString())
+}
+
+func TestCanonicalizeHostnameFollowsTheClientConfiguration(t *testing.T) {
+	cfg := config.New()
+	require.True(t, cfg.LibDefaults.DNSCanonicalizeHostname, "krb5.conf defaults the setting to true")
+
+	cl := client.NewWithPassword("testuser", "TEST.GOKRB5", "password", cfg)
+	assert.True(t, canonicalizeHostname(cl))
+
+	cfg.LibDefaults.DNSCanonicalizeHostname = false
+	assert.False(t, canonicalizeHostname(cl), "dns_canonicalize_hostname = false must be honoured")
+
+	// A client carrying no configuration canonicalizes, as krb5.conf defaults to.
+	assert.True(t, canonicalizeHostname(nil))
+}
+
+func TestSetSPNEGOHeaderDoesNotCanonicalizeWhenDisabled(t *testing.T) {
+	asked := stubCNAME(t, "elsewhere.attacker.example.")
+
+	cfg, err := config.NewFromString("[libdefaults]\n default_realm = TEST.GOKRB5\n dns_canonicalize_hostname = false\n")
+	require.NoError(t, err)
+	require.False(t, cfg.LibDefaults.DNSCanonicalizeHostname)
+
+	cl := client.NewWithPassword("testuser", "TEST.GOKRB5", "password", cfg)
+
+	r, err := http.NewRequest(http.MethodGet, "http://host.test.gokrb5/path", nil)
+	require.NoError(t, err)
+
+	// The exchange itself fails with no KDC to talk to; what matters is that the SPN was derived without DNS
+	// before any of that happened.
+	_ = SetSPNEGOHeader(cl, r, "")
+
+	assert.Empty(t, *asked, "the resolver must not be consulted when the configuration disables it")
+	assert.Equal(t, "host.test.gokrb5", r.Host)
+}


### PR DESCRIPTION
The service principal name was always canonicalized through DNS, letting the resolver choose which service key the ticket is encrypted to, and the setting that disables that was parsed and never read. rdns is now documented as inert since no reverse lookup is performed.