### PR TITLE
fix(spnego): accept the MS legacy Kerberos OID on the mech token

### DIFF
--- a/spnego/krb5_token.go
+++ b/spnego/krb5_token.go
@@ -78,8 +78,9 @@ func (m *KRB5Token) Unmarshal(b []byte) error {
 		return fmt.Errorf("error unmarshalling KRB5Token OID: %w", err)
 	}
 
-	if !oid.Equal(gssapi.OIDKRB5.OID()) {
-		return fmt.Errorf("error unmarshalling KRB5Token, OID is %s not %s", oid.String(), gssapi.OIDKRB5.OID().String())
+	if !isKerberosMech(oid) {
+		return fmt.Errorf("error unmarshalling KRB5Token, OID is %s not %s or %s",
+			oid.String(), gssapi.OIDKRB5.OID().String(), gssapi.OIDMSLegacyKRB5.OID().String())
 	}
 
 	m.OID = oid
@@ -420,4 +421,9 @@ func delegatedCredential(cl *client.Client, tkt messages.Ticket, sessionKey type
 	}
 
 	return b, nil
+}
+
+// isKerberosMech reports whether the object identifier names a Kerberos 5 GSS-API mechanism this library speaks.
+func isKerberosMech(oid asn1.ObjectIdentifier) bool {
+	return oid.Equal(gssapi.OIDKRB5.OID()) || oid.Equal(gssapi.OIDMSLegacyKRB5.OID())
 }

--- a/spnego/krb5_token_test.go
+++ b/spnego/krb5_token_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-krb5/x/encoding/asn1"
 
+	"github.com/go-krb5/krb5/asn1tools"
 	"github.com/go-krb5/krb5/client"
 	"github.com/go-krb5/krb5/config"
 	"github.com/go-krb5/krb5/credentials"
@@ -669,4 +670,60 @@ func TestKrb5TokenAuthenticatorShouldAdvertiseCBTWhenBound(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Empty(t, unbound.AuthorizationData)
+}
+
+// krb5TokenWithOID re-stamps the sample KRB5 token with the mechanism OID given, leaving the token ID and the
+// AP_REQ that follow it untouched.
+func krb5TokenWithOID(t *testing.T, oid asn1.ObjectIdentifier) []byte {
+	t.Helper()
+
+	b, err := hex.DecodeString(KRB5TokenHex)
+	require.NoError(t, err)
+
+	var original asn1.ObjectIdentifier
+
+	rest, err := asn1.UnmarshalWithParams(b, &original, "application,explicit,tag:0")
+	require.NoError(t, err)
+
+	ob, err := asn1.Marshal(oid, asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
+	require.NoError(t, err)
+
+	return asn1tools.AddASNAppTag(append(ob, rest...), 0)
+}
+
+func TestKRB5Token_UnmarshalAcceptsTheMechanismsSPNEGONegotiates(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		oid  asn1.ObjectIdentifier
+	}{
+		{"KRB5", gssapi.OIDKRB5.OID()},
+		{"MS legacy KRB5", gssapi.OIDMSLegacyKRB5.OID()},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var mt KRB5Token
+
+			require.NoError(t, mt.Unmarshal(krb5TokenWithOID(t, tc.oid)))
+
+			assert.True(t, mt.IsAPReq())
+			assert.Equal(t, tc.oid, mt.OID)
+
+			mb, err := mt.Marshal()
+			require.NoError(t, err)
+			assert.Equal(t, krb5TokenWithOID(t, tc.oid), mb)
+		})
+	}
+}
+
+func TestKRB5Token_UnmarshalRejectsAnUnrelatedMechanism(t *testing.T) {
+	t.Parallel()
+
+	var mt KRB5Token
+
+	assert.Error(t, mt.Unmarshal(krb5TokenWithOID(t, gssapi.OIDGSSIAKerb.OID())))
 }

--- a/spnego/negotiation_token.go
+++ b/spnego/negotiation_token.go
@@ -127,7 +127,7 @@ func (n *NegTokenInit) Verify() (bool, gssapi.Status) {
 	var mtSupported bool
 
 	for _, m := range n.MechTypes {
-		if m.Equal(gssapi.OIDKRB5.OID()) || m.Equal(gssapi.OIDMSLegacyKRB5.OID()) {
+		if isKerberosMech(m) {
 			if n.mechToken == nil && n.MechTokenBytes == nil {
 				return false, gssapi.Status{Code: gssapi.StatusContinueNeeded}
 			}
@@ -229,7 +229,7 @@ func (n *NegTokenResp) Unmarshal(b []byte) error {
 
 // Verify a Resp/Targ negotiation token.
 func (n *NegTokenResp) Verify() (bool, gssapi.Status) {
-	if n.SupportedMech.Equal(gssapi.OIDKRB5.OID()) || n.SupportedMech.Equal(gssapi.OIDMSLegacyKRB5.OID()) {
+	if isKerberosMech(n.SupportedMech) {
 		if n.mechToken == nil && n.ResponseToken == nil {
 			return false, gssapi.Status{Code: gssapi.StatusContinueNeeded}
 		}

--- a/spnego/spnego.go
+++ b/spnego/spnego.go
@@ -101,7 +101,7 @@ func (s *SPNEGO) AcceptSecContext(ct gssapi.ContextToken) (bool, context.Context
 		oid = t.NegTokenResp.SupportedMech
 	}
 
-	if !oid.Equal(gssapi.OIDKRB5.OID()) && !oid.Equal(gssapi.OIDMSLegacyKRB5.OID()) {
+	if !isKerberosMech(oid) {
 		return false, ctx, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: "SPNEGO OID of MechToken is not of type KRB5"}
 	}
 	// Flags in the NegInit must be used 	t.NegTokenInit.ReqFlags.


### PR DESCRIPTION
SPNEGO negotiates both Kerberos mechanism OIDs, but KRB5Token.Unmarshal accepted only one, so a peer that agreed on the legacy OID had its mech token rejected as defective. All four places that identify the mechanism now share one predicate.