### PR TITLE
fix: checksum verification, key derivation, padata, key precedence

### DIFF
--- a/client/as_xchange.go
+++ b/client/as_xchange.go
@@ -102,10 +102,22 @@ func referralASReq(req messages.ASReq, realm string) messages.ASReq {
 }
 
 // setPAData adds pre-authentication data to the AS_REQ.
+//
+// The data is rebuilt rather than appended to. ASExchange calls this once before sending and again on the same
+// request after a KDC_ERR_PREAUTH_REQUIRED, so appending sent the KDC two copies of everything.
 func setPAData(cl *Client, krberr *messages.KRBError, req *messages.ASReq) error {
+	var kept types.PADataSequence
+
+	for _, pa := range req.PAData {
+		if pa.PADataType != patype.PA_REQ_ENC_PA_REP && pa.PADataType != patype.PA_ENC_TIMESTAMP {
+			kept = append(kept, pa)
+		}
+	}
+
+	req.PAData = kept
+
 	if !cl.settings.DisablePAFXFAST() {
-		pa := types.PAData{PADataType: patype.PA_REQ_ENC_PA_REP}
-		req.PAData = append(req.PAData, pa)
+		req.PAData = append(req.PAData, types.PAData{PADataType: patype.PA_REQ_ENC_PA_REP})
 	}
 
 	if cl.settings.AssumePreAuthentication() {
@@ -163,13 +175,6 @@ func setPAData(cl *Client, krberr *messages.KRBError, req *messages.ASReq) error
 		pa := types.PAData{
 			PADataType:  patype.PA_ENC_TIMESTAMP,
 			PADataValue: pb,
-		}
-
-		for i, pa := range req.PAData {
-			if pa.PADataType == patype.PA_ENC_TIMESTAMP {
-				req.PAData[i] = req.PAData[len(req.PAData)-1]
-				req.PAData = req.PAData[:len(req.PAData)-1]
-			}
 		}
 
 		req.PAData = append(req.PAData, pa)

--- a/client/as_xchange_test.go
+++ b/client/as_xchange_test.go
@@ -47,3 +47,57 @@ func TestReferralASReqLeavesANonTGTServiceNameAlone(t *testing.T) {
 	assert.Equal(t, "NEW.GOKRB5", referred.ReqBody.Realm)
 	assert.Equal(t, []string{"kadmin", "changepw"}, referred.ReqBody.SName.NameString)
 }
+
+func TestSetPADataDoesNotAccumulateAcrossCalls(t *testing.T) {
+	t.Parallel()
+
+	cl := NewWithPassword("testuser", "TEST.GOKRB5", "password", config.New())
+
+	req, err := messages.NewASReqForTGT("TEST.GOKRB5", cl.Config, cl.Credentials.CName())
+	require.NoError(t, err)
+
+	require.NoError(t, setPAData(cl, nil, &req))
+	first := len(req.PAData)
+
+	require.NotPanics(t, func() {
+		require.NoError(t, setPAData(cl, nil, &req))
+	})
+
+	assert.Equal(t, first, len(req.PAData), "a second call must replace the pre-authentication data, not add to it")
+	assert.Equal(t, 1, countPAData(req.PAData, patype.PA_REQ_ENC_PA_REP))
+}
+
+func TestSetPADataReplacesAnExistingEncTimestamp(t *testing.T) {
+	t.Parallel()
+
+	cl := NewWithPassword("testuser", "TEST.GOKRB5", "password", config.New())
+	cl.settings.assumePreAuthentication = true
+
+	req, err := messages.NewASReqForTGT("TEST.GOKRB5", cl.Config, cl.Credentials.CName())
+	require.NoError(t, err)
+
+	req.PAData = types.PADataSequence{
+		{PADataType: patype.PA_ENC_TIMESTAMP, PADataValue: []byte("stale")},
+		{PADataType: patype.PA_ENC_TIMESTAMP, PADataValue: []byte("staler")},
+		{PADataType: patype.PA_ENC_TIMESTAMP, PADataValue: []byte("stalest")},
+	}
+
+	require.NotPanics(t, func() {
+		require.NoError(t, setPAData(cl, nil, &req))
+	})
+
+	assert.Equal(t, 1, countPAData(req.PAData, patype.PA_ENC_TIMESTAMP))
+	assert.Equal(t, 1, countPAData(req.PAData, patype.PA_REQ_ENC_PA_REP))
+}
+
+func countPAData(pas types.PADataSequence, t int32) int {
+	var n int
+
+	for _, pa := range pas {
+		if pa.PADataType == t {
+			n++
+		}
+	}
+
+	return n
+}

--- a/client/tgs_exchange.go
+++ b/client/tgs_exchange.go
@@ -15,7 +15,7 @@ func (cl *Client) TGSREQGenerateAndExchange(spn types.PrincipalName, kdcRealm st
 		return tgsReq, tgsRep, krberror.Errorf(err, krberror.KRBMsgError, "TGS Exchange Error: failed to generate a new TGS_REQ")
 	}
 
-	return cl.TGSExchange(tgsReq, kdcRealm, tgsRep.Ticket, sessionKey, 0)
+	return cl.TGSExchange(tgsReq, kdcRealm, tgt, sessionKey, 0)
 }
 
 // TGSExchange exchanges the provided TGS_REQ with the KDC to retrieve a TGS_REP.

--- a/crypto/common/common.go
+++ b/crypto/common/common.go
@@ -109,9 +109,16 @@ func GetIntegrityHash(b, key []byte, usage uint32, etype etype.EType) ([]byte, e
 }
 
 // VerifyChecksum compares the checksum of the msg bytes is the same as the checksum provided.
+//
+// A checksum that could not be computed fails verification rather than being compared. Discarding the error left
+// the expected checksum nil, and hmac.Equal reports two empty slices as equal, so a caller supplying an empty
+// checksum was told it verified.
 func VerifyChecksum(key, chksum, msg []byte, usage uint32, etype etype.EType) bool {
-	// The encrypted message is a concatenation of the encrypted output and the hash HMAC.
-	expectedMAC, _ := GetChecksumHash(msg, key, usage, etype)
+	expectedMAC, err := GetChecksumHash(msg, key, usage, etype)
+	if err != nil {
+		return false
+	}
+
 	return hmac.Equal(chksum, expectedMAC)
 }
 

--- a/crypto/common/common_test.go
+++ b/crypto/common/common_test.go
@@ -1,0 +1,36 @@
+package common_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/go-krb5/krb5/crypto"
+	"github.com/go-krb5/krb5/crypto/common"
+)
+
+func TestVerifyChecksumFailsClosedWhenTheChecksumCannotBeComputed(t *testing.T) {
+	t.Parallel()
+
+	var e crypto.Aes256CtsHmacSha96
+
+	badKey := make([]byte, 5)
+
+	assert.False(t, common.VerifyChecksum(badKey, []byte{}, []byte("a message"), 1, e),
+		"an empty checksum must not verify when the expected one could not be computed")
+	assert.False(t, common.VerifyChecksum(badKey, nil, []byte("a message"), 1, e))
+}
+
+func TestVerifyChecksumAcceptsAGoodChecksum(t *testing.T) {
+	t.Parallel()
+
+	var e crypto.Aes256CtsHmacSha96
+
+	key := make([]byte, 32)
+
+	sum, err := common.GetChecksumHash([]byte("a message"), key, 1, e)
+	assert.NoError(t, err)
+
+	assert.True(t, common.VerifyChecksum(key, sum, []byte("a message"), 1, e))
+	assert.False(t, common.VerifyChecksum(key, sum, []byte("another message"), 1, e))
+}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -124,7 +124,10 @@ func firstSupported(ids []int32) int {
 }
 
 // GetEncryptedData encrypts the data provided and returns and EncryptedData type.
-// Pass a usage value of zero to use the key provided directly rather than deriving one.
+//
+// The usage must be one of the key usage numbers RFC 4120 Section 7.5.1 assigns. Zero is not among them, and this
+// previously promised to encrypt with the key undivided, which is not a Kerberos operation and was never
+// implemented: it produced an empty derived key and an error about the key size.
 func GetEncryptedData(plainBytes []byte, key types.EncryptionKey, usage uint32, kvno int) (types.EncryptedData, error) {
 	var ed types.EncryptedData
 

--- a/crypto/deriverandom_test.go
+++ b/crypto/deriverandom_test.go
@@ -1,0 +1,48 @@
+package crypto
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/go-krb5/krb5/crypto/rfc3961"
+)
+
+func TestDeriveRandomReturnsWhenEncryptionFailsPartWayThrough(t *testing.T) {
+	t.Parallel()
+
+	e := &failAfterFirstEncrypt{}
+	key := make([]byte, 32)
+
+	done := make(chan error, 1)
+
+	go func() {
+		_, err := rfc3961.DeriveRandom(key, []byte("usage"), e)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		assert.Error(t, err, "the failure should be reported rather than swallowed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("DeriveRandom did not return: it loops when EncryptData fails part way through")
+	}
+}
+
+type failAfterFirstEncrypt struct {
+	Aes256CtsHmacSha96
+
+	calls int
+}
+
+func (e *failAfterFirstEncrypt) EncryptData(key, data []byte) ([]byte, []byte, error) {
+	e.calls++
+
+	if e.calls > 1 {
+		return nil, nil, errors.New("encryption unavailable")
+	}
+
+	return e.Aes256CtsHmacSha96.EncryptData(key, data)
+}

--- a/crypto/rfc3961/encryption.go
+++ b/crypto/rfc3961/encryption.go
@@ -43,7 +43,6 @@ func DES3EncryptData(key, data []byte, e etype.EType) ([]byte, []byte, error) {
 // DES3EncryptMessage encrypts the message provided using DES3 and methods specific to the etype provided.
 // The encrypted data is concatenated with its integrity hash to create an encrypted message.
 func DES3EncryptMessage(key, message []byte, usage uint32, e etype.EType) ([]byte, []byte, error) {
-	// confounder.
 	c := make([]byte, e.GetConfounderByteSize())
 
 	_, err := rand.Read(c)
@@ -54,13 +53,15 @@ func DES3EncryptMessage(key, message []byte, usage uint32, e etype.EType) ([]byt
 	plainBytes := append(c, message...)
 	plainBytes, _ = common.ZeroPad(plainBytes, e.GetMessageBlockByteSize())
 
-	// Derive key for encryption from usage.
-	var k []byte
-	if usage != 0 {
-		k, err = e.DeriveKey(key, common.GetUsageKe(usage))
-		if err != nil {
-			return []byte{}, []byte{}, fmt.Errorf("error deriving key for encryption: %w", err)
-		}
+	// RFC 4120 Section 7.5.1 assigns no key usage number zero, and decryption derives unconditionally, so a
+	// message encrypted without deriving could never be decrypted by this library.
+	if usage == 0 {
+		return []byte{}, []byte{}, errors.New("key usage 0 is not assigned by RFC 4120 section 7.5.1")
+	}
+
+	k, err := e.DeriveKey(key, common.GetUsageKe(usage))
+	if err != nil {
+		return []byte{}, []byte{}, fmt.Errorf("error deriving key for encryption: %w", err)
 	}
 
 	iv, b, err := e.EncryptData(k, plainBytes)

--- a/crypto/rfc3961/key_derivation.go
+++ b/crypto/rfc3961/key_derivation.go
@@ -35,7 +35,10 @@ func DeriveRandom(key, usage []byte, e etype.EType) ([]byte, error) {
 	}
 
 	for i := copy(out, K); i < len(out); {
-		_, K, _ = e.EncryptData(key, K)
+		if _, K, err = e.EncryptData(key, K); err != nil {
+			return out, err
+		}
+
 		i += copy(out[i:], K)
 	}
 

--- a/crypto/rfc3962/encryption.go
+++ b/crypto/rfc3962/encryption.go
@@ -29,7 +29,7 @@ func EncryptMessage(key, message []byte, usage uint32, e etype.EType) ([]byte, [
 	if len(key) != e.GetKeyByteSize() {
 		return []byte{}, []byte{}, fmt.Errorf("incorrect keysize: expected: %v actual: %v", e.GetKeyByteSize(), len(key))
 	}
-	// confounder.
+
 	c := make([]byte, e.GetConfounderByteSize())
 
 	_, err := rand.Read(c)
@@ -39,13 +39,15 @@ func EncryptMessage(key, message []byte, usage uint32, e etype.EType) ([]byte, [
 
 	plainBytes := append(c, message...)
 
-	// Derive key for encryption from usage.
-	var k []byte
-	if usage != 0 {
-		k, err = e.DeriveKey(key, common.GetUsageKe(usage))
-		if err != nil {
-			return []byte{}, []byte{}, fmt.Errorf("error deriving key for encryption: %w", err)
-		}
+	// RFC 4120 Section 7.5.1 assigns no key usage number zero, and decryption derives unconditionally, so a
+	// message encrypted without deriving could never be decrypted by this library.
+	if usage == 0 {
+		return []byte{}, []byte{}, errors.New("key usage 0 is not assigned by RFC 4120 section 7.5.1")
+	}
+
+	k, err := e.DeriveKey(key, common.GetUsageKe(usage))
+	if err != nil {
+		return []byte{}, []byte{}, fmt.Errorf("error deriving key for encryption: %w", err)
 	}
 
 	// Encrypt the data.

--- a/crypto/rfc8009/encryption.go
+++ b/crypto/rfc8009/encryption.go
@@ -32,7 +32,6 @@ func EncryptMessage(key, message []byte, usage uint32, e etype.EType) ([]byte, [
 		return []byte{}, []byte{}, fmt.Errorf("incorrect keysize: expected: %v actual: %v", e.GetKeyByteSize(), len(key))
 	}
 
-	// confounder.
 	c := make([]byte, e.GetConfounderByteSize())
 
 	_, err := rand.Read(c)
@@ -42,13 +41,15 @@ func EncryptMessage(key, message []byte, usage uint32, e etype.EType) ([]byte, [
 
 	plainBytes := append(c, message...)
 
-	// Derive key for encryption from usage.
-	var k []byte
-	if usage != 0 {
-		k, err = e.DeriveKey(key, common.GetUsageKe(usage))
-		if err != nil {
-			return []byte{}, []byte{}, fmt.Errorf("error deriving key for encryption: %w", err)
-		}
+	// RFC 4120 Section 7.5.1 assigns no key usage number zero, and decryption derives unconditionally, so a
+	// message encrypted without deriving could never be decrypted by this library.
+	if usage == 0 {
+		return []byte{}, []byte{}, errors.New("key usage 0 is not assigned by RFC 4120 section 7.5.1")
+	}
+
+	k, err := e.DeriveKey(key, common.GetUsageKe(usage))
+	if err != nil {
+		return []byte{}, []byte{}, fmt.Errorf("error deriving key for encryption: %w", err)
 	}
 
 	// Encrypt the data.

--- a/crypto/rfc8009/encryption_test.go
+++ b/crypto/rfc8009/encryption_test.go
@@ -538,9 +538,10 @@ func TestEncryptMessage_ZeroUsage(t *testing.T) {
 
 	_, _, err := e.EncryptMessage(key, message, zeroUsage)
 
+	// RFC 4120 Section 7.5.1 assigns no key usage number zero. It previously reported a key size problem,
+	// which was the symptom of skipping derivation rather than the reason for the refusal.
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "incorrect keysize",
-		"Should fail with keysize error because derived key is empty")
+	assert.Contains(t, err.Error(), "key usage 0 is not assigned")
 }
 
 func TestDecryptData_InvalidKeySize_AES128(t *testing.T) {

--- a/messages/kdc_rep.go
+++ b/messages/kdc_rep.go
@@ -248,7 +248,7 @@ func (k *ASRep) DecryptEncPart(c *credentials.Credentials) (types.EncryptionKey,
 		}
 	}
 
-	if c.HasPassword() {
+	if !c.HasKeytab() && c.HasPassword() {
 		key, _, err = crypto.GetKeyFromPassword(c.Password(), k.CName, k.CRealm, k.EncPart.EType, k.PAData)
 		if err != nil {
 			return key, krberror.Errorf(err, krberror.DecryptingError, "error decrypting AS_REP encrypted part")


### PR DESCRIPTION
VerifyChecksum treated an empty checksum as valid when the expected one could not be computed. DeriveRandom spun forever when EncryptData failed part way through. setPAData appended to the request instead of rebuilding it, and could index past the end while pruning. AS_REP decryption let a password override a keytab. TGSREQGenerateAndExchange passed a zero value ticket. Key usage 0 now says why it is refused instead of reporting a key size.