### PR TITLE
fix(pac): length for the camellia CMAC signatures

### DIFF
--- a/pac/signature_data.go
+++ b/pac/signature_data.go
@@ -49,6 +49,32 @@ func (k *SignatureData) Unmarshal(b []byte) (rb []byte, err error) {
 		c = 16
 	case uint32(chksumtype.HMAC_SHA384_192_AES256):
 		c = 24
+		// The Camellia CMACs (RFC 6803), 16 octets each. A KDC signs the PAC with the strongest key the
+		// krbtgt principal holds, and on a FreeIPA 4.13 realm that key set includes camellia256-cts-cmac
+		// so its KDC Signature buffer declares CMAC_CAMELLIA256 and carries 16 bytes. Both constants
+		// were already in iana/chksumtype; only their lengths were missing here, and a missing length is
+		// not inert (see below).
+	case uint32(chksumtype.CMAC_CAMELLIA128):
+		c = 16
+	case uint32(chksumtype.CMAC_CAMELLIA256):
+		c = 16
+	default:
+		// Defence for the next type that is missing rather than for any type known today.
+		//
+		// A length left at zero here is not merely "the signature could not be read": c also drives
+		// the zeroing at the end of this function, so an unlisted type would put the buffer into the
+		// caller's verification digest verbatim while the KDC had hashed it as zeros. Every checksum
+		// then fails, and it is reported as a bad signature rather than as a missing length — which
+		// sends the reader after keys, enctypes and clock skew. That is what the Camellia case above
+		// cost to find.
+		//
+		// A signature buffer is `type (4) + signature (rest)`, so the remainder is the reading to
+		// fall back on. No RODCIdentifier is read for such a type: with no known length there is
+		// nothing to tell a trailing identifier from signature bytes. Every listed type keeps its
+		// exact length and its RODC handling, so nothing that works today changes.
+		if len(b) > 4 {
+			c = len(b) - 4
+		}
 	}
 
 	k.Signature, err = r.ReadBytes(c)

--- a/pac/signature_data.go
+++ b/pac/signature_data.go
@@ -49,29 +49,17 @@ func (k *SignatureData) Unmarshal(b []byte) (rb []byte, err error) {
 		c = 16
 	case uint32(chksumtype.HMAC_SHA384_192_AES256):
 		c = 24
-		// The Camellia CMACs (RFC 6803), 16 octets each. A KDC signs the PAC with the strongest key the
-		// krbtgt principal holds, and on a FreeIPA 4.13 realm that key set includes camellia256-cts-cmac
-		// so its KDC Signature buffer declares CMAC_CAMELLIA256 and carries 16 bytes. Both constants
-		// were already in iana/chksumtype; only their lengths were missing here, and a missing length is
-		// not inert (see below).
-	case uint32(chksumtype.CMAC_CAMELLIA128):
-		c = 16
-	case uint32(chksumtype.CMAC_CAMELLIA256):
+	case uint32(chksumtype.CMAC_CAMELLIA128), uint32(chksumtype.CMAC_CAMELLIA256):
 		c = 16
 	default:
-		// Defence for the next type that is missing rather than for any type known today.
+		// Fall back for a checksum type not listed above. c is not just the read length: it also sets
+		// how many bytes are zeroed below for checksum verification. Leaving it at 0 leaves the
+		// signature in the buffer the caller hashes, where the KDC hashed zeros, so the failure
+		// surfaces as a bad signature rather than as an unhandled checksum type.
 		//
-		// A length left at zero here is not merely "the signature could not be read": c also drives
-		// the zeroing at the end of this function, so an unlisted type would put the buffer into the
-		// caller's verification digest verbatim while the KDC had hashed it as zeros. Every checksum
-		// then fails, and it is reported as a bad signature rather than as a missing length — which
-		// sends the reader after keys, enctypes and clock skew. That is what the Camellia case above
-		// cost to find.
-		//
-		// A signature buffer is `type (4) + signature (rest)`, so the remainder is the reading to
-		// fall back on. No RODCIdentifier is read for such a type: with no known length there is
-		// nothing to tell a trailing identifier from signature bytes. Every listed type keeps its
-		// exact length and its RODC handling, so nothing that works today changes.
+		// The buffer is type (4) + signature (rest), so take the rest. RODCIdentifier is left unread:
+		// without a known signature length, a trailing identifier cannot be told apart from signature
+		// bytes. Types listed above keep their exact length and RODC handling.
 		if len(b) > 4 {
 			c = len(b) - 4
 		}

--- a/pac/signature_data_test.go
+++ b/pac/signature_data_test.go
@@ -50,3 +50,63 @@ func TestPAC_SignatureData_Unmarshal_KDC_Signature(t *testing.T) {
 	assert.Equal(t, uint16(0), k.RODCIdentifier)
 	assert.Equal(t, zeroed, bz)
 }
+
+func TestPAC_SignatureData_Unmarshal_CMAC_Camellia256_Signature(t *testing.T) {
+	t.Parallel()
+
+	b, err := hex.DecodeString("12000000b1cc961bcb5585abd8d5ae4a2f3f7fea")
+	require.NoError(t, err)
+
+	var k SignatureData
+
+	bz, err := k.Unmarshal(b)
+	require.NoError(t, err)
+
+	sig, _ := hex.DecodeString("b1cc961bcb5585abd8d5ae4a2f3f7fea")
+	zeroed, _ := hex.DecodeString("1200000000000000000000000000000000000000")
+
+	assert.Equal(t, uint32(chksumtype.CMAC_CAMELLIA256), k.SignatureType)
+	assert.Equal(t, sig, k.Signature)
+	assert.Equal(t, uint16(0), k.RODCIdentifier)
+	assert.Equal(t, zeroed, bz)
+}
+
+func TestPAC_SignatureData_Unmarshal_Unknown_Signature_Type(t *testing.T) {
+	t.Parallel()
+
+	// 0x7fffffff is not a checksum type in iana/chksumtype, and is in the range the IANA registry
+	// leaves unassigned.
+	b, err := hex.DecodeString("ffffff7f0011223344556677")
+	require.NoError(t, err)
+
+	var k SignatureData
+
+	bz, err := k.Unmarshal(b)
+	require.NoError(t, err)
+
+	sig, _ := hex.DecodeString("0011223344556677")
+	zeroed, _ := hex.DecodeString("ffffff7f0000000000000000")
+
+	assert.Equal(t, uint32(0x7fffffff), k.SignatureType)
+	assert.Equal(t, sig, k.Signature)
+	// No RODC identifier: with no known length there is nothing to tell a trailing identifier from
+	// signature bytes, so the whole remainder is taken as the signature.
+	assert.Equal(t, uint16(0), k.RODCIdentifier)
+	assert.Equal(t, zeroed, bz)
+}
+
+func TestPAC_SignatureData_Unmarshal_Unknown_Type_Only(t *testing.T) {
+	t.Parallel()
+
+	b, err := hex.DecodeString("ffffff7f")
+	require.NoError(t, err)
+
+	var k SignatureData
+
+	bz, err := k.Unmarshal(b)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint32(0x7fffffff), k.SignatureType)
+	assert.Empty(t, k.Signature)
+	assert.Equal(t, b, bz)
+}


### PR DESCRIPTION
SignatureData.Unmarshal takes the length of the Signature field from a switch over checksum types. CMAC_CAMELLIA128 and CMAC_CAMELLIA256 are in iana/chksumtype but are not in that switch, so their length stays at zero — and zero is not inert. The same c drives the zeroing at the end of the function, so the buffer enters the caller's verification digest verbatim while the KDC that produced the PAC hashed it as zeros. Every checksum then fails, reported as "PAC service checksum verification failed", which sends the reader after keys, enctypes and clock skew rather than after a length. 
A KDC signs the PAC with the strongest key its krbtgt principal holds. On a FreeIPA 4.13 realm that key set includes camellia256-cts-cmac:

```shell
# kadmin.local -q "getprinc krbtgt/EXAMPLE.TEST"
Key: vno 1, camellia256-cts-cmac
Key: vno 1, camellia128-cts-cmac
Key: vno 1, aes256-cts-hmac-sha384-192
...
```

so its KDC Signature buffer declares CMAC_CAMELLIA256 and carries the 16 octets RFC 6803 specifies, while the Server Signature made with the service key declares HMAC_SHA1_96_AES256 and is handled correctly today. The consequence is that SPNEGOService cannot accept a single ticket from such a realm, on any configuration, unless PAC decoding is switched off entirely. Confirmed against a live FreeIPA 4.13: with these two lengths added and nothing else changed, the ticket that failed is accepted and its PAC group SIDs read.

The default clause is defence for the next missing type rather than for any type known today: a signature buffer is `type (4) + signature (rest)`, so the remainder is the reading to fall back on. No RODCIdentifier is read for such a type with no known length there is nothing to tell a trailing identifier from signature bytes and every listed type keeps its exact length and its existing RODC handling, so nothing that works today changes. A maintainer who would rather keep the switch exhaustive can delete that clause; the Camellia lengths are the fix.

Three tests are added: a real FreeIPA KDC Signature buffer, which fails without the Camellia lengths; an unassigned type, which fails without the default; and an unassigned type with no signature bytes, where the remainder is empty.