### PR TITLE
fix(gssapi): honour the rotate count and refuse sealed wrap tokens

### DIFF
--- a/gssapi/security_layer.go
+++ b/gssapi/security_layer.go
@@ -431,6 +431,25 @@ func (s *SecurityLayerSession) keyUsage(sending bool) uint32 {
 	return keyusage.GSSAPI_ACCEPTOR_SEAL
 }
 
+// rotate performs the right rotation the RRC field of a Wrap token records, as described in RFC 4121
+// Section 4.2.5. A sender may choose any count, including one longer than the data itself.
+func rotate(data []byte, rrc uint16) []byte {
+	if len(data) == 0 {
+		return data
+	}
+
+	n := int(rrc) % len(data)
+	if n == 0 {
+		return data
+	}
+
+	rotated := make([]byte, len(data))
+	copy(rotated[n:], data[:len(data)-n])
+	copy(rotated[:n], data[len(data)-n:])
+
+	return rotated
+}
+
 // unrotate reverses the right rotation the RRC field of a Wrap token records, as described in RFC 4121
 // section 4.2.5. A receiver has to cope with any rotation count, including one longer than the data itself.
 func unrotate(data []byte, rrc uint16) []byte {

--- a/gssapi/wrap_token.go
+++ b/gssapi/wrap_token.go
@@ -86,6 +86,10 @@ func (wt *WrapToken) Marshal() ([]byte, error) {
 	copy(bytes[pldOffset:], wt.Payload)
 	copy(bytes[chkSOffset:], wt.CheckSum)
 
+	// RFC 4121 Section 4.2.5 rotates everything after the header right by RRC octets. Recording the count in the
+	// header without performing the rotation would describe a token this did not produce.
+	copy(bytes[HdrLen:], rotate(bytes[HdrLen:], wt.RRC))
+
 	return bytes, nil
 }
 
@@ -192,23 +196,35 @@ func (wt *WrapToken) Unmarshal(b []byte, expectFromAcceptor bool) error {
 	if !isFromAcceptor && expectFromAcceptor {
 		return errors.New("expected acceptor flag is not set: expecting a token from the acceptor, not the initiator")
 	}
+
+	if flags&FlagSealed != 0 {
+		return errors.New("wrap token is confidentiality protected: its payload is encrypted and this type cannot decrypt it, use SecurityLayerSession")
+	}
+
 	// Check the filler byte.
 	if b[3] != FillerByte {
 		return fmt.Errorf("unexpected filler byte: expecting 0xFF, was %s ", hex.EncodeToString(b[3:4]))
 	}
 
 	checksumL := binary.BigEndian.Uint16(b[4:6])
+	rrc := binary.BigEndian.Uint16(b[6:8])
+
+	// RFC 4121 Section 4.2.5 rotates everything after the header right by RRC octets, and requires that a
+	// receiver "be able to interpret all possible rotation count values, including rotation counts greater than
+	// the length of the token".
+	data := unrotate(b[HdrLen:], rrc)
+
 	// Sanity check on the checksum length.
-	if int(checksumL) > len(b)-HdrLen {
+	if int(checksumL) > len(data) {
 		return fmt.Errorf("inconsistent checksum length: %d bytes to parse, checksum length is %d", len(b), checksumL)
 	}
 
 	wt.Flags = flags
 	wt.EC = checksumL
-	wt.RRC = binary.BigEndian.Uint16(b[6:8])
+	wt.RRC = rrc
 	wt.SndSeqNum = binary.BigEndian.Uint64(b[8:16])
-	wt.Payload = b[16 : len(b)-int(checksumL)]
-	wt.CheckSum = b[len(b)-int(checksumL):]
+	wt.Payload = data[:len(data)-int(checksumL)]
+	wt.CheckSum = data[len(data)-int(checksumL):]
 
 	return nil
 }

--- a/gssapi/wrap_token_sealed_test.go
+++ b/gssapi/wrap_token_sealed_test.go
@@ -1,0 +1,135 @@
+package gssapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/krb5/iana/etypeID"
+	"github.com/go-krb5/krb5/iana/keyusage"
+	"github.com/go-krb5/krb5/types"
+)
+
+func TestSecurityLayerSessionSealedRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	key := sealedTestKey(t)
+
+	initiator, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, true, 0)
+	require.NoError(t, err)
+
+	acceptor, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, false, 0)
+	require.NoError(t, err)
+
+	for _, message := range [][]byte{
+		[]byte("the quick brown fox"),
+		{},
+		make([]byte, 4096),
+	} {
+		token, err := initiator.Wrap(message)
+		require.NoError(t, err)
+
+		if len(message) > 0 {
+			assert.NotContains(t, string(token), string(message))
+		}
+
+		assert.NotZero(t, token[2]&FlagSealed, "the sealed flag should be set")
+
+		out, err := acceptor.Unwrap(token)
+		require.NoError(t, err)
+		assert.Equal(t, message, out)
+	}
+}
+
+func TestWrapTokenRefusesASealedToken(t *testing.T) {
+	t.Parallel()
+
+	key := sealedTestKey(t)
+
+	s, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, true, 0)
+	require.NoError(t, err)
+
+	token, err := s.Wrap([]byte("the quick brown fox"))
+	require.NoError(t, err)
+
+	var wt WrapToken
+
+	assert.Error(t, wt.Unmarshal(token, false), "a sealed token must not be parsed as an integrity protected one")
+}
+
+func TestWrapTokenUnrotatesTheRotateCount(t *testing.T) {
+	t.Parallel()
+
+	key := sealedTestKey(t)
+
+	s, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	token, err := s.Wrap([]byte("the quick brown fox"))
+	require.NoError(t, err)
+
+	body := token[HdrLen:]
+
+	for _, rrc := range []uint16{0, 1, 5, uint16(len(body)), uint16(len(body)) + 3, 60000} {
+		rotated := append([]byte(nil), token[:HdrLen]...)
+		rotated = append(rotated, rotateRight(body, rrc)...)
+		rotated[6] = byte(rrc >> 8)
+		rotated[7] = byte(rrc)
+
+		var wt WrapToken
+
+		require.NoError(t, wt.Unmarshal(rotated, false), "rrc=%d", rrc)
+
+		ok, err := wt.Verify(key, keyusage.GSSAPI_INITIATOR_SEAL)
+		require.NoError(t, err, "rrc=%d", rrc)
+		assert.True(t, ok, "rrc=%d", rrc)
+		assert.Equal(t, "the quick brown fox", string(wt.Payload), "rrc=%d", rrc)
+	}
+}
+
+func TestWrapTokenRoundTripsARotatedToken(t *testing.T) {
+	t.Parallel()
+
+	key := sealedTestKey(t)
+
+	s, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	token, err := s.Wrap([]byte("the quick brown fox"))
+	require.NoError(t, err)
+
+	body := token[HdrLen:]
+
+	rotated := append([]byte(nil), token[:HdrLen]...)
+	rotated = append(rotated, rotateRight(body, 5)...)
+	rotated[6], rotated[7] = 0, 5
+
+	var wt WrapToken
+
+	require.NoError(t, wt.Unmarshal(rotated, false))
+	assert.Equal(t, uint16(5), wt.RRC)
+
+	out, err := wt.Marshal()
+	require.NoError(t, err)
+	assert.Equal(t, rotated, out)
+}
+
+func sealedTestKey(t *testing.T) types.EncryptionKey {
+	t.Helper()
+
+	return types.EncryptionKey{KeyType: etypeID.AES256_CTS_HMAC_SHA1_96, KeyValue: make([]byte, 32)}
+}
+
+func rotateRight(b []byte, rrc uint16) []byte {
+	if len(b) == 0 {
+		return b
+	}
+
+	n := int(rrc) % len(b)
+	out := make([]byte, len(b))
+	copy(out[n:], b[:len(b)-n])
+	copy(out[:n], b[len(b)-n:])
+
+	return out
+}


### PR DESCRIPTION
WrapToken ignored RRC, which RFC 4121 section 4.2.5 requires a receiver to interpret for all values, and parsed a sealed token as an integrity protected one although its EC is a filler length and everything after the header is ciphertext. Unmarshal is given no key so it cannot decrypt one; SecurityLayerSession handles that form and already did. Marshal now performs the rotation its header records.