### PR TITLE
fix(spnego): accept a continuation without supportedMech

### DIFF
--- a/gssapi/security_layer.go
+++ b/gssapi/security_layer.go
@@ -431,6 +431,25 @@ func (s *SecurityLayerSession) keyUsage(sending bool) uint32 {
 	return keyusage.GSSAPI_ACCEPTOR_SEAL
 }
 
+// rotate performs the right rotation the RRC field of a Wrap token records, as described in RFC 4121
+// Section 4.2.5. A sender may choose any count, including one longer than the data itself.
+func rotate(data []byte, rrc uint16) []byte {
+	if len(data) == 0 {
+		return data
+	}
+
+	n := int(rrc) % len(data)
+	if n == 0 {
+		return data
+	}
+
+	rotated := make([]byte, len(data))
+	copy(rotated[n:], data[:len(data)-n])
+	copy(rotated[:n], data[len(data)-n:])
+
+	return rotated
+}
+
 // unrotate reverses the right rotation the RRC field of a Wrap token records, as described in RFC 4121
 // section 4.2.5. A receiver has to cope with any rotation count, including one longer than the data itself.
 func unrotate(data []byte, rrc uint16) []byte {

--- a/gssapi/wrap_token.go
+++ b/gssapi/wrap_token.go
@@ -86,6 +86,10 @@ func (wt *WrapToken) Marshal() ([]byte, error) {
 	copy(bytes[pldOffset:], wt.Payload)
 	copy(bytes[chkSOffset:], wt.CheckSum)
 
+	// RFC 4121 Section 4.2.5 rotates everything after the header right by RRC octets. Recording the count in the
+	// header without performing the rotation would describe a token this did not produce.
+	copy(bytes[HdrLen:], rotate(bytes[HdrLen:], wt.RRC))
+
 	return bytes, nil
 }
 
@@ -192,23 +196,35 @@ func (wt *WrapToken) Unmarshal(b []byte, expectFromAcceptor bool) error {
 	if !isFromAcceptor && expectFromAcceptor {
 		return errors.New("expected acceptor flag is not set: expecting a token from the acceptor, not the initiator")
 	}
+
+	if flags&FlagSealed != 0 {
+		return errors.New("wrap token is confidentiality protected: its payload is encrypted and this type cannot decrypt it, use SecurityLayerSession")
+	}
+
 	// Check the filler byte.
 	if b[3] != FillerByte {
 		return fmt.Errorf("unexpected filler byte: expecting 0xFF, was %s ", hex.EncodeToString(b[3:4]))
 	}
 
 	checksumL := binary.BigEndian.Uint16(b[4:6])
+	rrc := binary.BigEndian.Uint16(b[6:8])
+
+	// RFC 4121 Section 4.2.5 rotates everything after the header right by RRC octets, and requires that a
+	// receiver "be able to interpret all possible rotation count values, including rotation counts greater than
+	// the length of the token".
+	data := unrotate(b[HdrLen:], rrc)
+
 	// Sanity check on the checksum length.
-	if int(checksumL) > len(b)-HdrLen {
+	if int(checksumL) > len(data) {
 		return fmt.Errorf("inconsistent checksum length: %d bytes to parse, checksum length is %d", len(b), checksumL)
 	}
 
 	wt.Flags = flags
 	wt.EC = checksumL
-	wt.RRC = binary.BigEndian.Uint16(b[6:8])
+	wt.RRC = rrc
 	wt.SndSeqNum = binary.BigEndian.Uint64(b[8:16])
-	wt.Payload = b[16 : len(b)-int(checksumL)]
-	wt.CheckSum = b[len(b)-int(checksumL):]
+	wt.Payload = data[:len(data)-int(checksumL)]
+	wt.CheckSum = data[len(data)-int(checksumL):]
 
 	return nil
 }

--- a/gssapi/wrap_token_sealed_test.go
+++ b/gssapi/wrap_token_sealed_test.go
@@ -1,0 +1,135 @@
+package gssapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/krb5/iana/etypeID"
+	"github.com/go-krb5/krb5/iana/keyusage"
+	"github.com/go-krb5/krb5/types"
+)
+
+func TestSecurityLayerSessionSealedRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	key := sealedTestKey(t)
+
+	initiator, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, true, 0)
+	require.NoError(t, err)
+
+	acceptor, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, false, 0)
+	require.NoError(t, err)
+
+	for _, message := range [][]byte{
+		[]byte("the quick brown fox"),
+		{},
+		make([]byte, 4096),
+	} {
+		token, err := initiator.Wrap(message)
+		require.NoError(t, err)
+
+		if len(message) > 0 {
+			assert.NotContains(t, string(token), string(message))
+		}
+
+		assert.NotZero(t, token[2]&FlagSealed, "the sealed flag should be set")
+
+		out, err := acceptor.Unwrap(token)
+		require.NoError(t, err)
+		assert.Equal(t, message, out)
+	}
+}
+
+func TestWrapTokenRefusesASealedToken(t *testing.T) {
+	t.Parallel()
+
+	key := sealedTestKey(t)
+
+	s, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, true, 0)
+	require.NoError(t, err)
+
+	token, err := s.Wrap([]byte("the quick brown fox"))
+	require.NoError(t, err)
+
+	var wt WrapToken
+
+	assert.Error(t, wt.Unmarshal(token, false), "a sealed token must not be parsed as an integrity protected one")
+}
+
+func TestWrapTokenUnrotatesTheRotateCount(t *testing.T) {
+	t.Parallel()
+
+	key := sealedTestKey(t)
+
+	s, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	token, err := s.Wrap([]byte("the quick brown fox"))
+	require.NoError(t, err)
+
+	body := token[HdrLen:]
+
+	for _, rrc := range []uint16{0, 1, 5, uint16(len(body)), uint16(len(body)) + 3, 60000} {
+		rotated := append([]byte(nil), token[:HdrLen]...)
+		rotated = append(rotated, rotateRight(body, rrc)...)
+		rotated[6] = byte(rrc >> 8)
+		rotated[7] = byte(rrc)
+
+		var wt WrapToken
+
+		require.NoError(t, wt.Unmarshal(rotated, false), "rrc=%d", rrc)
+
+		ok, err := wt.Verify(key, keyusage.GSSAPI_INITIATOR_SEAL)
+		require.NoError(t, err, "rrc=%d", rrc)
+		assert.True(t, ok, "rrc=%d", rrc)
+		assert.Equal(t, "the quick brown fox", string(wt.Payload), "rrc=%d", rrc)
+	}
+}
+
+func TestWrapTokenRoundTripsARotatedToken(t *testing.T) {
+	t.Parallel()
+
+	key := sealedTestKey(t)
+
+	s, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	token, err := s.Wrap([]byte("the quick brown fox"))
+	require.NoError(t, err)
+
+	body := token[HdrLen:]
+
+	rotated := append([]byte(nil), token[:HdrLen]...)
+	rotated = append(rotated, rotateRight(body, 5)...)
+	rotated[6], rotated[7] = 0, 5
+
+	var wt WrapToken
+
+	require.NoError(t, wt.Unmarshal(rotated, false))
+	assert.Equal(t, uint16(5), wt.RRC)
+
+	out, err := wt.Marshal()
+	require.NoError(t, err)
+	assert.Equal(t, rotated, out)
+}
+
+func sealedTestKey(t *testing.T) types.EncryptionKey {
+	t.Helper()
+
+	return types.EncryptionKey{KeyType: etypeID.AES256_CTS_HMAC_SHA1_96, KeyValue: make([]byte, 32)}
+}
+
+func rotateRight(b []byte, rrc uint16) []byte {
+	if len(b) == 0 {
+		return b
+	}
+
+	n := int(rrc) % len(b)
+	out := make([]byte, len(b))
+	copy(out[n:], b[:len(b)-n])
+	copy(out[:n], b[len(b)-n:])
+
+	return out
+}

--- a/spnego/negotiation_continuation_test.go
+++ b/spnego/negotiation_continuation_test.go
@@ -1,0 +1,100 @@
+package spnego
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/x/encoding/asn1"
+
+	"github.com/go-krb5/krb5/gssapi"
+	"github.com/go-krb5/krb5/iana/etypeID"
+	"github.com/go-krb5/krb5/iana/nametype"
+	"github.com/go-krb5/krb5/keytab"
+	"github.com/go-krb5/krb5/messages"
+	"github.com/go-krb5/krb5/service"
+	"github.com/go-krb5/krb5/types"
+)
+
+func TestAcceptSecContextAcceptsAContinuationWithoutSupportedMech(t *testing.T) {
+	t.Parallel()
+
+	b, kt := continuationToken(t)
+
+	var st SPNEGOToken
+
+	require.NoError(t, st.Unmarshal(b))
+	require.True(t, st.Resp)
+	require.Empty(t, st.NegTokenResp.SupportedMech, "an initiator does not send supportedMech")
+
+	ok, _, status := SPNEGOService(kt).AcceptSecContext(&st)
+
+	assert.True(t, ok, "status was %d: %s", status.Code, status.Message)
+	assert.Equal(t, gssapi.StatusComplete, status.Code)
+}
+
+func TestNegTokenRespVerifyAcceptsAContinuationWithoutSupportedMech(t *testing.T) {
+	t.Parallel()
+
+	b, kt := continuationToken(t)
+
+	_, nt, err := UnmarshalNegToken(b)
+	require.NoError(t, err)
+
+	resp := nt.(NegTokenResp)
+	resp.settings = service.NewSettings(kt)
+
+	ok, status := resp.Verify()
+
+	assert.True(t, ok, "status was %d: %s", status.Code, status.Message)
+	assert.Equal(t, gssapi.StatusComplete, status.Code)
+}
+
+func TestNegTokenRespVerifyStillRejectsAnUnsupportedMechanism(t *testing.T) {
+	t.Parallel()
+
+	resp := NegTokenResp{SupportedMech: gssapi.OIDGSSIAKerb.OID(), ResponseToken: []byte{0x60, 0x01, 0x00}}
+
+	ok, status := resp.Verify()
+
+	assert.False(t, ok)
+	assert.Equal(t, gssapi.StatusBadMech, status.Code)
+}
+
+func continuationToken(t *testing.T) ([]byte, *keytab.Keytab) {
+	t.Helper()
+
+	kt := keytab.New()
+	sname := types.NewPrincipalName(nametype.KRB_NT_SRV_INST, "HTTP/host.test.gokrb5")
+
+	require.NoError(t, kt.AddEntry("HTTP/host.test.gokrb5", "TEST.GOKRB5", "servicepassword",
+		time.Now(), 1, etypeID.AES256_CTS_HMAC_SHA1_96))
+
+	cname := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, "testuser")
+	now := time.Now().UTC()
+
+	tkt, sessionKey, err := messages.NewTicket(cname, "TEST.GOKRB5", sname, "TEST.GOKRB5",
+		types.NewKrbFlags(), kt, etypeID.AES256_CTS_HMAC_SHA1_96, 1,
+		now, now, now.Add(time.Hour), now.Add(2*time.Hour))
+	require.NoError(t, err)
+
+	auth, err := types.NewAuthenticator("TEST.GOKRB5", cname)
+	require.NoError(t, err)
+
+	apreq, err := messages.NewAPReq(tkt, sessionKey, auth)
+	require.NoError(t, err)
+
+	mt := KRB5Token{OID: gssapi.OIDKRB5.OID(), tokID: []byte{0x01, 0x00}, APReq: apreq}
+
+	mb, err := mt.Marshal()
+	require.NoError(t, err)
+
+	resp := NegTokenResp{NegState: asn1.Enumerated(NegStateAcceptIncomplete), ResponseToken: mb}
+
+	b, err := resp.Marshal()
+	require.NoError(t, err)
+
+	return b, kt
+}

--- a/spnego/negotiation_token.go
+++ b/spnego/negotiation_token.go
@@ -228,39 +228,38 @@ func (n *NegTokenResp) Unmarshal(b []byte) error {
 }
 
 // Verify a Resp/Targ negotiation token.
+//
+// RFC 4178 Section 4.2.2 puts supportedMech "only in the first reply from the target", so a token continuing an
+// exchange carries none and the mechanism is the one already agreed. Its absence is therefore accepted; a
+// mechanism that is named and is not Kerberos is not.
 func (n *NegTokenResp) Verify() (bool, gssapi.Status) {
-	if isKerberosMech(n.SupportedMech) {
-		if n.mechToken == nil && n.ResponseToken == nil {
-			return false, gssapi.Status{Code: gssapi.StatusContinueNeeded}
-		}
-
-		mt := new(KRB5Token)
-
-		mt.settings = n.settings
-		if n.mechToken == nil {
-			err := mt.Unmarshal(n.ResponseToken)
-			if err != nil {
-				return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: err.Error()}
-			}
-
-			n.mechToken = mt
-		} else {
-			var ok bool
-
-			mt, ok = n.mechToken.(*KRB5Token)
-			if !ok {
-				return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: "MechToken is not a KRB5 token as expected"}
-			}
-		}
-
-		if mt == nil {
-			return false, gssapi.Status{Code: gssapi.StatusContinueNeeded}
-		}
-		// Verify the mechtoken.
-		return mt.Verify()
+	if len(n.SupportedMech) > 0 && !isKerberosMech(n.SupportedMech) {
+		return false, gssapi.Status{Code: gssapi.StatusBadMech, Message: "no supported mechanism specified in negotiation"}
 	}
 
-	return false, gssapi.Status{Code: gssapi.StatusBadMech, Message: "no supported mechanism specified in negotiation"}
+	if n.mechToken == nil && n.ResponseToken == nil {
+		return false, gssapi.Status{Code: gssapi.StatusContinueNeeded}
+	}
+
+	mt := new(KRB5Token)
+
+	mt.settings = n.settings
+	if n.mechToken == nil {
+		if err := mt.Unmarshal(n.ResponseToken); err != nil {
+			return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: err.Error()}
+		}
+
+		n.mechToken = mt
+	} else {
+		var ok bool
+
+		mt, ok = n.mechToken.(*KRB5Token)
+		if !ok {
+			return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: "MechToken is not a KRB5 token as expected"}
+		}
+	}
+
+	return mt.Verify()
 }
 
 // State returns the negotiation state of the negotiation response.

--- a/spnego/spnego.go
+++ b/spnego/spnego.go
@@ -101,7 +101,7 @@ func (s *SPNEGO) AcceptSecContext(ct gssapi.ContextToken) (bool, context.Context
 		oid = t.NegTokenResp.SupportedMech
 	}
 
-	if !isKerberosMech(oid) {
+	if len(oid) > 0 && !isKerberosMech(oid) {
 		return false, ctx, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: "SPNEGO OID of MechToken is not of type KRB5"}
 	}
 	// Flags in the NegInit must be used 	t.NegTokenInit.ReqFlags.


### PR DESCRIPTION
RFC 4178 section 4.2.2 puts supportedMech only in the first reply from the target, so an initiator continuing an exchange sends none. The acceptor required one and so rejected the second leg it had itself invited with accept-incomplete. The mech token still establishes the mechanism, and a supportedMech that is present and is not Kerberos is refused as before.