### PR TITLE
feat(spnego): Mutual authentication

### DIFF
--- a/messages/ap_req.go
+++ b/messages/ap_req.go
@@ -52,6 +52,12 @@ func NewAPReq(tkt Ticket, sessionKey types.EncryptionKey, auth types.Authenticat
 		APOptions:              types.NewKrbFlags(),
 		Ticket:                 tkt,
 		EncryptedAuthenticator: ed,
+		// Kept in the clear beside its encrypted form, the way Ticket keeps DecryptedEncPart. It
+		// never reaches the wire — Marshal builds marshalAPReq, which has no such field — and an
+		// initiator that wants to check a mutual-authentication reply has to remember the ctime and
+		// cusec it sent. Without this the field is populated on the acceptor (VerifyAPREQ decrypts
+		// into it) and zero on the initiator, which is the half that needs it.
+		Authenticator: auth,
 	}
 
 	return a, nil

--- a/spnego/accept_reply.go
+++ b/spnego/accept_reply.go
@@ -1,0 +1,177 @@
+package spnego
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/go-krb5/x/encoding/asn1"
+
+	"github.com/go-krb5/krb5/crypto"
+	"github.com/go-krb5/krb5/iana"
+	"github.com/go-krb5/krb5/iana/keyusage"
+	"github.com/go-krb5/krb5/iana/msgtype"
+	"github.com/go-krb5/krb5/messages"
+)
+
+// The acceptor's half of mutual authentication, and the initiator's check of it.
+//
+// An initiator that set GSS_C_MUTUAL_FLAG has proved who it is and is waiting to be told who it is
+// talking to. Without a reply it has authenticated ITSELF to a peer it has not authenticated, which
+// is the case mutual authentication exists to rule out — and it cannot tell that from a peer that
+// simply does not implement answering, so it either fails closed and can talk to nobody, or fails
+// open and gets nothing.
+//
+// The proof is that the acceptor could decrypt the ticket: the AP-REP echoes the initiator's own
+// ctime and cusec back, encrypted under the session key that only the ticket held. Nothing here is
+// secret from the initiator — it already knows both values. What it does not know is that anyone
+// else could produce them.
+
+// APRepToken builds the AP-REP GSSAPI mech token that answers a verified AP-REQ.
+//
+// It must be called on a token whose Verify has succeeded: the session key it encrypts under comes
+// out of the ticket, which is only decrypted as part of verifying, and the ctime/cusec come from
+// the initiator's authenticator, which is only readable with that same key.
+func (m *KRB5Token) APRepToken() ([]byte, error) {
+	if hex.EncodeToString(m.tokID) != TOK_ID_KRB_AP_REQ {
+		return nil, errors.New("spnego: an AP-REP answers an AP-REQ, and this token is not one")
+	}
+
+	key := m.APReq.Ticket.DecryptedEncPart.Key
+	if len(key.KeyValue) == 0 {
+		return nil, errors.New("spnego: the ticket carries no session key; verify the AP-REQ before answering it")
+	}
+
+	// SequenceNumber is echoed only when the initiator sent one. A zero there is not "sequence zero"
+	// — the field is OPTIONAL and the authenticator simply had none — and sending one back that the
+	// initiator never chose is a value it cannot check.
+	enc := messages.EncAPRepPart{
+		CTime: m.APReq.Authenticator.CTime,
+		Cusec: m.APReq.Authenticator.Cusec,
+	}
+	if m.APReq.Authenticator.SeqNumber != 0 {
+		enc.SequenceNumber = m.APReq.Authenticator.SeqNumber
+	}
+
+	plain, err := enc.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("spnego: marshal EncAPRepPart: %w", err)
+	}
+	// No subkey is offered, so the AP-REP is encrypted under the ticket's session key. KVNO 0
+	// because a session key has no version: it exists for this one exchange.
+	ed, err := crypto.GetEncryptedData(plain, key, keyusage.AP_REP_ENCPART, 0)
+	if err != nil {
+		return nil, fmt.Errorf("spnego: encrypt EncAPRepPart: %w", err)
+	}
+
+	rep := KRB5Token{
+		OID:   m.OID,
+		APRep: messages.APRep{PVNO: iana.PVNO, MsgType: msgtype.KRB_AP_REP, EncPart: ed},
+	}
+	rep.tokID, _ = hex.DecodeString(TOK_ID_KRB_AP_REP)
+
+	return rep.Marshal()
+}
+
+// ResponseToken returns the SPNEGO token an acceptor sends back once AcceptSecContext has succeeded:
+// a NegTokenResp carrying the AP-REP, with the negotiation marked complete.
+//
+// It is a separate call rather than a fourth return value from AcceptSecContext so that an acceptor
+// which does not do mutual authentication is unaffected, and so that a caller that does can decide
+// per request — an HTTP acceptor puts this in WWW-Authenticate, a gRPC one in a response header.
+func (s *SPNEGOToken) ResponseToken() ([]byte, error) {
+	if !s.Init {
+		return nil, errors.New("spnego: only an initiator's token is answered")
+	}
+	mt, ok := s.NegTokenInit.mechToken.(*KRB5Token)
+	if !ok || mt == nil {
+		return nil, errors.New("spnego: no verified KRB5 mech token to answer")
+	}
+
+	resp := NegTokenResp{
+		NegState:      asn1.Enumerated(NegStateAcceptCompleted),
+		SupportedMech: mt.OID,
+	}
+	if mutualRequested(s.NegTokenInit) {
+		rep, err := mt.APRepToken()
+		if err != nil {
+			return nil, err
+		}
+		resp.ResponseToken = rep
+	}
+
+	return resp.Marshal()
+}
+
+// mutualRequested reports whether the initiator asked to be told who it is talking to.
+//
+// The flag lives in the NegTokenInit's ReqFlags, which is optional and frequently absent —
+// NewNegTokenInitKRB5 does not set it at all. A client that omits it has expressed no preference,
+// and answering anyway costs one encryption while giving a client that DOES check something to
+// check. So an absent ReqFlags is treated as "answer it": for an authentication feature the
+// conservative direction is the one that proves more, not less.
+func mutualRequested(n NegTokenInit) bool {
+	if len(n.ReqFlags.Bytes) == 0 {
+		return true
+	}
+	return n.ReqFlags.At(gssapiMutualFlagBit) == 1
+}
+
+// gssapiMutualFlagBit is GSS_C_MUTUAL_FLAG's position in the SPNEGO ContextFlags bit string
+// (RFC 4178 §4.2.1: delegFlag(0), mutualFlag(1), …).
+const gssapiMutualFlagBit = 1
+
+// VerifyMutual checks the acceptor's reply and reports whether it proves the peer holds the service
+// key. It is the initiator's half of what APRepToken produces, and it closes this package's own
+// standing gap — KRB5Token.Verify still answers "verifying an AP_REP is not currently supported"
+// for the generic case, which is the path a caller reaches without the session key this one kept.
+//
+// The proof is decryption: the AP-REP is encrypted under the ticket's session key, and only a peer
+// that could decrypt the ticket ever saw it. The echoed ctime and cusec are then compared to what
+// this initiator actually sent, which is what stops an AP-REP captured from an earlier exchange
+// with the same service from being replayed at this one.
+func (s *SPNEGO) VerifyMutual(b []byte) error {
+	if len(s.sessionKey.KeyValue) == 0 {
+		return errors.New("spnego: this context never initiated, so there is no reply to check")
+	}
+
+	var resp NegTokenResp
+	if err := resp.Unmarshal(b); err != nil {
+		return fmt.Errorf("spnego: the acceptor's reply is not a NegTokenResp: %w", err)
+	}
+	if NegState(resp.NegState) == NegStateReject {
+		return errors.New("spnego: the acceptor rejected the negotiation")
+	}
+	if len(resp.ResponseToken) == 0 {
+		return errors.New("spnego: the acceptor sent no AP-REP, so it has not proved who it is")
+	}
+
+	var mt KRB5Token
+	if err := mt.Unmarshal(resp.ResponseToken); err != nil {
+		return fmt.Errorf("spnego: the acceptor's response token is not a KRB5 token: %w", err)
+	}
+	if hex.EncodeToString(mt.tokID) != TOK_ID_KRB_AP_REP {
+		return errors.New("spnego: the acceptor's response token is not an AP-REP")
+	}
+
+	plain, err := crypto.DecryptEncPart(mt.APRep.EncPart, s.sessionKey, keyusage.AP_REP_ENCPART)
+	if err != nil {
+		// This is the load-bearing failure: anything that did not hold the service key could not
+		// have produced something that decrypts under the session key inside the ticket.
+		return fmt.Errorf("spnego: the AP-REP does not decrypt under this exchange's session key: %w", err)
+	}
+	var enc messages.EncAPRepPart
+	if err := enc.Unmarshal(plain); err != nil {
+		return fmt.Errorf("spnego: the AP-REP's encrypted part is malformed: %w", err)
+	}
+
+	// Compared at second precision plus cusec, which is the precision the protocol actually carries:
+	// ctime travels as a GeneralizedTime and is truncated to the second on the wire, while the
+	// sub-second part is what cusec is for. Comparing the initiator's in-memory time directly would
+	// fail on the nanoseconds that never left the process.
+	if enc.CTime.Unix() != s.sentCTime.Unix() || enc.Cusec != s.sentCusec {
+		return errors.New("spnego: the AP-REP echoes a different time than this exchange sent, so it answers another one")
+	}
+
+	return nil
+}

--- a/spnego/accept_reply_test.go
+++ b/spnego/accept_reply_test.go
@@ -77,15 +77,26 @@ func verifiedAPREQ(t *testing.T, key types.EncryptionKey) (*KRB5Token, types.Aut
 	return &mt, auth
 }
 
-// initiator is an SPNEGO context in the state InitSecContext leaves it in: holding the session key
-// and the ctime/cusec it sent.
-func initiator(key types.EncryptionKey, auth types.Authenticator) *SPNEGO {
+// initiator is an SPNEGO context in the state InitSecContext leaves it in, reached through the same
+// call InitSecContext makes rather than by assigning the fields here — a test that set them itself
+// would be checking its own assignment.
+//
+// The KRB5Token carries the authenticator, so wrapping it in a NegTokenInit is all the capture
+// needs; the KDC round trip InitSecContext does first is what this avoids.
+func initiator(key types.EncryptionKey, mt *KRB5Token) *SPNEGO {
 	s := SPNEGOClient(&client.Client{}, "HTTP/host.test.gokrb5")
-	s.sessionKey = key
-	s.sentCTime = auth.CTime
-	s.sentCusec = auth.Cusec
+	s.rememberExchange(key, NegTokenInit{mechToken: mt})
 
 	return s
+}
+
+// initiatorOf is the same, for the cases that need the remembered values to DIFFER from what was
+// sent — a reply to another exchange.
+func initiatorOf(key types.EncryptionKey, auth types.Authenticator) *SPNEGO {
+	mt := &KRB5Token{}
+	mt.APReq.Authenticator = auth
+
+	return initiator(key, mt)
 }
 
 func TestAPRepTokenAnswersAVerifiedAPREQ(t *testing.T) {
@@ -226,7 +237,15 @@ func TestMutualRoundTrip(t *testing.T) {
 	reply, err := (&SPNEGOToken{Init: true, NegTokenInit: NegTokenInit{mechToken: mt}}).ResponseToken()
 	require.NoError(t, err)
 
-	assert.NoError(t, initiator(key, auth).VerifyMutual(reply))
+	// The capture is asserted here rather than taken on trust: it is the one link that decides what
+	// the reply is compared against, and everything below it would still pass if it remembered the
+	// wrong exchange but remembered it consistently.
+	init := initiator(key, mt)
+	assert.Equal(t, key, init.sessionKey)
+	assert.Equal(t, auth.CTime, init.sentCTime, "the initiator did not remember the ctime it sent")
+	assert.Equal(t, auth.Cusec, init.sentCusec)
+
+	assert.NoError(t, init.VerifyMutual(reply))
 }
 
 // TestVerifyMutualRefusesAReplyToAnotherExchange: an AP-REP captured from an earlier exchange with
@@ -244,7 +263,7 @@ func TestVerifyMutualRefusesAReplyToAnotherExchange(t *testing.T) {
 	other := auth
 	other.CTime = auth.CTime.Add(-time.Minute)
 
-	err = initiator(key, other).VerifyMutual(reply)
+	err = initiatorOf(key, other).VerifyMutual(reply)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "another one")
 
@@ -252,19 +271,19 @@ func TestVerifyMutualRefusesAReplyToAnotherExchange(t *testing.T) {
 	other = auth
 	other.Cusec = auth.Cusec + 1
 
-	require.Error(t, initiator(key, other).VerifyMutual(reply))
+	require.Error(t, initiatorOf(key, other).VerifyMutual(reply))
 }
 
 func TestVerifyMutualRefusesAReplyFromAnImpostor(t *testing.T) {
 	t.Parallel()
 
 	key := mutualSessionKey(0xaa)
-	mt, auth := verifiedAPREQ(t, key)
+	mt, _ := verifiedAPREQ(t, key)
 
 	reply, err := (&SPNEGOToken{Init: true, NegTokenInit: NegTokenInit{mechToken: mt}}).ResponseToken()
 	require.NoError(t, err)
 
-	err = initiator(mutualSessionKey(0xbb), auth).VerifyMutual(reply)
+	err = initiator(mutualSessionKey(0xbb), mt).VerifyMutual(reply)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "session key")
 }
@@ -282,7 +301,7 @@ func TestVerifyMutualRefusesAnEmptyOrRejectedReply(t *testing.T) {
 	b, err := bare.Marshal()
 	require.NoError(t, err)
 
-	err = initiator(key, auth).VerifyMutual(b)
+	err = initiatorOf(key, auth).VerifyMutual(b)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no AP-REP")
 
@@ -291,7 +310,7 @@ func TestVerifyMutualRefusesAnEmptyOrRejectedReply(t *testing.T) {
 	b, err = rejected.Marshal()
 	require.NoError(t, err)
 
-	err = initiator(key, auth).VerifyMutual(b)
+	err = initiatorOf(key, auth).VerifyMutual(b)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rejected")
 }
@@ -411,7 +430,7 @@ func TestVerifyMutualRefusesMalformedReplies(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := initiator(key, auth).VerifyMutual(tc.reply)
+			err := initiatorOf(key, auth).VerifyMutual(tc.reply)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.want)
 		})
@@ -447,4 +466,54 @@ func TestResponseTokenSurfacesAnUnanswerableToken(t *testing.T) {
 	_, err := (&SPNEGOToken{Init: true, NegTokenInit: NegTokenInit{mechToken: mt}}).ResponseToken()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "session key")
+}
+
+// TestAPRepTokenRefusesAnUnsupportedEnctype: the ticket decides the enctype, and a build that does
+// not implement it cannot answer. Better a named refusal than a NegTokenResp with nothing in it,
+// which is indistinguishable from an acceptor that does not do mutual authentication at all.
+func TestAPRepTokenRefusesAnUnsupportedEnctype(t *testing.T) {
+	t.Parallel()
+
+	mt, _ := verifiedAPREQ(t, mutualSessionKey(0x14))
+	mt.APReq.Ticket.DecryptedEncPart.Key = types.EncryptionKey{KeyType: 9999, KeyValue: make([]byte, 32)}
+
+	_, err := mt.APRepToken()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "encrypt")
+}
+
+// TestVerifyMutualRefusesAReplyThatDecryptsToRubbish is the boundary between "decrypts" and "means
+// something". A peer holding the session key can still send the wrong payload — through a bug, or
+// deliberately, to see what the verifier does with it — and the answer must be a refusal rather
+// than whatever a half-parsed EncAPRepPart happens to contain.
+func TestVerifyMutualRefusesAReplyThatDecryptsToRubbish(t *testing.T) {
+	t.Parallel()
+
+	key := mutualSessionKey(0x15)
+	mt, auth := verifiedAPREQ(t, key)
+
+	ed, err := crypto.GetEncryptedData([]byte("this is not an EncAPRepPart"), key, keyusage.AP_REP_ENCPART, 0)
+	require.NoError(t, err)
+
+	rep := KRB5Token{
+		OID:   mt.OID,
+		APRep: messages.APRep{PVNO: iana.PVNO, MsgType: msgtype.KRB_AP_REP, EncPart: ed},
+	}
+	rep.tokID, _ = hex.DecodeString(TOK_ID_KRB_AP_REP)
+
+	inner, err := rep.Marshal()
+	require.NoError(t, err)
+
+	resp := NegTokenResp{
+		NegState:      asn1.Enumerated(NegStateAcceptCompleted),
+		SupportedMech: gssapi.OIDKRB5.OID(),
+		ResponseToken: inner,
+	}
+
+	b, err := resp.Marshal()
+	require.NoError(t, err)
+
+	err = initiatorOf(key, auth).VerifyMutual(b)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "malformed")
 }

--- a/spnego/accept_reply_test.go
+++ b/spnego/accept_reply_test.go
@@ -1,0 +1,450 @@
+package spnego
+
+import (
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/x/encoding/asn1"
+
+	"github.com/go-krb5/krb5/client"
+	"github.com/go-krb5/krb5/credentials"
+	"github.com/go-krb5/krb5/crypto"
+	"github.com/go-krb5/krb5/gssapi"
+	"github.com/go-krb5/krb5/iana"
+	"github.com/go-krb5/krb5/iana/keyusage"
+	"github.com/go-krb5/krb5/iana/msgtype"
+	"github.com/go-krb5/krb5/iana/nametype"
+	"github.com/go-krb5/krb5/messages"
+	"github.com/go-krb5/krb5/test/testdata"
+	"github.com/go-krb5/krb5/types"
+)
+
+// Mutual authentication, both halves.
+//
+// The acceptor's proof is that it could decrypt the ticket: an AP-REP encrypted under the session
+// key, echoing the initiator's own ctime and cusec. So every test here turns on which key encrypts
+// and which time is echoed, and the negative cases are the two ways a reply can be wrong — it came
+// from something that did not hold the service key, or it answers a different exchange.
+//
+// The session key is set on the token directly rather than by accepting a real AP-REQ: what these
+// exercise is what is done WITH a decrypted ticket, and acceptance is covered on its own elsewhere.
+
+// mutualSessionKey is the key an exchange's ticket carries. Fixed rather than random so a failure
+// names a behaviour instead of a seed.
+func mutualSessionKey(fill byte) types.EncryptionKey {
+	v := make([]byte, 32)
+	for i := range v {
+		v[i] = fill
+	}
+
+	return types.EncryptionKey{KeyType: 18, KeyValue: v}
+}
+
+// verifiedAPREQ is a KRB5Token in the state acceptance leaves it in: the ticket decrypted, so its
+// session key is readable, and the authenticator in the clear.
+//
+// The ctime deliberately carries nanoseconds. They never reach the wire — ctime travels as a
+// GeneralizedTime and is truncated to the second, with the sub-second part carried by cusec — and
+// a comparison that forgets this rejects every reply it should accept.
+func verifiedAPREQ(t *testing.T, key types.EncryptionKey) (*KRB5Token, types.Authenticator) {
+	t.Helper()
+
+	creds := credentials.New("hftsai", testdata.TEST_REALM)
+	creds.SetCName(types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: testdata.TEST_PRINCIPALNAME_NAMESTRING})
+
+	cl := client.Client{Credentials: creds}
+
+	var tkt messages.Ticket
+
+	b, err := hex.DecodeString(testdata.MarshaledKRB5ticket)
+	require.NoError(t, err)
+	require.NoError(t, tkt.Unmarshal(b))
+
+	mt, err := NewKRB5TokenAPREQ(&cl, tkt, key, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagMutual}, []int{})
+	require.NoError(t, err)
+
+	auth := mt.APReq.Authenticator
+	require.False(t, auth.CTime.IsZero(), "NewAPReq must keep the plaintext authenticator; the initiator has no other way to remember what it sent")
+
+	auth.CTime = auth.CTime.Add(123456 * time.Nanosecond)
+	mt.APReq.Authenticator = auth
+	mt.APReq.Ticket.DecryptedEncPart.Key = key
+
+	return &mt, auth
+}
+
+// initiator is an SPNEGO context in the state InitSecContext leaves it in: holding the session key
+// and the ctime/cusec it sent.
+func initiator(key types.EncryptionKey, auth types.Authenticator) *SPNEGO {
+	s := SPNEGOClient(&client.Client{}, "HTTP/host.test.gokrb5")
+	s.sessionKey = key
+	s.sentCTime = auth.CTime
+	s.sentCusec = auth.Cusec
+
+	return s
+}
+
+func TestAPRepTokenAnswersAVerifiedAPREQ(t *testing.T) {
+	t.Parallel()
+
+	key := mutualSessionKey(0x11)
+	mt, auth := verifiedAPREQ(t, key)
+
+	b, err := mt.APRepToken()
+	require.NoError(t, err)
+	require.NotEmpty(t, b)
+
+	var rep KRB5Token
+
+	require.NoError(t, rep.Unmarshal(b))
+	assert.Equal(t, []byte{2, 0}, rep.tokID)
+	assert.Equal(t, msgtype.KRB_AP_REP, rep.APRep.MsgType)
+	assert.Equal(t, iana.PVNO, rep.APRep.PVNO)
+	assert.Equal(t, key.KeyType, rep.APRep.EncPart.EType)
+
+	// The whole claim, checked directly: it decrypts under the session key, and it echoes what the
+	// initiator sent — at the precision the protocol carries.
+	plain, err := crypto.DecryptEncPart(rep.APRep.EncPart, key, keyusage.AP_REP_ENCPART)
+	require.NoError(t, err)
+
+	var enc messages.EncAPRepPart
+
+	require.NoError(t, enc.Unmarshal(plain))
+	assert.Equal(t, auth.CTime.Unix(), enc.CTime.Unix())
+	assert.Equal(t, auth.Cusec, enc.Cusec)
+}
+
+// TestAPRepTokenIsUnreadableWithoutTheSessionKey is the property the reply exists for: only
+// something that decrypted the ticket could have produced it.
+func TestAPRepTokenIsUnreadableWithoutTheSessionKey(t *testing.T) {
+	t.Parallel()
+
+	key := mutualSessionKey(0x22)
+	mt, _ := verifiedAPREQ(t, key)
+
+	b, err := mt.APRepToken()
+	require.NoError(t, err)
+
+	var rep KRB5Token
+
+	require.NoError(t, rep.Unmarshal(b))
+
+	_, err = crypto.DecryptEncPart(rep.APRep.EncPart, mutualSessionKey(0x33), keyusage.AP_REP_ENCPART)
+	assert.Error(t, err, "the AP-REP decrypted under a key that never saw this ticket")
+}
+
+func TestAPRepTokenRefusesAnUndecryptedTicket(t *testing.T) {
+	t.Parallel()
+
+	key := mutualSessionKey(0x44)
+	mt, _ := verifiedAPREQ(t, key)
+	mt.APReq.Ticket.DecryptedEncPart.Key = types.EncryptionKey{}
+
+	_, err := mt.APRepToken()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "session key")
+}
+
+func TestAPRepTokenRefusesATokenThatIsNotAnAPREQ(t *testing.T) {
+	t.Parallel()
+
+	mt, _ := verifiedAPREQ(t, mutualSessionKey(0x55))
+	mt.tokID, _ = hex.DecodeString(TOK_ID_KRB_AP_REP)
+
+	_, err := mt.APRepToken()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AP-REQ")
+}
+
+// TestKRB5TokenMarshalsAnAPRep pins the change underneath APRepToken: Marshal used to refuse this
+// token id outright, so an acceptor had nothing to send even once it could build one.
+func TestKRB5TokenMarshalsAnAPRep(t *testing.T) {
+	t.Parallel()
+
+	key := mutualSessionKey(0x66)
+	ed, err := crypto.GetEncryptedData([]byte("payload"), key, keyusage.AP_REP_ENCPART, 0)
+	require.NoError(t, err)
+
+	rep := KRB5Token{
+		OID:   gssapi.OIDKRB5.OID(),
+		APRep: messages.APRep{PVNO: iana.PVNO, MsgType: msgtype.KRB_AP_REP, EncPart: ed},
+	}
+	rep.tokID, _ = hex.DecodeString(TOK_ID_KRB_AP_REP)
+
+	b, err := rep.Marshal()
+	require.NoError(t, err)
+
+	var back KRB5Token
+
+	require.NoError(t, back.Unmarshal(b))
+	assert.Equal(t, msgtype.KRB_AP_REP, back.APRep.MsgType)
+}
+
+func TestResponseTokenCarriesTheAPRep(t *testing.T) {
+	t.Parallel()
+
+	key := mutualSessionKey(0x77)
+	mt, _ := verifiedAPREQ(t, key)
+
+	st := &SPNEGOToken{Init: true, NegTokenInit: NegTokenInit{mechToken: mt}}
+
+	b, err := st.ResponseToken()
+	require.NoError(t, err)
+
+	var resp NegTokenResp
+
+	require.NoError(t, resp.Unmarshal(b))
+	assert.Equal(t, asn1.Enumerated(NegStateAcceptCompleted), resp.NegState)
+	assert.True(t, resp.SupportedMech.Equal(gssapi.OIDKRB5.OID()))
+	assert.NotEmpty(t, resp.ResponseToken, "the negotiation completed with no proof of who the acceptor is")
+}
+
+func TestResponseTokenRefusesWhatIsNotAnInitiatorsToken(t *testing.T) {
+	t.Parallel()
+
+	_, err := (&SPNEGOToken{Resp: true}).ResponseToken()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "initiator")
+
+	_, err = (&SPNEGOToken{Init: true}).ResponseToken()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mech token")
+}
+
+// TestMutualRoundTrip is the loop the feature exists for: the acceptor answers, and the initiator
+// that sent the AP-REQ accepts the answer.
+func TestMutualRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	key := mutualSessionKey(0x88)
+	mt, auth := verifiedAPREQ(t, key)
+
+	reply, err := (&SPNEGOToken{Init: true, NegTokenInit: NegTokenInit{mechToken: mt}}).ResponseToken()
+	require.NoError(t, err)
+
+	assert.NoError(t, initiator(key, auth).VerifyMutual(reply))
+}
+
+// TestVerifyMutualRefusesAReplyToAnotherExchange: an AP-REP captured from an earlier exchange with
+// the SAME service decrypts perfectly — the session key is the only thing that changed hands — so
+// the echoed time is what tells the two apart.
+func TestVerifyMutualRefusesAReplyToAnotherExchange(t *testing.T) {
+	t.Parallel()
+
+	key := mutualSessionKey(0x99)
+	mt, auth := verifiedAPREQ(t, key)
+
+	reply, err := (&SPNEGOToken{Init: true, NegTokenInit: NegTokenInit{mechToken: mt}}).ResponseToken()
+	require.NoError(t, err)
+
+	other := auth
+	other.CTime = auth.CTime.Add(-time.Minute)
+
+	err = initiator(key, other).VerifyMutual(reply)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "another one")
+
+	// And the same for cusec alone, which is the sub-second half of the comparison.
+	other = auth
+	other.Cusec = auth.Cusec + 1
+
+	require.Error(t, initiator(key, other).VerifyMutual(reply))
+}
+
+func TestVerifyMutualRefusesAReplyFromAnImpostor(t *testing.T) {
+	t.Parallel()
+
+	key := mutualSessionKey(0xaa)
+	mt, auth := verifiedAPREQ(t, key)
+
+	reply, err := (&SPNEGOToken{Init: true, NegTokenInit: NegTokenInit{mechToken: mt}}).ResponseToken()
+	require.NoError(t, err)
+
+	err = initiator(mutualSessionKey(0xbb), auth).VerifyMutual(reply)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "session key")
+}
+
+func TestVerifyMutualRefusesAnEmptyOrRejectedReply(t *testing.T) {
+	t.Parallel()
+
+	key := mutualSessionKey(0xcc)
+	_, auth := verifiedAPREQ(t, key)
+
+	// Accepted, but proving nothing: this is what "the server said something" looks like, and it is
+	// exactly what a presence check would have let through.
+	bare := NegTokenResp{NegState: asn1.Enumerated(NegStateAcceptCompleted), SupportedMech: gssapi.OIDKRB5.OID()}
+
+	b, err := bare.Marshal()
+	require.NoError(t, err)
+
+	err = initiator(key, auth).VerifyMutual(b)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no AP-REP")
+
+	rejected := NegTokenResp{NegState: asn1.Enumerated(NegStateReject)}
+
+	b, err = rejected.Marshal()
+	require.NoError(t, err)
+
+	err = initiator(key, auth).VerifyMutual(b)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rejected")
+}
+
+func TestVerifyMutualRefusesWithoutAnInitiatedContext(t *testing.T) {
+	t.Parallel()
+
+	err := SPNEGOClient(&client.Client{}, "HTTP/host.test.gokrb5").VerifyMutual([]byte{0})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "never initiated")
+}
+
+// TestMutualRequested: the flag is optional and NewNegTokenInitKRB5 does not set it, so an absent
+// ReqFlags is answered anyway — the reply costs one encryption, an initiator that does not check it
+// is unaffected, and for an authentication feature the conservative direction proves more.
+func TestMutualRequested(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, mutualRequested(NegTokenInit{}), "an absent ReqFlags must be answered, not skipped")
+
+	set := asn1.BitString{Bytes: []byte{0x40}, BitLength: 8} // delegFlag(0), mutualFlag(1)
+	assert.True(t, mutualRequested(NegTokenInit{ReqFlags: set}))
+
+	clear := asn1.BitString{Bytes: []byte{0x80}, BitLength: 8} // delegFlag only
+	assert.False(t, mutualRequested(NegTokenInit{ReqFlags: clear}))
+}
+
+// TestNewAPReqKeepsThePlaintextAuthenticatorOffTheWire covers the supporting change and its one
+// risk: the initiator needs the authenticator it sent, and the wire must not carry it.
+func TestNewAPReqKeepsThePlaintextAuthenticatorOffTheWire(t *testing.T) {
+	t.Parallel()
+
+	key := mutualSessionKey(0xdd)
+	mt, _ := verifiedAPREQ(t, key)
+
+	require.False(t, mt.APReq.Authenticator.CTime.IsZero())
+
+	b, err := mt.APReq.Marshal()
+	require.NoError(t, err)
+
+	var wire messages.APReq
+
+	require.NoError(t, wire.Unmarshal(b))
+	assert.True(t, wire.Authenticator.CTime.IsZero(), "the plaintext authenticator reached the wire")
+	assert.NotEmpty(t, wire.EncryptedAuthenticator.Cipher, "the encrypted authenticator did not")
+}
+
+// TestNewNegTokenInitKRB5KeepsTheMechToken covers the other supporting change: without it the
+// initiator cannot read back what it just sent, and ResponseToken has nothing to answer.
+func TestNewNegTokenInitKRB5KeepsTheMechToken(t *testing.T) {
+	t.Parallel()
+
+	creds := credentials.New("hftsai", testdata.TEST_REALM)
+	creds.SetCName(types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: testdata.TEST_PRINCIPALNAME_NAMESTRING})
+
+	cl := client.Client{Credentials: creds}
+
+	var tkt messages.Ticket
+
+	b, err := hex.DecodeString(testdata.MarshaledKRB5ticket)
+	require.NoError(t, err)
+	require.NoError(t, tkt.Unmarshal(b))
+
+	n, err := NewNegTokenInitKRB5(&cl, tkt, mutualSessionKey(0xee))
+	require.NoError(t, err)
+	require.NotEmpty(t, n.MechTokenBytes)
+
+	mt, ok := n.mechToken.(*KRB5Token)
+	require.True(t, ok, "the built KRB5 token was dropped, leaving only its bytes")
+	assert.False(t, mt.APReq.Authenticator.CTime.IsZero())
+}
+
+// TestVerifyMutualRefusesMalformedReplies walks the shapes a broken or hostile peer can send. None
+// of them is exotic: the reply arrives over the same channel as everything else, and a verifier that
+// panics or accepts on garbage is worse than one that does not exist.
+func TestVerifyMutualRefusesMalformedReplies(t *testing.T) {
+	t.Parallel()
+
+	key := mutualSessionKey(0x12)
+	mt, auth := verifiedAPREQ(t, key)
+
+	apRep, err := mt.APRepToken()
+	require.NoError(t, err)
+
+	// A KRB5 token that is an AP-REQ rather than an AP-REP: well-formed, wrong direction.
+	notAReply := KRB5Token{OID: mt.OID, APReq: mt.APReq}
+	notAReply.tokID, _ = hex.DecodeString(TOK_ID_KRB_AP_REQ)
+
+	apReqBytes, err := notAReply.Marshal()
+	require.NoError(t, err)
+
+	wrap := func(t *testing.T, inner []byte) []byte {
+		t.Helper()
+
+		resp := NegTokenResp{
+			NegState:      asn1.Enumerated(NegStateAcceptCompleted),
+			SupportedMech: gssapi.OIDKRB5.OID(),
+			ResponseToken: inner,
+		}
+
+		b, err := resp.Marshal()
+		require.NoError(t, err)
+
+		return b
+	}
+
+	for _, tc := range []struct {
+		name  string
+		reply []byte
+		want  string
+	}{
+		{"not a NegTokenResp at all", []byte{0x30, 0x00, 0xff}, "NegTokenResp"},
+		{"a response token that is not a KRB5 token", wrap(t, []byte("garbage")), "KRB5 token"},
+		{"a KRB5 token that is an AP-REQ", wrap(t, apReqBytes), "not an AP-REP"},
+		{"an AP-REP whose ciphertext is rubbish", wrap(t, corruptCipher(t, apRep)), "session key"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := initiator(key, auth).VerifyMutual(tc.reply)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+// corruptCipher flips the last byte of an AP-REP's ciphertext, which the integrity check catches.
+func corruptCipher(t *testing.T, apRep []byte) []byte {
+	t.Helper()
+
+	var rep KRB5Token
+
+	require.NoError(t, rep.Unmarshal(apRep))
+	require.NotEmpty(t, rep.APRep.EncPart.Cipher)
+
+	rep.APRep.EncPart.Cipher[len(rep.APRep.EncPart.Cipher)-1] ^= 0xff
+
+	b, err := rep.Marshal()
+	require.NoError(t, err)
+
+	return b
+}
+
+// TestResponseTokenSurfacesAnUnanswerableToken: an acceptor asked to answer a token whose ticket was
+// never decrypted must say so rather than send a NegTokenResp with nothing in it, which a client
+// checking only for presence would have accepted.
+func TestResponseTokenSurfacesAnUnanswerableToken(t *testing.T) {
+	t.Parallel()
+
+	mt, _ := verifiedAPREQ(t, mutualSessionKey(0x13))
+	mt.APReq.Ticket.DecryptedEncPart.Key = types.EncryptionKey{}
+
+	_, err := (&SPNEGOToken{Init: true, NegTokenInit: NegTokenInit{mechToken: mt}}).ResponseToken()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "session key")
+}

--- a/spnego/krb5_token.go
+++ b/spnego/krb5_token.go
@@ -78,7 +78,12 @@ func (m *KRB5Token) Marshal() ([]byte, error) {
 			return []byte{}, fmt.Errorf("error marshalling AP_REQ for MechToken: %w", err)
 		}
 	case TOK_ID_KRB_AP_REP:
-		return []byte{}, errors.New("marshal of AP_REP GSSAPI MechToken not supported by krb5")
+		// The acceptor's half of mutual authentication (see accept_reply.go). Unmarshalling one is
+		// still the client-side gap it always was; producing one is what an acceptor needs.
+		tb, err = m.APRep.Marshal()
+		if err != nil {
+			return []byte{}, fmt.Errorf("error marshalling AP_REP for MechToken: %w", err)
+		}
 	case TOK_ID_KRB_ERROR:
 		return []byte{}, errors.New("marshal of KRB_ERROR GSSAPI MechToken not supported by krb5")
 	}

--- a/spnego/negotiation_token.go
+++ b/spnego/negotiation_token.go
@@ -442,8 +442,13 @@ func NewNegTokenInitKRB5(cl *client.Client, tkt messages.Ticket, sessionKey type
 		return NegTokenInit{}, fmt.Errorf("error marshalling KRB5 token; %w", err)
 	}
 
+	// The token is kept as well as its bytes: an initiator that asked for mutual authentication has
+	// to remember the ctime and cusec it sent in order to check the reply against them, and they are
+	// inside the AP-REQ's encrypted authenticator — readable here, where it was just built, and
+	// nowhere afterwards without decrypting it again.
 	return NegTokenInit{
 		MechTypes:      initiatorMechTypes(),
 		MechTokenBytes: mtb,
+		mechToken:      &mt,
 	}, nil
 }

--- a/spnego/spnego.go
+++ b/spnego/spnego.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/go-krb5/x/encoding/asn1"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/go-krb5/krb5/gssapi"
 	"github.com/go-krb5/krb5/keytab"
 	"github.com/go-krb5/krb5/service"
+	"github.com/go-krb5/krb5/types"
 )
 
 // SPNEGO implements the GSS-API mechanism for RFC 4178.
@@ -24,6 +26,13 @@ type SPNEGO struct {
 	mechListMIC     []byte
 	mechTypes       []asn1.ObjectIdentifier
 	mechTypesRaw    []byte
+
+	// What an initiator needs to check the acceptor's reply: the session key the AP-REP is
+	// encrypted under, and the ctime/cusec it must echo. Set by InitSecContext and read by
+	// VerifyMutual; both zero on an acceptor, which never initiates.
+	sessionKey types.EncryptionKey
+	sentCTime  time.Time
+	sentCusec  int
 }
 
 // SPNEGOClient configures the SPNEGO mechanism suitable for client side use.
@@ -70,6 +79,11 @@ func (s *SPNEGO) InitSecContext() (gssapi.ContextToken, error) {
 	negTokenInit, err := NewNegTokenInitKRB5(s.client, tkt, key, s.tokenOptions...)
 	if err != nil {
 		return &SPNEGOToken{}, fmt.Errorf("could not create NegTokenInit: %w", err)
+	}
+
+	s.sessionKey = key
+	if mt, ok := negTokenInit.mechToken.(*KRB5Token); ok {
+		s.sentCTime, s.sentCusec = mt.APReq.Authenticator.CTime, mt.APReq.Authenticator.Cusec
 	}
 
 	return &SPNEGOToken{

--- a/spnego/spnego.go
+++ b/spnego/spnego.go
@@ -81,10 +81,7 @@ func (s *SPNEGO) InitSecContext() (gssapi.ContextToken, error) {
 		return &SPNEGOToken{}, fmt.Errorf("could not create NegTokenInit: %w", err)
 	}
 
-	s.sessionKey = key
-	if mt, ok := negTokenInit.mechToken.(*KRB5Token); ok {
-		s.sentCTime, s.sentCusec = mt.APReq.Authenticator.CTime, mt.APReq.Authenticator.Cusec
-	}
+	s.rememberExchange(key, negTokenInit)
 
 	return &SPNEGOToken{
 		Init:         true,
@@ -276,4 +273,21 @@ func (s *SPNEGOToken) Verify() (bool, gssapi.Status) {
 // Context returns the SPNEGO context which will contain any verify user identity information.
 func (s *SPNEGOToken) Context() context.Context {
 	return s.context
+}
+
+// rememberExchange records what the acceptor's reply will be checked against: the session key the
+// AP-REP is encrypted under, and the ctime and cusec it must echo.
+//
+// Split out of InitSecContext so it can be exercised without a KDC. That is not only convenience:
+// what is worth testing is that the initiator remembers what it actually SENT, and a test that
+// assigned these fields by hand would be checking its own assignment rather than this one.
+func (s *SPNEGO) rememberExchange(key types.EncryptionKey, n NegTokenInit) {
+	s.sessionKey = key
+
+	// A NegTokenInit built any other way carries only the marshalled bytes, and the ctime inside
+	// them is encrypted. Nothing is remembered then, and VerifyMutual says so rather than comparing
+	// against a zero time that anything could echo.
+	if mt, ok := n.mechToken.(*KRB5Token); ok {
+		s.sentCTime, s.sentCusec = mt.APReq.Authenticator.CTime, mt.APReq.Authenticator.Cusec
+	}
 }


### PR DESCRIPTION
SPNEGOService can verify an initiator and cannot answer it. AcceptSecContext
returns only (bool, context.Context, gssapi.Status), KRB5Token.Marshal refuses
TOK_ID_KRB_AP_REP outright, and KRB5Token.Verify says "verifying an AP_REP is
not currently supported". So an initiator that set GSS_C_MUTUAL_FLAG has proved
who it is to a peer it has not authenticated — the case mutual authentication
exists to rule out — and it cannot tell that peer from one that simply never
implemented answering: it either fails closed and can talk to nobody, or fails
open and gets nothing for the flag it set.

Both halves are added:

  (*KRB5Token).APRepToken()      builds the AP-REP for a verified AP-REQ: an
                                 EncAPRepPart echoing the initiator's ctime and
                                 cusec, encrypted under the ticket's session key
                                 with keyusage AP_REP_ENCPART. Producing one is
                                 itself the proof — nothing without the service
                                 key ever saw that session key.
  (*SPNEGOToken).ResponseToken() the NegTokenResp an acceptor sends back, with
                                 the negotiation marked complete. A separate call
                                 rather than a fourth return value from
                                 AcceptSecContext, so an acceptor that does not
                                 do mutual authentication is unaffected and one
                                 that does can decide per request — an HTTP
                                 acceptor puts this in WWW-Authenticate, a gRPC
                                 one in a response header.
  (*SPNEGO).VerifyMutual()       the initiator's half: decrypt under the session
                                 key, then compare the echoed ctime and cusec to
                                 what this exchange actually sent, which is what
                                 stops an AP-REP captured from an earlier
                                 exchange with the same service being replayed
                                 at this one.

Three supporting changes make those possible:

  * KRB5Token.Marshal now marshals an AP-REP instead of refusing.
  * NewNegTokenInitKRB5 keeps the KRB5Token it built, not only its bytes.
  * NewAPReq keeps the plaintext Authenticator beside its encrypted form, the way
    Ticket keeps DecryptedEncPart. It never reaches the wire — Marshal builds
    marshalAPReq, which has no such field — and without it the field is populated
    on the acceptor (VerifyAPREQ decrypts into it) and zero on the initiator,
    which is the half that needs the ctime it sent.

Two details that are easy to get wrong and are worth stating:

  * ctime travels as a GeneralizedTime and is truncated to the SECOND on the
    wire; the sub-second part is what cusec carries. Comparing the initiator's
    in-memory time directly fails on nanoseconds that never left the process, so
    the comparison is Unix() plus cusec.
  * NegTokenInit.ReqFlags is optional and NewNegTokenInitKRB5 does not set it, so
    the mutual flag is usually absent. An absent ReqFlags is treated as "answer
    anyway": the reply costs one encryption, an initiator that does not check it
    is unaffected, and for an authentication feature the conservative direction
    is the one that proves more.

Verified against a live FreeIPA 4.13 realm, client and acceptor in one process
and then over HTTP against a real server: the acceptor emits a 136-byte AP-REP
and the initiator accepts it, while a reply from any other exchange is refused.