### PR TITLE
fix(spnego): multi-leg negotiation and the mechListMIC

### DIFF
--- a/spnego/http.go
+++ b/spnego/http.go
@@ -39,6 +39,7 @@ type Client struct {
 	maxRedirects       int
 	tokenOptions       []KRB5TokenOption
 	autoChannelBinding bool
+	legs               int
 }
 
 type redirectErr struct {
@@ -175,24 +176,57 @@ func (c *Client) Do(req *http.Request) (resp *http.Response, err error) {
 		return resp, err
 	}
 
-	if respUnauthorizedNegotiate(resp) {
-		if err = SetSPNEGOHeader(c.krb5Client, req, c.spn, c.requestTokenOptions(resp)...); err != nil {
-			return resp, err
-		}
+	token, challenged, cerr := negotiateChallenge(resp)
+	if cerr != nil {
+		c.endNegotiation()
 
-		if req.Body != nil {
-			req.Body = io.NopCloser(&body)
-		}
-
-		_, _ = io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-
-		return c.Do(req)
+		return resp, cerr
 	}
 
-	c.reqs = c.reqs[:0]
+	if challenged {
+		send, nerr := c.nextNegotiationLeg(req, resp, token)
+		if nerr != nil {
+			c.endNegotiation()
+
+			return resp, nerr
+		}
+
+		if send {
+			if req.Body != nil {
+				// Refresh the body reader so the body can be sent again.
+				req.Body = io.NopCloser(&body)
+			}
+
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+
+			return c.Do(req)
+		}
+	}
+
+	c.endNegotiation()
 
 	return resp, err
+}
+
+// nextNegotiationLeg sets the Authorization header answering a challenge, reporting whether there is a leg to send.
+//
+// The legs already spent bound the exchange. Without a bound a target that answers every token with another
+// challenge, which the bare Negotiate of RFC 4559 Section 4 is, keeps this client answering it indefinitely.
+func (c *Client) nextNegotiationLeg(req *http.Request, resp *http.Response, token []byte) (bool, error) {
+	if c.legs >= MaxNegotiationLegs {
+		return false, fmt.Errorf("SPNEGO negotiation did not complete within %d legs", MaxNegotiationLegs)
+	}
+
+	c.legs++
+
+	return c.negotiate(req, resp, token)
+}
+
+// endNegotiation clears the state held for the exchange that has finished.
+func (c *Client) endNegotiation() {
+	c.reqs = c.reqs[:0]
+	c.legs = 0
 }
 
 // requestTokenOptions returns the token options to use for the response that challenged the client, deriving a
@@ -252,16 +286,6 @@ func (c *Client) Head(url string) (resp *http.Response, err error) {
 	return c.Do(req)
 }
 
-func respUnauthorizedNegotiate(resp *http.Response) bool {
-	if resp.StatusCode == http.StatusUnauthorized {
-		if resp.Header.Get(HTTPHeaderAuthResponse) == HTTPHeaderAuthResponseValueKey {
-			return true
-		}
-	}
-
-	return false
-}
-
 // setRequestSPN derives the service principal name for the request and updates the request's Host to match.
 //
 // canonicalize is the dns_canonicalize_hostname setting of krb5.conf. It is a security control as much as a
@@ -312,20 +336,15 @@ func canonicalizeHostname(cl *client.Client) bool {
 // SetSPNEGOHeader gets the service ticket and sets it as the SPNEGO authorization header on HTTP request object.
 // To auto generate the SPN from the request object pass a null string "".
 func SetSPNEGOHeader(cl *client.Client, r *http.Request, spn string, opts ...KRB5TokenOption) error {
-	if spn == "" {
-		pn, err := setRequestSPN(r, canonicalizeHostname(cl))
-		if err != nil {
-			return err
-		}
-
-		spn = pn.PrincipalNameString()
+	spn, err := requestSPN(cl, r, spn)
+	if err != nil {
+		return err
 	}
 
 	cl.Log("using SPN %s", spn)
 	s := SPNEGOClient(cl, spn, opts...)
 
-	err := s.AcquireCred()
-	if err != nil {
+	if err = s.AcquireCred(); err != nil {
 		return fmt.Errorf("could not acquire client credential: %w", err)
 	}
 
@@ -428,7 +447,9 @@ func SPNEGOKRB5Authenticate(inner http.Handler, kt *keytab.Keytab, settings ...f
 				return
 			}
 
-			spnegoResponseAcceptCompleted(spnego, w, "%s %s@%s - SPNEGO authentication succeeded", r.RemoteAddr, id.UserName(), id.Domain())
+			if err = spnegoResponseAcceptCompleted(spnego, w, "%s %s@%s - SPNEGO authentication succeeded", r.RemoteAddr, id.UserName(), id.Domain()); err != nil {
+				return
+			}
 			// Add the identity to the context and serve the inner/wrapped handler.
 			inner.ServeHTTP(w, identity.AddToHTTPRequestContext(id, r))
 
@@ -536,9 +557,48 @@ func spnegoResponseReject(s *SPNEGO, w http.ResponseWriter, format string, v ...
 	http.Error(w, UnauthorizedMsg, http.StatusUnauthorized)
 }
 
-func spnegoResponseAcceptCompleted(s *SPNEGO, w http.ResponseWriter, format string, v ...any) {
+func spnegoResponseAcceptCompleted(s *SPNEGO, w http.ResponseWriter, format string, v ...any) error {
+	h, err := spnegoAcceptCompletedHeader(s)
+	if err != nil {
+		spnegoInternalServerError(s, w, "SPNEGO could not build the accept-completed response: %v", err)
+
+		return err
+	}
+
 	s.Log(format, v...)
-	w.Header().Set(HTTPHeaderAuthResponse, spnegoNegTokenRespKRBAcceptCompleted)
+	w.Header().Set(HTTPHeaderAuthResponse, h)
+
+	return nil
+}
+
+// spnegoAcceptCompletedHeader returns the WWW-Authenticate value ending a successful negotiation.
+//
+// RFC 4178 Section 5(c)(I) has the reply carry a mechListMIC whenever the initiator sent one, and the initiator MUST
+// verify it, so the token has to be built for that exchange. The constant covers every other exchange, which is the
+// common one and the reason it is a constant: the same accept-completed state and Kerberos supportedMech, with
+// nothing variable in it.
+//
+// A failure to build the token is returned rather than answered with the constant. Replying accept-completed without
+// the MIC that was asked for would leave the initiator terminating a negotiation this acceptor had already
+// completed, having decided a request was authentic and then told the client it was not.
+func spnegoAcceptCompletedHeader(s *SPNEGO) (string, error) {
+	mic := s.MechListMIC()
+	if len(mic) == 0 {
+		return spnegoNegTokenRespKRBAcceptCompleted, nil
+	}
+
+	nt := NegTokenResp{
+		NegState:      asn1.Enumerated(NegStateAcceptCompleted),
+		SupportedMech: gssapi.OIDKRB5.OID(),
+		MechListMIC:   mic,
+	}
+
+	b, err := nt.Marshal()
+	if err != nil {
+		return "", err
+	}
+
+	return HTTPHeaderAuthResponseValueKey + " " + base64.StdEncoding.EncodeToString(b), nil
 }
 
 func spnegoInternalServerError(s *SPNEGO, w http.ResponseWriter, format string, v ...any) {

--- a/spnego/http_mechlist_test.go
+++ b/spnego/http_mechlist_test.go
@@ -1,0 +1,116 @@
+package spnego
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/x/encoding/asn1"
+
+	"github.com/go-krb5/krb5/gssapi"
+	"github.com/go-krb5/krb5/keytab"
+)
+
+func TestSPNEGOKRB5AuthenticateReturnsAMechListMIC(t *testing.T) {
+	t.Parallel()
+
+	init, kt, key := negTokenInitWithMIC(t)
+
+	resp := negotiateOverHTTP(t, kt, init)
+	require.Equal(t, http.StatusOK, resp.Code, "body: %s", resp.Body.String())
+
+	nt := negTokenRespFromHeader(t, resp.Header().Get(HTTPHeaderAuthResponse))
+
+	assert.EqualValues(t, NegStateAcceptCompleted, nt.NegState)
+	require.NotEmpty(t, nt.MechListMIC, "the acceptor must return a mechListMIC when the initiator sent one")
+
+	payload, err := mechListMICPayload(nil, init.MechTypes)
+	require.NoError(t, err)
+
+	assert.NoError(t, verifyMechListMIC(nt.MechListMIC, payload, key, true))
+}
+
+func TestSPNEGOKRB5AuthenticateRejectsAnIncorrectMechListMIC(t *testing.T) {
+	t.Parallel()
+
+	init, kt, _ := negTokenInitWithMIC(t)
+	init.MechListMIC[len(init.MechListMIC)-1] ^= 0xff
+
+	resp := negotiateOverHTTP(t, kt, init)
+
+	assert.Equal(t, http.StatusUnauthorized, resp.Code)
+	assert.Equal(t, spnegoNegTokenRespReject, resp.Header().Get(HTTPHeaderAuthResponse))
+}
+
+func TestSPNEGOKRB5AuthenticateNegotiatesWhenKerberosIsNotFirst(t *testing.T) {
+	t.Parallel()
+
+	init := NegTokenInit{
+		MechTypes:      []asn1.ObjectIdentifier{oidNTLMSSP, gssapi.OIDKRB5.OID()},
+		MechTokenBytes: []byte("NTLMSSP\x00\x01\x00\x00\x00"),
+	}
+
+	resp := negotiateOverHTTP(t, testKeytab(t), init)
+
+	assert.Equal(t, http.StatusUnauthorized, resp.Code)
+
+	nt := negTokenRespFromHeader(t, resp.Header().Get(HTTPHeaderAuthResponse))
+
+	assert.EqualValues(t, NegStateAcceptIncomplete, nt.NegState)
+	assert.True(t, isKerberosMech(nt.SupportedMech), "the acceptor must name the mechanism it selected")
+}
+
+func TestSPNEGOKRB5AuthenticateStillCompletesWithoutAMechListMIC(t *testing.T) {
+	t.Parallel()
+
+	mtb, _, kt := krb5MechToken(t)
+
+	init := NegTokenInit{MechTypes: []asn1.ObjectIdentifier{gssapi.OIDKRB5.OID()}, MechTokenBytes: mtb}
+
+	resp := negotiateOverHTTP(t, kt, init)
+
+	assert.Equal(t, http.StatusOK, resp.Code, "body: %s", resp.Body.String())
+	assert.Equal(t, spnegoNegTokenRespKRBAcceptCompleted, resp.Header().Get(HTTPHeaderAuthResponse))
+}
+
+func negotiateOverHTTP(t *testing.T, kt *keytab.Keytab, init NegTokenInit) *httptest.ResponseRecorder {
+	t.Helper()
+
+	b, err := (&SPNEGOToken{Init: true, NegTokenInit: init}).Marshal()
+	require.NoError(t, err)
+
+	r := httptest.NewRequest(http.MethodGet, "http://host.test.gokrb5/", nil)
+	r.Header.Set(HTTPHeaderAuthRequest, "Negotiate "+base64.StdEncoding.EncodeToString(b))
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("served"))
+	})
+
+	w := httptest.NewRecorder()
+	SPNEGOKRB5Authenticate(inner, kt).ServeHTTP(w, r)
+
+	return w
+}
+
+func negTokenRespFromHeader(t *testing.T, header string) NegTokenResp {
+	t.Helper()
+
+	name, token, found := strings.Cut(header, " ")
+	require.True(t, found, "header %q carries no token", header)
+	require.Equal(t, HTTPHeaderAuthResponseValueKey, name)
+
+	b, err := base64.StdEncoding.DecodeString(token)
+	require.NoError(t, err)
+
+	init, nt, err := UnmarshalNegToken(b)
+	require.NoError(t, err)
+	require.False(t, init, "the target replies with a NegTokenResp")
+
+	return nt.(NegTokenResp)
+}

--- a/spnego/http_negotiate.go
+++ b/spnego/http_negotiate.go
@@ -1,0 +1,235 @@
+package spnego
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/go-krb5/x/encoding/asn1"
+
+	"github.com/go-krb5/krb5/client"
+	"github.com/go-krb5/krb5/gssapi"
+)
+
+// MaxNegotiationLegs bounds the number of SPNEGO tokens the client will send in answer to one request. RFC 4178
+// negotiations with the Kerberos mechanism take one leg, or two when the target asks to continue, so the bound is
+// slack; it is there because a target that keeps challenging would otherwise keep the client answering forever.
+const MaxNegotiationLegs = 4
+
+// negotiationAction is what a Negotiate challenge asks the client to do next.
+type negotiationAction int
+
+const (
+	// negotiationStop means the exchange is over, or there is nothing this client can usefully send. The
+	// challenging response is returned to the caller as it stands.
+	negotiationStop negotiationAction = iota
+	// negotiationInitiate means send the first token of an exchange.
+	negotiationInitiate
+	// negotiationContinue means send a token continuing an exchange the target asked to continue.
+	negotiationContinue
+	// negotiationAnswerMIC means verify the target's mechListMIC and answer it with one of the client's own.
+	negotiationAnswerMIC
+)
+
+// negotiateChallenge returns the SPNEGO token in a Negotiate challenge, and reports whether the response is one.
+func negotiateChallenge(resp *http.Response) ([]byte, bool, error) {
+	if resp.StatusCode != http.StatusUnauthorized {
+		return nil, false, nil
+	}
+
+	for _, h := range resp.Header.Values(HTTPHeaderAuthResponse) {
+		scheme, token, _ := strings.Cut(h, " ")
+		if !strings.EqualFold(scheme, HTTPHeaderAuthResponseValueKey) {
+			continue
+		}
+
+		token = strings.TrimSpace(token)
+		if token == "" {
+			return nil, true, nil
+		}
+
+		b, err := base64.StdEncoding.DecodeString(token)
+		if err != nil {
+			return nil, true, fmt.Errorf("error in base64 decoding the negotiation challenge: %w", err)
+		}
+
+		return b, true, nil
+	}
+
+	return nil, false, nil
+}
+
+// negotiationNext decides what the client does with the token a target challenged it with.
+func negotiationNext(token []byte) (negotiationAction, NegTokenResp, error) {
+	var nr NegTokenResp
+
+	if len(token) == 0 {
+		return negotiationInitiate, nr, nil
+	}
+
+	init, nt, err := UnmarshalNegToken(token)
+	if err != nil {
+		return negotiationStop, nr, fmt.Errorf("could not read the SPNEGO challenge: %w", err)
+	}
+
+	if init {
+		return negotiationStop, nr, errors.New("the SPNEGO challenge is a NegTokenInit, not a negotiation response from a target")
+	}
+
+	nr = nt.(NegTokenResp)
+
+	// RFC 4178 Section 4.2.2 has the target name the mechanism it selected in its first reply. One that is named
+	// and is not Kerberos is a mechanism this client cannot continue with.
+	if len(nr.SupportedMech) > 0 && !isKerberosMech(nr.SupportedMech) {
+		return negotiationStop, nr, nil
+	}
+
+	switch nr.State() {
+	case NegStateAcceptIncomplete:
+		return negotiationContinue, nr, nil
+	case NegStateRequestMIC:
+		// Section 5(c)(IV): where the optimistic token is also the last mechanism token, which is always so for
+		// this client because it offers one mechanism, a target asking for the MIC exchange "MUST include a
+		// mechlistMIC token in that first reply". Without it there is nothing to verify and no way to proceed
+		// that would not amount to answering an unauthenticated request for a MIC.
+		if len(nr.MechListMIC) == 0 {
+			return negotiationStop, nr, errors.New("the target asked for the mechListMIC exchange but sent no mechListMIC of its own")
+		}
+
+		return negotiationAnswerMIC, nr, nil
+	default:
+		// accept-completed ends the negotiation and reject terminates it. Either way there is nothing to send.
+		return negotiationStop, nr, nil
+	}
+}
+
+// negotiate sets the Authorization header for the next leg of an exchange, reporting whether there is a leg to send.
+func (c *Client) negotiate(req *http.Request, resp *http.Response, token []byte) (bool, error) {
+	action, nr, err := negotiationNext(token)
+	if err != nil {
+		return false, err
+	}
+
+	switch action {
+	case negotiationInitiate:
+		return true, SetSPNEGOHeader(c.krb5Client, req, c.spn, c.requestTokenOptions(resp)...)
+	case negotiationContinue:
+		return true, setSPNEGOContinuationHeader(c.krb5Client, req, c.spn, c.requestTokenOptions(resp)...)
+	case negotiationAnswerMIC:
+		return true, setSPNEGOMechListMICHeader(c.krb5Client, req, c.spn, nr.MechListMIC)
+	default:
+		return false, nil
+	}
+}
+
+// setSPNEGOContinuationHeader sets the Authorization header for a leg continuing an exchange the target asked to
+// continue.
+//
+// RFC 4178 Section 4.2.2 carries this in a NegTokenResp and not another NegTokenInit, and the initiator names no
+// supportedMech there because that field appears "only in the first reply from the target"; the mech token itself
+// names the mechanism. The AP_REQ is built afresh rather than reused, since the one already sent has been seen by
+// the target and a service that keeps a replay cache would refuse it.
+func setSPNEGOContinuationHeader(cl *client.Client, r *http.Request, spn string, opts ...KRB5TokenOption) error {
+	spn, err := requestSPN(cl, r, spn)
+	if err != nil {
+		return err
+	}
+
+	mt, err := negotiationMechToken(cl, spn, opts...)
+	if err != nil {
+		return err
+	}
+
+	b, err := mt.Marshal()
+	if err != nil {
+		return fmt.Errorf("could not marshal the KRB5 token continuing the negotiation: %w", err)
+	}
+
+	return setNegotiationHeader(r, NegTokenResp{
+		NegState:      asn1.Enumerated(NegStateAcceptIncomplete),
+		ResponseToken: b,
+	})
+}
+
+// setSPNEGOMechListMICHeader answers a target's request-mic, as RFC 4178 Section 5(c)(IV) describes: "The initiator
+// MUST verify the received mechlistMIC token and generate a mechlistMIC token to send back to the target."
+func setSPNEGOMechListMICHeader(cl *client.Client, r *http.Request, spn string, targetMIC []byte) error {
+	spn, err := requestSPN(cl, r, spn)
+	if err != nil {
+		return err
+	}
+
+	_, key, err := cl.GetServiceTicket(spn)
+	if err != nil {
+		return fmt.Errorf("could not get the service ticket to verify the mechListMIC: %w", err)
+	}
+
+	payload, err := mechListMICPayload(nil, initiatorMechTypes())
+	if err != nil {
+		return err
+	}
+
+	if err = verifyMechListMIC(targetMIC, payload, key, true); err != nil {
+		return err
+	}
+
+	mic, err := newMechListMIC(payload, key, false)
+	if err != nil {
+		return err
+	}
+
+	return setNegotiationHeader(r, NegTokenResp{
+		NegState:    asn1.Enumerated(NegStateAcceptCompleted),
+		MechListMIC: mic,
+	})
+}
+
+// negotiationMechToken builds the Kerberos mech token for a leg of a negotiation.
+func negotiationMechToken(cl *client.Client, spn string, opts ...KRB5TokenOption) (KRB5Token, error) {
+	tkt, key, err := cl.GetServiceTicket(spn)
+	if err != nil {
+		return KRB5Token{}, fmt.Errorf("could not get the service ticket for %s: %w", spn, err)
+	}
+
+	mt, err := NewKRB5TokenAPREQ(cl, tkt, key, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, []int{}, opts...)
+	if err != nil {
+		return mt, fmt.Errorf("could not build the KRB5 token: %w", err)
+	}
+
+	return mt, nil
+}
+
+// setNegotiationHeader base64 encodes a negotiation token into the request's Authorization header.
+func setNegotiationHeader(r *http.Request, nr NegTokenResp) error {
+	b, err := nr.Marshal()
+	if err != nil {
+		return fmt.Errorf("could not marshal the SPNEGO negotiation token: %w", err)
+	}
+
+	r.Header.Set(HTTPHeaderAuthRequest, HTTPHeaderAuthResponseValueKey+" "+base64.StdEncoding.EncodeToString(b))
+
+	return nil
+}
+
+// requestSPN resolves the service principal name for a request, deriving it from the request when none is
+// configured, exactly as SetSPNEGOHeader does.
+func requestSPN(cl *client.Client, r *http.Request, spn string) (string, error) {
+	if spn != "" {
+		return spn, nil
+	}
+
+	pn, err := setRequestSPN(r, canonicalizeHostname(cl))
+	if err != nil {
+		return "", err
+	}
+
+	return pn.PrincipalNameString(), nil
+}
+
+// initiatorMechTypes returns the mechanism list this library offers as a SPNEGO initiator. It holds Kerberos alone,
+// which is the only mechanism implemented here, and it is what a mechListMIC computed by this initiator protects.
+func initiatorMechTypes() []asn1.ObjectIdentifier {
+	return []asn1.ObjectIdentifier{gssapi.OIDKRB5.OID()}
+}

--- a/spnego/http_negotiate_test.go
+++ b/spnego/http_negotiate_test.go
@@ -1,0 +1,336 @@
+package spnego
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/x/encoding/asn1"
+
+	"github.com/go-krb5/krb5/client"
+	"github.com/go-krb5/krb5/config"
+	"github.com/go-krb5/krb5/gssapi"
+	"github.com/go-krb5/krb5/keytab"
+	"github.com/go-krb5/krb5/test"
+	"github.com/go-krb5/krb5/test/testdata"
+)
+
+func TestNegotiateChallenge(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		status  int
+		headers []string
+		token   []byte
+		ok      bool
+		err     string
+	}{
+		{name: "no header", status: http.StatusUnauthorized},
+		{name: "not a challenge", status: http.StatusOK, headers: []string{"Negotiate"}},
+		{name: "bare", status: http.StatusUnauthorized, headers: []string{"Negotiate"}, ok: true},
+		{name: "trailing space", status: http.StatusUnauthorized, headers: []string{"Negotiate "}, ok: true},
+		{
+			// RFC 7235 Section 2.1 makes the auth-scheme case insensitive.
+			name: "lower case scheme", status: http.StatusUnauthorized,
+			headers: []string{"negotiate " + base64.StdEncoding.EncodeToString([]byte{0xa1, 0x00})},
+			token:   []byte{0xa1, 0x00}, ok: true,
+		},
+		{
+			name: "with a token", status: http.StatusUnauthorized,
+			headers: []string{"Negotiate " + base64.StdEncoding.EncodeToString([]byte{0xa1, 0x00})},
+			token:   []byte{0xa1, 0x00}, ok: true,
+		},
+		{
+			name: "alongside another scheme", status: http.StatusUnauthorized,
+			headers: []string{"Basic realm=\"test\"", "Negotiate " + base64.StdEncoding.EncodeToString([]byte{0xa1, 0x00})},
+			token:   []byte{0xa1, 0x00}, ok: true,
+		},
+		{name: "another scheme only", status: http.StatusUnauthorized, headers: []string{"Basic realm=\"test\""}},
+		{
+			name: "undecodable token", status: http.StatusUnauthorized,
+			headers: []string{"Negotiate !!!not base64!!!"}, err: "base64",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := &http.Response{StatusCode: tc.status, Header: http.Header{}}
+			for _, h := range tc.headers {
+				resp.Header.Add(HTTPHeaderAuthResponse, h)
+			}
+
+			token, ok, err := negotiateChallenge(resp)
+
+			if tc.err != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.token, token)
+		})
+	}
+}
+
+func TestNegotiationNext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		token  func(t *testing.T) []byte
+		action negotiationAction
+		err    string
+	}{
+		{
+			name:   "bare challenge starts the exchange",
+			token:  func(*testing.T) []byte { return nil },
+			action: negotiationInitiate,
+		},
+		{
+			name: "accept-incomplete asks for another leg",
+			token: func(t *testing.T) []byte {
+				return negTokenRespBytes(t, NegTokenResp{
+					NegState:      asn1.Enumerated(NegStateAcceptIncomplete),
+					SupportedMech: gssapi.OIDKRB5.OID(),
+				})
+			},
+			action: negotiationContinue,
+		},
+		{
+			name: "the MS legacy Kerberos OID is Kerberos too",
+			token: func(t *testing.T) []byte {
+				return negTokenRespBytes(t, NegTokenResp{
+					NegState:      asn1.Enumerated(NegStateAcceptIncomplete),
+					SupportedMech: gssapi.OIDMSLegacyKRB5.OID(),
+				})
+			},
+			action: negotiationContinue,
+		},
+		{
+			name: "reject ends the exchange",
+			token: func(t *testing.T) []byte {
+				return negTokenRespBytes(t, NegTokenResp{NegState: asn1.Enumerated(NegStateReject)})
+			},
+			action: negotiationStop,
+		},
+		{
+			name: "accept-completed ends the exchange",
+			token: func(t *testing.T) []byte {
+				return negTokenRespBytes(t, NegTokenResp{NegState: asn1.Enumerated(NegStateAcceptCompleted)})
+			},
+			action: negotiationStop,
+		},
+		{
+			name: "a mechanism this client does not speak ends the exchange",
+			token: func(t *testing.T) []byte {
+				return negTokenRespBytes(t, NegTokenResp{
+					NegState:      asn1.Enumerated(NegStateAcceptIncomplete),
+					SupportedMech: oidNTLMSSP,
+				})
+			},
+			action: negotiationStop,
+		},
+		{
+			name: "request-mic asks for the MIC exchange",
+			token: func(t *testing.T) []byte {
+				return negTokenRespBytes(t, NegTokenResp{
+					NegState:      asn1.Enumerated(NegStateRequestMIC),
+					SupportedMech: gssapi.OIDKRB5.OID(),
+					MechListMIC:   []byte{0x04, 0x04},
+				})
+			},
+			action: negotiationAnswerMIC,
+		},
+		{
+			// RFC 4178 Section 5(c)(IV) makes the target's own MIC mandatory here, so there is nothing to verify
+			// and the exchange cannot proceed correctly.
+			name: "request-mic without a MIC cannot be answered",
+			token: func(t *testing.T) []byte {
+				return negTokenRespBytes(t, NegTokenResp{
+					NegState:      asn1.Enumerated(NegStateRequestMIC),
+					SupportedMech: gssapi.OIDKRB5.OID(),
+				})
+			},
+			err: "no mechListMIC",
+		},
+		{
+			name:  "a NegTokenInit is not a reply from a target",
+			token: func(t *testing.T) []byte { return negTokenInitBytes(t) },
+			err:   "not a negotiation response",
+		},
+		{
+			name:  "unreadable token",
+			token: func(*testing.T) []byte { return []byte{0xff, 0xff, 0xff} },
+			err:   "could not read",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			action, _, err := negotiationNext(tc.token(t))
+
+			if tc.err != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.action, action)
+		})
+	}
+}
+
+func negTokenRespBytes(t *testing.T, nr NegTokenResp) []byte {
+	t.Helper()
+
+	b, err := nr.Marshal()
+	require.NoError(t, err)
+
+	return b
+}
+
+func negTokenInitBytes(t *testing.T) []byte {
+	t.Helper()
+
+	init := NegTokenInit{MechTypes: []asn1.ObjectIdentifier{gssapi.OIDKRB5.OID()}}
+
+	b, err := init.Marshal()
+	require.NoError(t, err)
+
+	return b
+}
+
+func TestClientBoundsTheNumberOfNegotiationLegs(t *testing.T) {
+	t.Parallel()
+
+	c := NewClient(nil, nil, "HTTP/localhost")
+	c.legs = MaxNegotiationLegs
+
+	send, err := c.nextNegotiationLeg(httptest.NewRequest(http.MethodGet, "http://host.test.gokrb5/", nil),
+		&http.Response{Header: http.Header{}}, nil)
+
+	assert.False(t, send)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not complete within")
+}
+
+func TestClientContinuesANegotiation(t *testing.T) {
+	test.Integration(t)
+
+	b, err := hex.DecodeString(testdata.HTTP_KEYTAB)
+	require.NoError(t, err)
+
+	kt := keytab.New()
+	require.NoError(t, kt.Unmarshal(b))
+
+	var legs atomic.Int32
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	authenticated := SPNEGOKRB5Authenticate(inner, kt)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(HTTPHeaderAuthRequest) != "" && legs.Add(1) == 1 {
+			w.Header().Set(HTTPHeaderAuthResponse, spnegoNegTokenRespIncompleteKRB5)
+			http.Error(w, UnauthorizedMsg, http.StatusUnauthorized)
+
+			return
+		}
+
+		authenticated.ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	r, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := NewClient(integrationClient(t), srv.Client(), "HTTP/host.test.gokrb5").Do(r)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.EqualValues(t, 2, legs.Load(), "the client must send a second token")
+}
+
+func TestClientReadsTheTokenInAChallenge(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(HTTPHeaderAuthResponse, "Negotiate !!!not base64!!!")
+		http.Error(w, UnauthorizedMsg, http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := NewClient(nil, srv.Client(), "HTTP/host.test.gokrb5").Get(srv.URL)
+	if resp != nil {
+		t.Cleanup(func() { _ = resp.Body.Close() })
+	}
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "base64")
+}
+
+func TestClientStopsOnAReject(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set(HTTPHeaderAuthResponse, spnegoNegTokenRespReject)
+		http.Error(w, UnauthorizedMsg, http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := NewClient(nil, srv.Client(), "HTTP/host.test.gokrb5").Get(srv.URL)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.EqualValues(t, 1, requests.Load(), "a rejected negotiation must not be retried")
+}
+
+func integrationClient(t *testing.T) *client.Client {
+	t.Helper()
+
+	b, err := hex.DecodeString(testdata.KEYTAB_TESTUSER1_TEST_GOKRB5)
+	require.NoError(t, err)
+
+	kt := keytab.New()
+	require.NoError(t, kt.Unmarshal(b))
+
+	c, err := config.NewFromString(testdata.KRB5_CONF)
+	require.NoError(t, err)
+
+	addr := os.Getenv("TEST_KDC_ADDR")
+	if addr == "" {
+		addr = testdata.KDC_IP_TEST_GOKRB5
+	}
+
+	c.Realms[0].KDC = []string{addr + ":" + testdata.KDC_PORT_TEST_GOKRB5}
+
+	cl := client.NewWithKeytab("testuser1", "TEST.GOKRB5", kt, c)
+	require.NoError(t, cl.Login())
+
+	return cl
+}

--- a/spnego/krb5_token.go
+++ b/spnego/krb5_token.go
@@ -35,11 +35,34 @@ type KRB5Token struct {
 	KRBError messages.KRBError
 	settings *service.Settings
 	context  context.Context
+	key      types.EncryptionKey
+}
+
+// contextKey returns the key protecting per-message tokens on the context this token establishes, which is what the
+// mechListMIC of RFC 4178 Section 5 is computed with.
+//
+// RFC 4121 Section 4.2.6 signs with the subkey the acceptor asserts when there is one. This library sends no AP_REP
+// and so asserts none, leaving the subkey the initiator put in its authenticator if it sent one, and the ticket
+// session key otherwise. An initiator holds that key directly; an acceptor reads it out of the ticket it decrypted,
+// so this is only meaningful once the AP_REQ has been verified.
+func (m *KRB5Token) contextKey() (types.EncryptionKey, error) {
+	if len(m.key.KeyValue) > 0 {
+		return m.key, nil
+	}
+
+	if len(m.APReq.Authenticator.SubKey.KeyValue) > 0 {
+		return m.APReq.Authenticator.SubKey, nil
+	}
+
+	if len(m.APReq.Ticket.DecryptedEncPart.Key.KeyValue) > 0 {
+		return m.APReq.Ticket.DecryptedEncPart.Key, nil
+	}
+
+	return types.EncryptionKey{}, errors.New("the KRB5 context has no established key")
 }
 
 // Marshal a KRB5Token into a slice of bytes.
 func (m *KRB5Token) Marshal() ([]byte, error) {
-	// Create the header.
 	b, _ := asn1.Marshal(m.OID, asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
 	b = append(b, m.tokID...)
 
@@ -280,6 +303,7 @@ func NewKRB5TokenAPREQ(cl *client.Client, tkt messages.Ticket, sessionKey types.
 	}
 
 	m.APReq = APReq
+	m.key = sessionKey
 
 	return m, nil
 }
@@ -426,4 +450,19 @@ func delegatedCredential(cl *client.Client, tkt messages.Ticket, sessionKey type
 // isKerberosMech reports whether the object identifier names a Kerberos 5 GSS-API mechanism this library speaks.
 func isKerberosMech(oid asn1.ObjectIdentifier) bool {
 	return oid.Equal(gssapi.OIDKRB5.OID()) || oid.Equal(gssapi.OIDMSLegacyKRB5.OID())
+}
+
+// kerberosMechIndex returns the position of the first Kerberos mechanism in the list, or -1 when it holds none.
+//
+// The position matters and not only the presence. RFC 4178 Section 4.2.1 lists mechTypes "in decreasing preference
+// order", so position zero is both the mechanism the optimistic mechToken belongs to and the initiator's first
+// choice, which is what Section 5 weighs when deciding whether a mechListMIC exchange is required.
+func kerberosMechIndex(mechTypes []asn1.ObjectIdentifier) int {
+	for i, m := range mechTypes {
+		if isKerberosMech(m) {
+			return i
+		}
+	}
+
+	return -1
 }

--- a/spnego/mechlist_mic.go
+++ b/spnego/mechlist_mic.go
@@ -1,0 +1,88 @@
+package spnego
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/go-krb5/x/encoding/asn1"
+
+	"github.com/go-krb5/krb5/gssapi"
+	"github.com/go-krb5/krb5/iana/keyusage"
+	"github.com/go-krb5/krb5/types"
+)
+
+// mechListMICPayload returns the message a mechListMIC is computed over. RFC 4178 Section 5(a) defines it as "the
+// DER encoding of the value of type MechTypeList, which is contained in the mechTypes field of the NegTokenInit",
+// and is explicit that "the input message is NOT the DER encoding of the type [0] MechTypeList": the context tag
+// the field carries inside the token is not part of what is signed.
+func mechListMICPayload(raw []byte, mechTypes []asn1.ObjectIdentifier) ([]byte, error) {
+	if len(raw) > 0 {
+		return raw, nil
+	}
+
+	if len(mechTypes) == 0 {
+		return nil, errors.New("cannot compute a mechListMIC over an empty mechanism list")
+	}
+
+	b, err := asn1.Marshal(mechTypes, asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling the MechTypeList for the mechListMIC: %w", err)
+	}
+
+	return b, nil
+}
+
+// newMechListMIC returns the MIC token RFC 4178 Section 5(a) obtains by "invoking GSS_GetMIC()" over the mechanism
+// list, which for the Kerberos mechanism is the token described by RFC 4121 Section 4.2.6.1.
+func newMechListMIC(payload []byte, key types.EncryptionKey, fromAcceptor bool) ([]byte, error) {
+	mt := gssapi.MICToken{Payload: payload}
+
+	if fromAcceptor {
+		mt.Flags = gssapi.MICTokenFlagSentByAcceptor
+	}
+
+	if err := mt.SetChecksum(key, micKeyUsage(fromAcceptor)); err != nil {
+		return nil, fmt.Errorf("error computing the mechListMIC checksum: %w", err)
+	}
+
+	return mt.Marshal()
+}
+
+// verifyMechListMIC checks a MIC token against the mechanism list it should protect. Every failure is an error: RFC
+// 4178 Section 5 terminates the negotiation for a MIC that does not verify, so there is no partial success to
+// report and nothing for a caller to weigh up.
+func verifyMechListMIC(mic, payload []byte, key types.EncryptionKey, fromAcceptor bool) error {
+	var mt gssapi.MICToken
+
+	if err := mt.Unmarshal(mic, fromAcceptor); err != nil {
+		return fmt.Errorf("error reading the mechListMIC: %w", err)
+	}
+
+	if len(mt.Checksum) == 0 {
+		return errors.New("the mechListMIC carries no checksum")
+	}
+
+	mt.Payload = payload
+
+	ok, err := mt.Verify(key, micKeyUsage(fromAcceptor))
+	if err != nil {
+		return fmt.Errorf("the mechListMIC does not verify: %w", err)
+	}
+
+	if !ok {
+		return errors.New("the mechListMIC does not verify")
+	}
+
+	return nil
+}
+
+// micKeyUsage returns the key usage RFC 4121 Section 2 assigns to a MIC token from each side of the exchange. It is
+// derived from the same argument that sets the acceptor flag in the token header so that the two, which are one
+// fact spelled twice, cannot be set inconsistently.
+func micKeyUsage(fromAcceptor bool) uint32 {
+	if fromAcceptor {
+		return keyusage.GSSAPI_ACCEPTOR_SIGN
+	}
+
+	return keyusage.GSSAPI_INITIATOR_SIGN
+}

--- a/spnego/negotiation_mechlist_test.go
+++ b/spnego/negotiation_mechlist_test.go
@@ -1,0 +1,343 @@
+package spnego
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/x/encoding/asn1"
+
+	"github.com/go-krb5/krb5/gssapi"
+	"github.com/go-krb5/krb5/iana/etypeID"
+	"github.com/go-krb5/krb5/iana/nametype"
+	"github.com/go-krb5/krb5/keytab"
+	"github.com/go-krb5/krb5/messages"
+	"github.com/go-krb5/krb5/types"
+)
+
+func TestAcceptSecContextSelectsKerberosWhenItIsNotTheFirstMechanism(t *testing.T) {
+	t.Parallel()
+
+	kt := testKeytab(t)
+
+	// The optimistic mech token belongs to NTLM, the initiator's first choice, so it is not ours to read.
+	init := NegTokenInit{
+		MechTypes:      []asn1.ObjectIdentifier{oidNTLMSSP, gssapi.OIDKRB5.OID()},
+		MechTokenBytes: []byte("NTLMSSP\x00\x01\x00\x00\x00"),
+	}
+
+	ok, _, status := SPNEGOService(kt).AcceptSecContext(spnegoInitToken(t, init))
+
+	assert.False(t, ok)
+	assert.Equal(t, gssapi.StatusContinueNeeded, status.Code, "message was %q", status.Message)
+}
+
+func TestAcceptSecContextStillRejectsAListWithoutKerberos(t *testing.T) {
+	t.Parallel()
+
+	kt := testKeytab(t)
+
+	init := NegTokenInit{
+		MechTypes:      []asn1.ObjectIdentifier{oidNTLMSSP},
+		MechTokenBytes: []byte("NTLMSSP\x00\x01\x00\x00\x00"),
+	}
+
+	ok, _, status := SPNEGOService(kt).AcceptSecContext(spnegoInitToken(t, init))
+
+	assert.False(t, ok)
+	assert.Equal(t, gssapi.StatusBadMech, status.Code)
+}
+
+func TestAcceptSecContextStillAcceptsTheOptimisticKerberosToken(t *testing.T) {
+	t.Parallel()
+
+	mtb, _, kt := krb5MechToken(t)
+
+	init := NegTokenInit{
+		MechTypes:      []asn1.ObjectIdentifier{gssapi.OIDKRB5.OID()},
+		MechTokenBytes: mtb,
+	}
+
+	ok, _, status := SPNEGOService(kt).AcceptSecContext(spnegoInitToken(t, init))
+
+	assert.True(t, ok, "status was %d: %s", status.Code, status.Message)
+	assert.Equal(t, gssapi.StatusComplete, status.Code)
+}
+
+func TestMechListMICPayloadIsTheUntaggedMechTypeList(t *testing.T) {
+	t.Parallel()
+
+	mechs := []asn1.ObjectIdentifier{oidNTLMSSP, gssapi.OIDKRB5.OID()}
+
+	payload, err := mechListMICPayload(nil, mechs)
+	require.NoError(t, err)
+	require.NotEmpty(t, payload)
+
+	assert.EqualValues(t, 0x30, payload[0], "expected a SEQUENCE, not the [0] context tag 0xa0")
+
+	init := NegTokenInit{MechTypes: mechs, MechTokenBytes: []byte{0xde, 0xad}}
+
+	b, err := init.Marshal()
+	require.NoError(t, err)
+
+	var outer asn1.RawValue
+
+	_, err = asn1.Unmarshal(b, &outer)
+	require.NoError(t, err)
+
+	var field0 struct {
+		MechTypes asn1.RawValue `asn1:"explicit,tag:0"`
+	}
+
+	_, err = asn1.Unmarshal(outer.Bytes, &field0)
+	require.NoError(t, err)
+
+	assert.Equal(t, field0.MechTypes.Bytes, payload)
+}
+
+func TestMechListMICPayloadPrefersTheOctetsReceived(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte{0x30, 0x00}
+
+	payload, err := mechListMICPayload(raw, []asn1.ObjectIdentifier{gssapi.OIDKRB5.OID()})
+	require.NoError(t, err)
+
+	assert.Equal(t, raw, payload)
+}
+
+func TestNegTokenInitVerifiesACorrectMechListMIC(t *testing.T) {
+	t.Parallel()
+
+	init, kt, _ := negTokenInitWithMIC(t)
+
+	ok, _, status := SPNEGOService(kt).AcceptSecContext(spnegoInitToken(t, init))
+
+	assert.True(t, ok, "status was %d: %s", status.Code, status.Message)
+	assert.Equal(t, gssapi.StatusComplete, status.Code)
+}
+
+func TestNegTokenInitRejectsAnIncorrectMechListMIC(t *testing.T) {
+	t.Parallel()
+
+	init, kt, _ := negTokenInitWithMIC(t)
+
+	init.MechListMIC[len(init.MechListMIC)-1] ^= 0xff
+
+	ok, _, status := SPNEGOService(kt).AcceptSecContext(spnegoInitToken(t, init))
+
+	assert.False(t, ok)
+	assert.Equal(t, gssapi.StatusDefectiveToken, status.Code)
+}
+
+func TestNegTokenInitRejectsAMechListMICOverADifferentList(t *testing.T) {
+	t.Parallel()
+
+	init, kt, _ := negTokenInitWithMIC(t)
+
+	init.MechTypes = append(init.MechTypes, oidNTLMSSP)
+
+	ok, _, status := SPNEGOService(kt).AcceptSecContext(spnegoInitToken(t, init))
+
+	assert.False(t, ok)
+	assert.Equal(t, gssapi.StatusDefectiveToken, status.Code)
+}
+
+func TestAcceptorReturnsAMechListMIC(t *testing.T) {
+	t.Parallel()
+
+	init, kt, key := negTokenInitWithMIC(t)
+
+	s := SPNEGOService(kt)
+
+	ok, _, status := s.AcceptSecContext(spnegoInitToken(t, init))
+	require.True(t, ok, "status was %d: %s", status.Code, status.Message)
+
+	mic := s.MechListMIC()
+	require.NotEmpty(t, mic, "the acceptor must return a mechListMIC when the initiator sent one")
+
+	payload, err := mechListMICPayload(nil, init.MechTypes)
+	require.NoError(t, err)
+
+	assert.NoError(t, verifyMechListMIC(mic, payload, key, true))
+}
+
+func TestAcceptorReturnsNoMechListMICWhenTheInitiatorSentNone(t *testing.T) {
+	t.Parallel()
+
+	mtb, _, kt := krb5MechToken(t)
+
+	init := NegTokenInit{MechTypes: []asn1.ObjectIdentifier{gssapi.OIDKRB5.OID()}, MechTokenBytes: mtb}
+
+	s := SPNEGOService(kt)
+
+	ok, _, status := s.AcceptSecContext(spnegoInitToken(t, init))
+	require.True(t, ok, "status was %d: %s", status.Code, status.Message)
+
+	assert.Empty(t, s.MechListMIC())
+}
+
+func TestNegTokenRespVerifiesAMechListMICAgainstTheRetainedList(t *testing.T) {
+	t.Parallel()
+
+	s, mechs, key, mtb := negotiationInProgress(t)
+
+	mic := mechListMICOver(t, mechs, key, false)
+
+	ok, _, status := s.AcceptSecContext(spnegoRespToken(t, NegTokenResp{
+		NegState:      asn1.Enumerated(NegStateAcceptIncomplete),
+		ResponseToken: mtb,
+		MechListMIC:   mic,
+	}))
+
+	assert.True(t, ok, "status was %d: %s", status.Code, status.Message)
+	assert.Equal(t, gssapi.StatusComplete, status.Code)
+	assert.NotEmpty(t, s.MechListMIC(), "the acceptor owes a mechListMIC in reply")
+}
+
+func TestNegTokenRespRejectsAMechListMICOverADifferentList(t *testing.T) {
+	t.Parallel()
+
+	s, _, key, mtb := negotiationInProgress(t)
+
+	mic := mechListMICOver(t, []asn1.ObjectIdentifier{gssapi.OIDKRB5.OID()}, key, false)
+
+	ok, _, status := s.AcceptSecContext(spnegoRespToken(t, NegTokenResp{
+		NegState:      asn1.Enumerated(NegStateAcceptIncomplete),
+		ResponseToken: mtb,
+		MechListMIC:   mic,
+	}))
+
+	assert.False(t, ok)
+	assert.Equal(t, gssapi.StatusDefectiveToken, status.Code)
+}
+
+func TestNegTokenRespRejectsAMechListMICWithoutTheList(t *testing.T) {
+	t.Parallel()
+
+	mtb, key, kt := krb5MechToken(t)
+
+	mic := mechListMICOver(t, []asn1.ObjectIdentifier{gssapi.OIDKRB5.OID()}, key, false)
+
+	ok, _, status := SPNEGOService(kt).AcceptSecContext(spnegoRespToken(t, NegTokenResp{
+		NegState:      asn1.Enumerated(NegStateAcceptIncomplete),
+		ResponseToken: mtb,
+		MechListMIC:   mic,
+	}))
+
+	assert.False(t, ok)
+	assert.Equal(t, gssapi.StatusDefectiveToken, status.Code)
+	assert.Contains(t, status.Message, "did not retain")
+}
+
+func negotiationInProgress(t *testing.T) (*SPNEGO, []asn1.ObjectIdentifier, types.EncryptionKey, []byte) {
+	t.Helper()
+
+	mtb, key, kt := krb5MechToken(t)
+	mechs := []asn1.ObjectIdentifier{oidNTLMSSP, gssapi.OIDKRB5.OID()}
+
+	s := SPNEGOService(kt)
+
+	_, _, status := s.AcceptSecContext(spnegoInitToken(t, NegTokenInit{
+		MechTypes:      mechs,
+		MechTokenBytes: []byte("NTLMSSP\x00\x01\x00\x00\x00"),
+	}))
+	require.Equal(t, gssapi.StatusContinueNeeded, status.Code, "message was %q", status.Message)
+
+	return s, mechs, key, mtb
+}
+
+func mechListMICOver(t *testing.T, mechs []asn1.ObjectIdentifier, key types.EncryptionKey, fromAcceptor bool) []byte {
+	t.Helper()
+
+	payload, err := mechListMICPayload(nil, mechs)
+	require.NoError(t, err)
+
+	mic, err := newMechListMIC(payload, key, fromAcceptor)
+	require.NoError(t, err)
+
+	return mic
+}
+
+func spnegoRespToken(t *testing.T, resp NegTokenResp) *SPNEGOToken {
+	t.Helper()
+
+	b, err := resp.Marshal()
+	require.NoError(t, err)
+
+	var st SPNEGOToken
+
+	require.NoError(t, st.Unmarshal(b))
+
+	return &st
+}
+
+func krb5MechToken(t *testing.T) ([]byte, types.EncryptionKey, *keytab.Keytab) {
+	t.Helper()
+
+	kt := testKeytab(t)
+	sname := types.NewPrincipalName(nametype.KRB_NT_SRV_INST, "HTTP/host.test.gokrb5")
+	cname := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, "testuser")
+	now := time.Now().UTC()
+
+	tkt, sessionKey, err := messages.NewTicket(cname, "TEST.GOKRB5", sname, "TEST.GOKRB5",
+		types.NewKrbFlags(), kt, etypeID.AES256_CTS_HMAC_SHA1_96, 1,
+		now, now, now.Add(time.Hour), now.Add(2*time.Hour))
+	require.NoError(t, err)
+
+	auth, err := types.NewAuthenticator("TEST.GOKRB5", cname)
+	require.NoError(t, err)
+
+	apreq, err := messages.NewAPReq(tkt, sessionKey, auth)
+	require.NoError(t, err)
+
+	mt := KRB5Token{OID: gssapi.OIDKRB5.OID(), tokID: []byte{0x01, 0x00}, APReq: apreq}
+
+	b, err := mt.Marshal()
+	require.NoError(t, err)
+
+	return b, sessionKey, kt
+}
+
+func testKeytab(t *testing.T) *keytab.Keytab {
+	t.Helper()
+
+	kt := keytab.New()
+	require.NoError(t, kt.AddEntry("HTTP/host.test.gokrb5", "TEST.GOKRB5", "servicepassword",
+		time.Now(), 1, etypeID.AES256_CTS_HMAC_SHA1_96))
+
+	return kt
+}
+
+func spnegoInitToken(t *testing.T, init NegTokenInit) *SPNEGOToken {
+	t.Helper()
+
+	b, err := (&SPNEGOToken{Init: true, NegTokenInit: init}).Marshal()
+	require.NoError(t, err)
+
+	var st SPNEGOToken
+
+	require.NoError(t, st.Unmarshal(b))
+
+	return &st
+}
+
+func negTokenInitWithMIC(t *testing.T) (NegTokenInit, *keytab.Keytab, types.EncryptionKey) {
+	t.Helper()
+
+	mtb, key, kt := krb5MechToken(t)
+
+	mechs := []asn1.ObjectIdentifier{gssapi.OIDKRB5.OID(), oidNTLMSSP}
+
+	payload, err := mechListMICPayload(nil, mechs)
+	require.NoError(t, err)
+
+	mic, err := newMechListMIC(payload, key, false)
+	require.NoError(t, err)
+
+	return NegTokenInit{MechTypes: mechs, MechTokenBytes: mtb, MechListMIC: mic}, kt, key
+}
+
+var oidNTLMSSP = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 311, 2, 2, 10}

--- a/spnego/negotiation_token.go
+++ b/spnego/negotiation_token.go
@@ -29,12 +29,14 @@ type NegState int
 
 // NegTokenInit implements Negotiation Token of type Init.
 type NegTokenInit struct {
-	MechTypes      []asn1.ObjectIdentifier
-	ReqFlags       asn1.BitString
-	MechTokenBytes []byte
-	MechListMIC    []byte
-	mechToken      gssapi.ContextToken
-	settings       *service.Settings
+	MechTypes       []asn1.ObjectIdentifier
+	ReqFlags        asn1.BitString
+	MechTokenBytes  []byte
+	MechListMIC     []byte
+	mechToken       gssapi.ContextToken
+	settings        *service.Settings
+	mechTypesRaw    []byte
+	respMechListMIC []byte
 }
 
 type marshalNegTokenInit struct {
@@ -44,18 +46,20 @@ type marshalNegTokenInit struct {
 
 	MechTokenBytes []byte `asn1:"explicit,optional,omitempty,tag:2"`
 
-	// This field is not used when negotiating Kerberos tokens.
 	MechListMIC []byte `asn1:"explicit,optional,omitempty,tag:3"`
 }
 
 // NegTokenResp implements Negotiation Token of type Resp/Targ.
 type NegTokenResp struct {
-	NegState      asn1.Enumerated
-	SupportedMech asn1.ObjectIdentifier
-	ResponseToken []byte
-	MechListMIC   []byte
-	mechToken     gssapi.ContextToken
-	settings      *service.Settings
+	NegState        asn1.Enumerated
+	SupportedMech   asn1.ObjectIdentifier
+	ResponseToken   []byte
+	MechListMIC     []byte
+	mechToken       gssapi.ContextToken
+	settings        *service.Settings
+	mechTypes       []asn1.ObjectIdentifier
+	mechTypesRaw    []byte
+	respMechListMIC []byte
 }
 
 type marshalNegTokenResp struct {
@@ -65,7 +69,7 @@ type marshalNegTokenResp struct {
 
 	ResponseToken []byte `asn1:"explicit,optional,omitempty,tag:2"`
 
-	// This field is not used when negotiating Kerberos tokens.
+	// MechListMIC protects the initiator's MechTypes; see RFC 4178 Section 5 and mechlist_mic.go.
 	MechListMIC []byte `asn1:"explicit,optional,omitempty,tag:3"`
 }
 
@@ -118,28 +122,27 @@ func (n *NegTokenInit) Unmarshal(b []byte) error {
 	n.MechListMIC = nInit.MechListMIC
 	n.MechTypes = nInit.MechTypes
 	n.ReqFlags = nInit.ReqFlags
+	n.mechTypesRaw = nInit.mechTypesRaw
 
 	return nil
 }
 
 // Verify an Init negotiation token.
+//
+// Kerberos is selected wherever it appears in mechTypes rather than only at the head of the list. RFC 4178 Section
+// 4.2.2 has the acceptor name the mechanism it selected and ask for another leg, which is what an initiator offering
+// NegoEx or NTLM ahead of Kerberos, the ordinary Windows case, expects to happen.
 func (n *NegTokenInit) Verify() (bool, gssapi.Status) {
-	var mtSupported bool
-
-	for _, m := range n.MechTypes {
-		if isKerberosMech(m) {
-			if n.mechToken == nil && n.MechTokenBytes == nil {
-				return false, gssapi.Status{Code: gssapi.StatusContinueNeeded}
-			}
-
-			mtSupported = true
-
-			break
-		}
+	i := kerberosMechIndex(n.MechTypes)
+	if i < 0 {
+		return false, gssapi.Status{Code: gssapi.StatusBadMech, Message: "no supported mechanism specified in negotiation"}
 	}
 
-	if !mtSupported {
-		return false, gssapi.Status{Code: gssapi.StatusBadMech, Message: "no supported mechanism specified in negotiation"}
+	// The optimistic mechToken belongs to the first mechanism in the list. When that is not Kerberos the token is
+	// not ours to read, so the reply names Kerberos and the initiator sends a Kerberos token of its own in the
+	// leg that follows.
+	if i > 0 || (n.mechToken == nil && n.MechTokenBytes == nil) {
+		return false, gssapi.Status{Code: gssapi.StatusContinueNeeded}
 	}
 
 	mt := new(KRB5Token)
@@ -161,7 +164,50 @@ func (n *NegTokenInit) Verify() (bool, gssapi.Status) {
 		}
 	}
 
-	return n.mechToken.Verify()
+	ok, status := mt.Verify()
+	if !ok || status.Code != gssapi.StatusComplete {
+		return ok, status
+	}
+
+	if err := n.exchangeMechListMIC(mt); err != nil {
+		return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: err.Error()}
+	}
+
+	return ok, status
+}
+
+// exchangeMechListMIC performs the acceptor's half of the mechListMIC exchange of RFC 4178 Section 5 for the leg
+// that carried the mechanism list itself.
+func (n *NegTokenInit) exchangeMechListMIC(mt *KRB5Token) error {
+	var err error
+
+	n.respMechListMIC, err = exchangeMechListMIC(n.MechListMIC, n.mechTypesRaw, n.MechTypes, mt)
+
+	return err
+}
+
+// exchangeMechListMIC verifies an initiator's mechListMIC against the mechanism list it protects and returns the MIC
+// the acceptor owes in reply, or nil when the initiator sent none and there is no exchange to perform.
+func exchangeMechListMIC(mic, raw []byte, mechTypes []asn1.ObjectIdentifier, mt *KRB5Token) ([]byte, error) {
+	if len(mic) == 0 {
+		return nil, nil
+	}
+
+	key, err := mt.contextKey()
+	if err != nil {
+		return nil, err
+	}
+
+	payload, err := mechListMICPayload(raw, mechTypes)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = verifyMechListMIC(mic, payload, key, false); err != nil {
+		return nil, err
+	}
+
+	return newMechListMIC(payload, key, true)
 }
 
 // Context returns the SPNEGO context which will contain any verify user identity information.
@@ -259,7 +305,33 @@ func (n *NegTokenResp) Verify() (bool, gssapi.Status) {
 		}
 	}
 
-	return mt.Verify()
+	ok, status := mt.Verify()
+	if !ok || status.Code != gssapi.StatusComplete {
+		return ok, status
+	}
+
+	if err := n.exchangeMechListMIC(mt); err != nil {
+		return false, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: err.Error()}
+	}
+
+	return ok, status
+}
+
+// exchangeMechListMIC performs the acceptor's half of the mechListMIC exchange of RFC 4178 Section 5 for a leg
+// continuing an exchange, where the mechanism list the MIC protects arrived earlier and is not in this token.
+//
+// An acceptor with no list retained refuses rather than passes a MIC it cannot check. Accepting one unverified would
+// be indistinguishable, to anyone reading the result, from having verified it.
+func (n *NegTokenResp) exchangeMechListMIC(mt *KRB5Token) error {
+	if len(n.MechListMIC) > 0 && len(n.mechTypesRaw) == 0 && len(n.mechTypes) == 0 {
+		return errors.New("the negotiation carries a mechListMIC but this acceptor did not retain the mechanism list it protects, so it cannot be verified: drive the whole exchange through one SPNEGO value")
+	}
+
+	var err error
+
+	n.respMechListMIC, err = exchangeMechListMIC(n.MechListMIC, n.mechTypesRaw, n.mechTypes, mt)
+
+	return err
 }
 
 // State returns the negotiation state of the negotiation response.
@@ -314,6 +386,7 @@ func UnmarshalNegToken(b []byte) (bool, any, error) {
 			ReqFlags:       n.ReqFlags,
 			MechTokenBytes: n.MechTokenBytes,
 			MechListMIC:    n.MechListMIC,
+			mechTypesRaw:   mechTypeListBytes(a.Bytes),
 		}
 
 		return true, nt, nil
@@ -338,6 +411,21 @@ func UnmarshalNegToken(b []byte) (bool, any, error) {
 	}
 }
 
+// mechTypeListBytes recovers the MechTypeList from the body of a NegTokenInit exactly as it arrived, which is the
+// message a mechListMIC is computed over. It returns nil when the field cannot be read that way, leaving the caller
+// to fall back on re-encoding the decoded list.
+func mechTypeListBytes(b []byte) []byte {
+	var raw struct {
+		MechTypes asn1.RawValue `asn1:"explicit,tag:0"`
+	}
+
+	if _, err := asn1.Unmarshal(b, &raw, asn1.WithUnmarshalAllowTypeGeneralString(true)); err != nil {
+		return nil
+	}
+
+	return raw.MechTypes.Bytes
+}
+
 // NewNegTokenInitKRB5 creates new Init negotiation token for Kerberos 5.
 func NewNegTokenInitKRB5(cl *client.Client, tkt messages.Ticket, sessionKey types.EncryptionKey, opts ...KRB5TokenOption) (NegTokenInit, error) {
 	// The Delegation option is not folded into these flags here: NewKRB5TokenAPREQ does that for every caller, so
@@ -355,7 +443,7 @@ func NewNegTokenInitKRB5(cl *client.Client, tkt messages.Ticket, sessionKey type
 	}
 
 	return NegTokenInit{
-		MechTypes:      []asn1.ObjectIdentifier{gssapi.OIDKRB5.OID()},
+		MechTypes:      initiatorMechTypes(),
 		MechTokenBytes: mtb,
 	}, nil
 }

--- a/spnego/spnego.go
+++ b/spnego/spnego.go
@@ -21,6 +21,9 @@ type SPNEGO struct {
 	client          *client.Client
 	spn             string
 	tokenOptions    []KRB5TokenOption
+	mechListMIC     []byte
+	mechTypes       []asn1.ObjectIdentifier
+	mechTypesRaw    []byte
 }
 
 // SPNEGOClient configures the SPNEGO mechanism suitable for client side use.
@@ -88,27 +91,44 @@ func (s *SPNEGO) AcceptSecContext(ct gssapi.ContextToken) (bool, context.Context
 
 	t.settings = s.serviceSettings
 
-	var oid asn1.ObjectIdentifier
-	if t.Init {
-		if len(t.NegTokenInit.MechTypes) == 0 {
-			return false, ctx, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: "SPNEGO NegTokenInit does not contain any mechanism types"}
-		}
+	if t.Init && len(t.NegTokenInit.MechTypes) == 0 {
+		return false, ctx, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: "SPNEGO NegTokenInit does not contain any mechanism types"}
+	}
 
-		oid = t.NegTokenInit.MechTypes[0]
+	// Which mechanism a NegTokenInit selects is left to NegTokenInit.Verify, which searches the whole of mechTypes
+	// rather than only its first entry. RFC 4178 Section 4.2.2 puts supportedMech "only in the first reply from
+	// the target", so an initiator continuing an exchange names no mechanism here and the mech token decides; a
+	// mechanism that is named and is not Kerberos is refused.
+	if t.Resp && len(t.NegTokenResp.SupportedMech) > 0 && !isKerberosMech(t.NegTokenResp.SupportedMech) {
+		return false, ctx, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: "SPNEGO OID of MechToken is not of type KRB5"}
 	}
 
 	if t.Resp {
-		oid = t.NegTokenResp.SupportedMech
+		t.NegTokenResp.mechTypes, t.NegTokenResp.mechTypesRaw = s.mechTypes, s.mechTypesRaw
 	}
 
-	if len(oid) > 0 && !isKerberosMech(oid) {
-		return false, ctx, gssapi.Status{Code: gssapi.StatusDefectiveToken, Message: "SPNEGO OID of MechToken is not of type KRB5"}
-	}
-	// Flags in the NegInit must be used 	t.NegTokenInit.ReqFlags.
+	// RFC 4178 Section 4.2.1 says of reqFlags that "the acceptor MUST ignore this reqFlags field", which is why
+	// t.NegTokenInit.ReqFlags is read nowhere: it is not integrity protected and carries no authority.
 	ok, status := t.Verify()
 	ctx = t.Context()
 
+	if t.Init {
+		s.mechListMIC = t.NegTokenInit.respMechListMIC
+		// The list is kept whatever the outcome, because the leg that offers it is the only one that carries it
+		// and a mechListMIC on a later leg protects it.
+		s.mechTypes, s.mechTypesRaw = t.NegTokenInit.MechTypes, t.NegTokenInit.mechTypesRaw
+	} else {
+		s.mechListMIC = t.NegTokenResp.respMechListMIC
+	}
+
 	return ok, ctx, status
+}
+
+// MechListMIC returns the mechListMIC this acceptor owes the initiator in its reply to the negotiation token it
+// last accepted, or nil when no MIC was exchanged. RFC 4178 Section 5(c)(I) requires one whenever the initiator
+// supplied one, and has the initiator verify it.
+func (s *SPNEGO) MechListMIC() []byte {
+	return s.mechListMIC
 }
 
 // Log will write to the service's logger if it is configured.


### PR DESCRIPTION
RFC 4178 section 4.2.2 has the acceptor name the mechanism it selected and ask for another leg, but this one required kerberos to be the first entry in mechTypes and so refused a Windows client offering NegoEx or NTLM ahead of it, and the http client read a challenge only when WWW-Authenticate held the bare word Negotiate, so it ended an exchange the target had asked to continue. Section 5 then requires the mechListMIC exchange once a mechanism other than the initiator's first choice can be selected, and nothing computed or verified one: a mechListMIC was accepted whatever it held, leaving the mechanism list rewritable in flight. It is now checked against the list it protects and answered with the acceptor's own, a continuation leg whose acceptor no longer holds that list is refused rather than passed unverified, and the client answers accept-incomplete with a fresh AP_REQ and request-mic per section 5c.