### PR TITLE
fix(service): key the replay cache on the whole authenticator tuple

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.cap
 *.raw
 
+specs/
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -98,3 +98,20 @@ change will be elaborated on in time):
   that its forwarded ticket was discarded, so accepting the request while dropping the credential would leave the
   initiator believing a delegation happened that did not. Services that must keep authenticating such clients need
   those clients fixed or the encryption type registered with `crypto.AddEType`.
+- `service.Cache.IsReplay` and `service.Cache.AddEntry` take the service principal's realm as a new second argument,
+  `IsReplay(sname types.PrincipalName, srealm string, a types.Authenticator)`, and the replay cache is now keyed on
+  the whole tuple RFC 4120 §3.2.3 describes: the client name and realm, the service name and realm, and the
+  authenticator's `ctime` and `cusec`. Previously an entry was keyed on the client and the time alone, with the
+  service name held as its value and compared on lookup, so a presentation under a second service name both failed
+  to match the stored entry and *replaced* it — which §3.2.3 forbids: "If a server loses track of authenticators
+  presented within the allowable clock skew, it MUST reject all requests until the clock skew interval has passed."
+  Callers of these two methods must add the argument; there is no compatibility shim, because silently keying on an
+  empty realm would reintroduce the collision between a service principal registered in more than one realm.
+
+  `service.VerifyAPREQ` additionally now records a presentation against the service principal whose key **decrypted**
+  the ticket rather than against the `SName` the ticket carries in its unencrypted portion. Where
+  `service.KeytabPrincipal` overrides the keytab lookup those differ, and the ticket's copy is covered by no
+  checksum, so a captured AP-REQ could be replayed indefinitely by rewriting it: each rewrite missed the entry that
+  should have caught it and displaced that entry for the next attempt. Deployments using `KeytabPrincipal` had no
+  working replay protection at all. No configuration change is needed to pick the fix up, and without the override
+  the two values are identical, so nothing changes for acceptors that do not set it.

--- a/service/ap_exchange.go
+++ b/service/ap_exchange.go
@@ -39,8 +39,10 @@ func VerifyAPREQ(APReq *messages.APReq, s *Settings) (bool, *credentials.Credent
 	}
 
 	// Check for replay.
+	sname, srealm := replayCacheService(&APReq.Ticket, s)
+
 	rc := GetReplayCache(s.MaxClockSkew())
-	if rc.IsReplay(APReq.Ticket.SName, APReq.Authenticator) {
+	if rc.IsReplay(sname, srealm, APReq.Authenticator) {
 		return false, creds,
 			messages.NewKRBError(APReq.Ticket.SName, APReq.Ticket.Realm, errorcode.KRB_AP_ERR_REPEAT, "replay detected")
 	}
@@ -81,6 +83,26 @@ func VerifyAPREQ(APReq *messages.APReq, s *Settings) (bool, *credentials.Credent
 	}
 
 	return true, creds, nil
+}
+
+// replayCacheService returns the service principal a presentation is recorded against, which RFC 4120 Section 3.2.3
+// stores "along with the client name, time, and microsecond fields from the recently-seen authenticators".
+//
+// It is the principal whose key actually decrypted the ticket, which is not always the one the ticket names.
+// Ticket.SName sits outside the KDC-sealed EncTicketPart and is covered by no checksum, and where KeytabPrincipal
+// overrides the keytab lookup it is consulted for nothing else at all. Keying the replay cache on it there would let
+// a captured AP_REQ be replayed indefinitely by rewriting it, each rewrite both missing the entry that should have
+// caught it and displacing that entry for the next attempt.
+//
+// Without the override the two are the same value: DecryptEncPart resolved the key by that name and realm, so a
+// ticket naming anything else would not have decrypted. The realm is taken from the ticket in both cases for the
+// same reason, since it selects the key whether or not the name is overridden.
+func replayCacheService(tkt *messages.Ticket, s *Settings) (sname types.PrincipalName, srealm string) {
+	if kp := s.KeytabPrincipal(); kp != nil {
+		return *kp, tkt.Realm
+	}
+
+	return tkt.SName, tkt.Realm
 }
 
 // ErrBadChannelBinding identifies a channel binding verification failure. RFC 2743 Section 2.2.2 gives this failure

--- a/service/ap_exchange_test.go
+++ b/service/ap_exchange_test.go
@@ -1090,3 +1090,93 @@ func resealEncTicketPart(t *testing.T, etp messages.EncTicketPart, kt *keytab.Ke
 
 	return ed
 }
+
+// TestVerifyAPREQ_ReplayWithRewrittenTicketSName covers the replay cache being keyed on the ticket's plaintext
+// service name. That field sits outside the KDC-sealed EncTicketPart and is covered by no checksum, and when
+// KeytabPrincipal overrides the keytab lookup it is used for nothing else, so rewriting it must not change whether
+// an authenticator is recognised as one that has already been presented.
+//
+// RFC 4120 Section 3.2.3 requires as much: "If a server loses track of authenticators presented within the allowable
+// clock skew, it MUST reject all requests until the clock skew interval has passed".
+func TestVerifyAPREQ_ReplayWithRewrittenTicketSName(t *testing.T) {
+	sname := types.PrincipalName{
+		NameType:   nametype.KRB_NT_PRINCIPAL,
+		NameString: []string{"HTTP", "host.test.gokrb5"},
+	}
+
+	b, err := hex.DecodeString(testdata.HTTP_KEYTAB)
+	require.NoError(t, err)
+
+	kt := keytab.New()
+	require.NoError(t, kt.Unmarshal(b))
+
+	// A client name of this test's own, so that the process wide replay cache singleton cannot be perturbed by
+	// another test presenting an authenticator for the same principal.
+	cname := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, "replayrewriteuser")
+
+	st := time.Now().UTC()
+
+	tkt, sessionKey, err := messages.NewTicket(cname, "TEST.GOKRB5",
+		sname, "TEST.GOKRB5",
+		types.NewKrbFlags(),
+		kt,
+		18,
+		1,
+		st,
+		st,
+		st.Add(time.Duration(24)*time.Hour),
+		st.Add(time.Duration(48)*time.Hour),
+	)
+	require.NoError(t, err)
+
+	auth, err := types.NewAuthenticator("TEST.GOKRB5", cname)
+	require.NoError(t, err)
+
+	apReq, err := messages.NewAPReq(tkt, sessionKey, auth)
+	require.NoError(t, err)
+
+	// Captured off the wire before anything decrypts it, which is what an attacker replays.
+	wire, err := apReq.Marshal()
+	require.NoError(t, err)
+
+	h, _ := types.GetHostAddress("127.0.0.1:1234")
+	s := NewSettings(kt, ClientAddress(h), KeytabPrincipal("HTTP/host.test.gokrb5"))
+
+	verify := func(t *testing.T, b []byte) (bool, error) {
+		t.Helper()
+
+		var a messages.APReq
+		require.NoError(t, a.Unmarshal(b))
+
+		ok, _, err := VerifyAPREQ(&a, s)
+
+		return ok, err
+	}
+
+	ok, err := verify(t, wire)
+	require.NoError(t, err)
+	require.True(t, ok, "the first presentation is not a replay")
+
+	ok, err = verify(t, wire)
+	require.False(t, ok)
+	require.EqualError(t, err, "KRB Error: (34) KRB_AP_ERR_REPEAT Request is a replay - replay detected")
+
+	// The same AP_REQ with the ticket's plaintext service name rewritten. The override means the keytab lookup
+	// never consults it, so the ticket still decrypts and the authenticator is still the one already presented.
+	var tampered messages.APReq
+	require.NoError(t, tampered.Unmarshal(wire))
+
+	tampered.Ticket.SName = types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, "HTTP/anything-at-all")
+
+	tamperedWire, err := tampered.Marshal()
+	require.NoError(t, err)
+
+	ok, err = verify(t, tamperedWire)
+	assert.False(t, ok, "rewriting the ticket's unauthenticated SName must not defeat replay detection")
+	assert.EqualError(t, err, "KRB Error: (34) KRB_AP_ERR_REPEAT Request is a replay - replay detected")
+
+	// And the original must still be recognised: answering the rewritten one must not have displaced its entry.
+	ok, err = verify(t, wire)
+	assert.False(t, ok, "the entry for the original presentation must survive a presentation under another name")
+	assert.EqualError(t, err, "KRB Error: (34) KRB_AP_ERR_REPEAT Request is a replay - replay detected")
+}

--- a/service/cache.go
+++ b/service/cache.go
@@ -19,24 +19,48 @@ type Cache struct {
 
 // clientEntries holds entries of client details sent to the service.
 type clientEntries struct {
-	replayMap map[time.Time]replayCacheEntry
+	replayMap map[replayKey]replayCacheEntry
 	seqNumber int64
 	subKey    types.EncryptionKey
 }
 
-// Cache entry tracking client time values of tickets sent to the service.
+// replayKey identifies one presentation of an authenticator to one service.
+//
+// RFC 4120 Section 3.2.3 has the cache "store at least the server name, along with the client name, time, and
+// microsecond fields from the recently-seen authenticators, and if a matching tuple is found, the KRB_AP_ERR_REPEAT
+// error is returned". The client name and realm choose the clientEntries this is looked up in; the rest of that
+// tuple is here.
+//
+// The server name and realm are part of the key rather than of the value. The same section requires that losing
+// track of a presentation reject rather than admit — "If a server loses track of authenticators presented within
+// the allowable clock skew, it MUST reject all requests until the clock skew interval has passed" — and a value can
+// be displaced by the next presentation under a different server name where a key cannot.
+type replayKey struct {
+	cTime  time.Time
+	sName  string
+	sRealm string
+}
+
+// Cache entry tracking when a presentation was seen, so that ClearOldEntries can retire it.
 type replayCacheEntry struct {
 	presentedTime time.Time
-
-	sName types.PrincipalName
-
-	// This combines the ticket's CTime and Cusec.
-	cTime time.Time
 }
 
 // clientKey identifies the client an entry belongs to.
 func clientKey(cname types.PrincipalName, crealm string) string {
 	return fmt.Sprintf("%q@%q", cname.PrincipalNameString(), crealm)
+}
+
+// newReplayKey identifies the presentation of the authenticator to the service named by sname in srealm.
+//
+// The name is compared by its components only, as PrincipalName.Equal does, because RFC 4120 Section 6.2 makes the
+// name type insignificant when comparing principal names.
+func newReplayKey(sname types.PrincipalName, srealm string, a types.Authenticator) replayKey {
+	return replayKey{
+		cTime:  a.CTime.Add(time.Duration(a.Cusec) * time.Microsecond).UTC(),
+		sName:  sname.PrincipalNameString(),
+		sRealm: srealm,
+	}
 }
 
 // getClientEntries returns the entries held for a client. The caller must hold at least the read lock.
@@ -71,27 +95,26 @@ func GetReplayCache(d time.Duration) *Cache {
 	return &replayCache
 }
 
-// AddEntry adds an entry to the Cache.
-func (c *Cache) AddEntry(sname types.PrincipalName, a types.Authenticator) {
+// AddEntry adds an entry to the Cache, recording that a was presented to the service named by sname in srealm.
+//
+// sname and srealm must identify the service principal whose key decrypted the ticket, not the service the ticket
+// claims in its unencrypted portion; see IsReplay.
+func (c *Cache) AddEntry(sname types.PrincipalName, srealm string, a types.Authenticator) {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
-	c.addEntry(sname, a)
+	c.addEntry(sname, srealm, a)
 }
 
 // addEntry records an authenticator against its client. The caller must hold the write lock.
-func (c *Cache) addEntry(sname types.PrincipalName, a types.Authenticator) {
-	ct := a.CTime.Add(time.Duration(a.Cusec) * time.Microsecond)
-
+func (c *Cache) addEntry(sname types.PrincipalName, srealm string, a types.Authenticator) {
 	ce, ok := c.getClientEntries(a.CName, a.CRealm)
 	if !ok {
-		ce = clientEntries{replayMap: make(map[time.Time]replayCacheEntry)}
+		ce = clientEntries{replayMap: make(map[replayKey]replayCacheEntry)}
 	}
 
-	ce.replayMap[ct] = replayCacheEntry{
+	ce.replayMap[newReplayKey(sname, srealm, a)] = replayCacheEntry{
 		presentedTime: time.Now().UTC(),
-		sName:         sname,
-		cTime:         ct,
 	}
 	ce.seqNumber = a.SeqNumber
 	ce.subKey = a.SubKey
@@ -119,21 +142,26 @@ func (c *Cache) ClearOldEntries(d time.Duration) {
 	}
 }
 
-// IsReplay tests if the Authenticator provided is a replay within the duration defined. If this is not a replay
-// the entry is added to the cache for tracking.
-func (c *Cache) IsReplay(sname types.PrincipalName, a types.Authenticator) bool {
-	ct := a.CTime.Add(time.Duration(a.Cusec) * time.Microsecond)
+// IsReplay tests if the Authenticator provided has already been presented to the service named by sname in srealm
+// within the duration defined. If this is not a replay the entry is added to the cache for tracking.
+//
+// sname and srealm must identify the service principal whose key decrypted the ticket the authenticator arrived in,
+// which is the ticket's SName and Realm only where those chose the key. A ticket's unencrypted portion is covered
+// by no checksum, so keying the cache on what it claims would let a captured AP_REQ be replayed indefinitely by
+// rewriting the claim — see service.VerifyAPREQ, which resolves this before calling.
+func (c *Cache) IsReplay(sname types.PrincipalName, srealm string, a types.Authenticator) bool {
+	k := newReplayKey(sname, srealm, a)
 
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
 	if ce, ok := c.getClientEntries(a.CName, a.CRealm); ok {
-		if e, ok := ce.replayMap[ct]; ok && e.sName.Equal(sname) {
+		if _, ok := ce.replayMap[k]; ok {
 			return true
 		}
 	}
 
-	c.addEntry(sname, a)
+	c.addEntry(sname, srealm, a)
 
 	return false
 }

--- a/service/cache_test.go
+++ b/service/cache_test.go
@@ -20,9 +20,9 @@ func TestIsReplayAcceptsOnceAndRejectsAfter(t *testing.T) {
 	sname := types.NewPrincipalName(nametype.KRB_NT_SRV_INST, "HTTP/host.test.gokrb5")
 	a := testAuthenticator("testuser", "TEST.GOKRB5", time.Now().UTC())
 
-	assert.False(t, c.IsReplay(sname, a), "the first presentation is not a replay")
-	assert.True(t, c.IsReplay(sname, a), "the second presentation of the same authenticator is a replay")
-	assert.True(t, c.IsReplay(sname, a), "and so is the third")
+	assert.False(t, c.IsReplay(sname, testSRealm, a), "the first presentation is not a replay")
+	assert.True(t, c.IsReplay(sname, testSRealm, a), "the second presentation of the same authenticator is a replay")
+	assert.True(t, c.IsReplay(sname, testSRealm, a), "and so is the third")
 }
 
 func TestIsReplayIsAtomicUnderConcurrency(t *testing.T) {
@@ -56,7 +56,7 @@ func TestIsReplayIsAtomicUnderConcurrency(t *testing.T) {
 
 				<-release
 
-				if !c.IsReplay(sname, a) {
+				if !c.IsReplay(sname, testSRealm, a) {
 					mu.Lock()
 					fresh++
 					mu.Unlock()
@@ -81,12 +81,12 @@ func TestIsReplayDistinguishesClientRealms(t *testing.T) {
 	sname := types.NewPrincipalName(nametype.KRB_NT_SRV_INST, "HTTP/host.test.gokrb5")
 	ct := time.Now().UTC()
 
-	assert.False(t, c.IsReplay(sname, testAuthenticator("collide", "REALM-A.GOKRB5", ct)))
-	assert.False(t, c.IsReplay(sname, testAuthenticator("collide", "REALM-B.GOKRB5", ct)),
+	assert.False(t, c.IsReplay(sname, testSRealm, testAuthenticator("collide", "REALM-A.GOKRB5", ct)))
+	assert.False(t, c.IsReplay(sname, testSRealm, testAuthenticator("collide", "REALM-B.GOKRB5", ct)),
 		"a different realm is a different principal, not a replay")
 
-	assert.True(t, c.IsReplay(sname, testAuthenticator("collide", "REALM-A.GOKRB5", ct)))
-	assert.True(t, c.IsReplay(sname, testAuthenticator("collide", "REALM-B.GOKRB5", ct)))
+	assert.True(t, c.IsReplay(sname, testSRealm, testAuthenticator("collide", "REALM-A.GOKRB5", ct)))
+	assert.True(t, c.IsReplay(sname, testSRealm, testAuthenticator("collide", "REALM-B.GOKRB5", ct)))
 }
 
 func TestIsReplayDistinguishesServices(t *testing.T) {
@@ -95,8 +95,8 @@ func TestIsReplayDistinguishesServices(t *testing.T) {
 	c := newTestCache()
 	a := testAuthenticator("testuser", "TEST.GOKRB5", time.Now().UTC())
 
-	assert.False(t, c.IsReplay(types.NewPrincipalName(nametype.KRB_NT_SRV_INST, "HTTP/one.test.gokrb5"), a))
-	assert.False(t, c.IsReplay(types.NewPrincipalName(nametype.KRB_NT_SRV_INST, "HTTP/two.test.gokrb5"), a))
+	assert.False(t, c.IsReplay(types.NewPrincipalName(nametype.KRB_NT_SRV_INST, "HTTP/one.test.gokrb5"), testSRealm, a))
+	assert.False(t, c.IsReplay(types.NewPrincipalName(nametype.KRB_NT_SRV_INST, "HTTP/two.test.gokrb5"), testSRealm, a))
 }
 
 func TestClearOldEntriesRemovesExpiredAndKeepsCurrent(t *testing.T) {
@@ -106,7 +106,7 @@ func TestClearOldEntriesRemovesExpiredAndKeepsCurrent(t *testing.T) {
 	sname := types.NewPrincipalName(nametype.KRB_NT_SRV_INST, "HTTP/host.test.gokrb5")
 
 	old := testAuthenticator("olduser", "TEST.GOKRB5", time.Now().UTC())
-	require.False(t, c.IsReplay(sname, old))
+	require.False(t, c.IsReplay(sname, testSRealm, old))
 
 	c.mux.Lock()
 	for k, ce := range c.entries {
@@ -120,12 +120,12 @@ func TestClearOldEntriesRemovesExpiredAndKeepsCurrent(t *testing.T) {
 	c.mux.Unlock()
 
 	current := testAuthenticator("currentuser", "TEST.GOKRB5", time.Now().UTC())
-	require.False(t, c.IsReplay(sname, current))
+	require.False(t, c.IsReplay(sname, testSRealm, current))
 
 	c.ClearOldEntries(time.Minute)
 
-	assert.False(t, c.IsReplay(sname, old), "the expired entry should have been cleared")
-	assert.True(t, c.IsReplay(sname, current), "the current entry should have been kept")
+	assert.False(t, c.IsReplay(sname, testSRealm, old), "the expired entry should have been cleared")
+	assert.True(t, c.IsReplay(sname, testSRealm, current), "the current entry should have been kept")
 }
 
 func TestIsReplayIsRaceFree(t *testing.T) {
@@ -145,7 +145,7 @@ func TestIsReplayIsRaceFree(t *testing.T) {
 			for j := range 32 {
 				a := testAuthenticator(fmt.Sprintf("user%d", i), "TEST.GOKRB5",
 					time.Now().UTC().Add(time.Duration(j)*time.Millisecond))
-				c.IsReplay(sname, a)
+				c.IsReplay(sname, testSRealm, a)
 			}
 		}(i)
 	}
@@ -160,6 +160,41 @@ func TestClientKeyDoesNotCollideAcrossNameAndRealm(t *testing.T) {
 
 	assert.NotEqual(t, a, b, "a name containing the separator must not collide with a name plus realm")
 }
+
+func TestIsReplayKeepsAnEntryWhenAnotherServiceIsPresented(t *testing.T) {
+	t.Parallel()
+
+	c := newTestCache()
+	a := testAuthenticator("evicteduser", "TEST.GOKRB5", time.Now().UTC())
+
+	one := types.NewPrincipalName(nametype.KRB_NT_SRV_INST, "HTTP/one.test.gokrb5")
+	two := types.NewPrincipalName(nametype.KRB_NT_SRV_INST, "HTTP/two.test.gokrb5")
+
+	require.False(t, c.IsReplay(one, testSRealm, a), "the first presentation is not a replay")
+	require.False(t, c.IsReplay(two, testSRealm, a), "a different service is a different presentation, not a replay")
+
+	assert.True(t, c.IsReplay(one, testSRealm, a), "the entry for the first service must survive the second being recorded")
+	assert.True(t, c.IsReplay(two, testSRealm, a))
+}
+
+func TestIsReplayDistinguishesServiceRealms(t *testing.T) {
+	t.Parallel()
+
+	c := newTestCache()
+	sname := types.NewPrincipalName(nametype.KRB_NT_SRV_INST, "HTTP/host.test.gokrb5")
+	a := testAuthenticator("crossrealmuser", "TEST.GOKRB5", time.Now().UTC())
+
+	// RFC 4120 Section 3.2.3: a server may be "registered in multiple realms, with different keys in each", so the
+	// same name in two realms is two service principals, not one.
+	require.False(t, c.IsReplay(sname, "REALM-A.GOKRB5", a))
+	assert.False(t, c.IsReplay(sname, "REALM-B.GOKRB5", a),
+		"the same service name in another realm is another principal, not a replay")
+
+	assert.True(t, c.IsReplay(sname, "REALM-A.GOKRB5", a))
+	assert.True(t, c.IsReplay(sname, "REALM-B.GOKRB5", a))
+}
+
+const testSRealm = "TEST.GOKRB5"
 
 func newTestCache() *Cache {
 	return &Cache{entries: make(map[string]clientEntries)}


### PR DESCRIPTION
The replay map was keyed on the client and the authenticator time alone, holding the service name as its value and comparing it on lookup. A presentation under a second service name therefore missed the stored entry and overwrote it, so the first authenticator was accepted again.

VerifyAPREQ passed the SName from the ticket's unencrypted portion, which no checksum covers and which KeytabPrincipal makes irrelevant to key selection. Where that option is set, a captured AP_REQ could be replayed indefinitely by rewriting the name: each rewrite missed the entry that should have caught it and displaced it for the next attempt.

Key on the tuple RFC 4120 section 3.2.3 describes, and record a presentation against the principal whose key decrypted the ticket.

BREAKING CHANGE: service.Cache.IsReplay and service.Cache.AddEntry take the service realm as a new second argument.