### PR TITLE
fix(keytab): keep key material out of parse errors

### DIFF
--- a/keytab/keytab.go
+++ b/keytab/keytab.go
@@ -277,7 +277,7 @@ func (kt *Keytab) Unmarshal(b []byte) error {
 			}
 
 			if n+int(l) > len(b) {
-				return fmt.Errorf("%s's length is less than %d", b, n+int(l))
+				return fmt.Errorf("keytab is %d bytes, cannot read an entry of %d at offset %d", len(b), l, n)
 			}
 
 			eb := b[n : n+int(l)]
@@ -532,7 +532,7 @@ func readInt8(b []byte, p *int, e *binary.ByteOrder) (i int8, err error) {
 	}
 
 	if (*p + 1) > len(b) {
-		return 0, fmt.Errorf("%s's length is less than %d", b, *p+1)
+		return 0, fmt.Errorf("keytab is %d bytes, cannot read %d at offset %d", len(b), 1, *p)
 	}
 
 	buf := bytes.NewBuffer(b[*p : *p+1])
@@ -553,7 +553,7 @@ func readInt16(b []byte, p *int, e *binary.ByteOrder) (i int16, err error) {
 	}
 
 	if (*p + 2) > len(b) {
-		return 0, fmt.Errorf("%s's length is less than %d", b, *p+2)
+		return 0, fmt.Errorf("keytab is %d bytes, cannot read %d at offset %d", len(b), 2, *p)
 	}
 
 	buf := bytes.NewBuffer(b[*p : *p+2])
@@ -574,7 +574,7 @@ func readInt32(b []byte, p *int, e *binary.ByteOrder) (i int32, err error) {
 	}
 
 	if (*p + 4) > len(b) {
-		return 0, fmt.Errorf("%s's length is less than %d", b, *p+4)
+		return 0, fmt.Errorf("keytab is %d bytes, cannot read %d at offset %d", len(b), 4, *p)
 	}
 
 	buf := bytes.NewBuffer(b[*p : *p+4])
@@ -596,7 +596,7 @@ func readBytes(b []byte, p *int, s int, e *binary.ByteOrder) ([]byte, error) {
 	i := *p + s
 
 	if i > len(b) {
-		return nil, fmt.Errorf("%s's length is greater than %d", b, i)
+		return nil, fmt.Errorf("keytab is %d bytes, cannot read %d at offset %d", len(b), s, *p)
 	}
 
 	buf := bytes.NewBuffer(b[*p:i])

--- a/keytab/keytab_test.go
+++ b/keytab/keytab_test.go
@@ -127,7 +127,7 @@ func TestReadBytes(t *testing.T) {
 	var err error
 
 	_, err = readBytes(nil, &p, 1, &endian)
-	assert.EqualError(t, err, "'s length is greater than 1")
+	assert.EqualError(t, err, "keytab is 0 bytes, cannot read 1 at offset 0")
 
 	_, err = readBytes(nil, &p, -1, &endian)
 	assert.EqualError(t, err, "-1 cannot be less than zero")
@@ -262,4 +262,64 @@ func TestKeytab_GetEncryptionKeyWithIdenticalTimestamps(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, 3, kvno)
+}
+
+func TestUnmarshalErrorsShouldNotContainKeyMaterial(t *testing.T) {
+	t.Parallel()
+
+	kt := New()
+	require.NoError(t, kt.AddEntry("HTTP/host.test.gokrb5", "TEST.GOKRB5", "passwordvalue",
+		time.Now().UTC(), 1, etypeID.AES256_CTS_HMAC_SHA1_96))
+
+	b, err := kt.Marshal()
+	require.NoError(t, err)
+
+	key := kt.Entries[0].Key.KeyValue
+	require.Len(t, key, 32)
+
+	var errs int
+
+	for n := 1; n < len(b); n++ {
+		var got Keytab
+
+		err := got.Unmarshal(b[:n])
+		if err == nil {
+			continue
+		}
+
+		errs++
+
+		assert.NotContains(t, err.Error(), string(key[:8]),
+			"the error from a keytab truncated to %d bytes carries the entry's key", n)
+	}
+
+	require.Positive(t, errs, "the truncated keytabs must produce errors for this to be testing anything")
+}
+
+func TestReaderErrorsShouldNotContainTheBuffer(t *testing.T) {
+	t.Parallel()
+
+	var endian binary.ByteOrder = binary.BigEndian
+
+	const secret = "SUPER-SECRET-KEY-MATERIAL"
+
+	b := []byte(secret)
+
+	for name, read := range map[string]func(p *int) error{
+		"readInt8":  func(p *int) error { _, err := readInt8(b, p, &endian); return err },
+		"readInt16": func(p *int) error { _, err := readInt16(b, p, &endian); return err },
+		"readInt32": func(p *int) error { _, err := readInt32(b, p, &endian); return err },
+		"readBytes": func(p *int) error { _, err := readBytes(b, p, len(b), &endian); return err },
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			p := len(b)
+
+			err := read(&p)
+
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), secret, "the error carries the buffer it was reading")
+		})
+	}
 }


### PR DESCRIPTION
Five errors raised while parsing a keytab formatted the whole buffer with %s, so every long term key in the file landed in the error string. A keytab that will not parse is exactly the condition an operator logs, which put the keys in the log with it.

Report the buffer length, the read size and the offset instead. The messages say more than they did: a truncated file now reports "keytab is 90 bytes, cannot read an entry of 88 at offset 6" rather than rendering itself as text.