### PR TITLE
fix(messages): keep the decrypted part out of the wire encoding

### DIFF
--- a/messages/krb_priv.go
+++ b/messages/krb_priv.go
@@ -16,6 +16,16 @@ import (
 	"github.com/go-krb5/krb5/types"
 )
 
+// marshalKRBPriv is the wire form of a KRBPriv: the fields RFC 4120 Section 5.7.1 defines, and nothing else. See
+// marshalTicket in ticket.go for why the decrypted part cannot be a tagged field of the type callers hold.
+type marshalKRBPriv struct {
+	PVNO int `asn1:"explicit,tag:0"`
+
+	MsgType int `asn1:"explicit,tag:1"`
+
+	EncPart types.EncryptedData `asn1:"explicit,tag:3"`
+}
+
 // KRBPriv implements RFC 4120 type: https://tools.ietf.org/html/rfc4120#section-5.7.1.
 type KRBPriv struct {
 	PVNO int `asn1:"explicit,tag:0"`
@@ -24,8 +34,7 @@ type KRBPriv struct {
 
 	EncPart types.EncryptedData `asn1:"explicit,tag:3"`
 
-	// Not part of ASN1 bytes so marked as optional so unmarshalling works.
-	DecryptedEncPart EncKrbPrivPart `asn1:"optional,omitempty"`
+	DecryptedEncPart EncKrbPrivPart
 }
 
 // EncKrbPrivPart is the encrypted part of KRB_PRIV.
@@ -49,10 +58,14 @@ func NewKRBPriv(part EncKrbPrivPart) KRBPriv {
 
 // Unmarshal bytes b into the KRBPriv struct.
 func (k *KRBPriv) Unmarshal(b []byte) error {
-	_, err := asn1.UnmarshalWithParams(b, k, fmt.Sprintf("application,explicit,tag:%v", asn1apptag.KRBPriv))
+	var m marshalKRBPriv
+
+	_, err := asn1.UnmarshalWithParams(b, &m, fmt.Sprintf("application,explicit,tag:%v", asn1apptag.KRBPriv))
 	if err != nil {
 		return processUnmarshalReplyError(b, err)
 	}
+
+	*k = KRBPriv{PVNO: m.PVNO, MsgType: m.MsgType, EncPart: m.EncPart}
 
 	expectedMsgType := msgtype.KRB_PRIV
 	if k.MsgType != expectedMsgType {
@@ -74,7 +87,7 @@ func (k *EncKrbPrivPart) Unmarshal(b []byte) error {
 
 // Marshal the KRBPriv.
 func (k *KRBPriv) Marshal() ([]byte, error) {
-	tk := KRBPriv{
+	tk := marshalKRBPriv{
 		PVNO:    k.PVNO,
 		MsgType: k.MsgType,
 		EncPart: k.EncPart,

--- a/messages/krb_priv_test.go
+++ b/messages/krb_priv_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-krb5/x/encoding/asn1"
+
 	"github.com/go-krb5/krb5/iana"
 	"github.com/go-krb5/krb5/iana/addrtype"
 	"github.com/go-krb5/krb5/iana/msgtype"
@@ -117,4 +119,24 @@ func TestKRBPriv_EncryptEncPart(t *testing.T) {
 	}
 
 	require.NoError(t, a.EncryptEncPart(key))
+}
+
+func TestKRBPrivUnmarshalShouldNotAcceptADecryptedEncPart(t *testing.T) {
+	t.Parallel()
+
+	b, err := hex.DecodeString(testdata.MarshaledKRB5priv)
+	require.NoError(t, err)
+
+	forged, err := asn1.Marshal(EncKrbPrivPart{
+		UserData: []byte("attacker supplied"),
+		SAddress: types.HostAddress{AddrType: addrtype.IPv4, Address: []byte{127, 0, 0, 1}},
+	}, asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
+	require.NoError(t, err)
+
+	var k KRBPriv
+
+	if err := k.Unmarshal(appendToSequence(t, b, forged)); err == nil {
+		assert.Empty(t, k.DecryptedEncPart.UserData,
+			"user data appended to the wire message became its decrypted part")
+	}
 }

--- a/messages/ticket.go
+++ b/messages/ticket.go
@@ -25,6 +25,23 @@ import (
 // Reference: https://www.ietf.org/rfc/rfc4120.txt
 // Section: 5.3.
 
+// marshalTicket is the wire form of a Ticket: the four fields RFC 4120 Section 5.3 defines, and nothing else.
+//
+// Ticket itself carries DecryptedEncPart for the convenience of callers, and that field must take no part in the
+// encoding in either direction. Marshalling it appends the plaintext, session key and all, to a ticket about to go
+// on the wire; unmarshalling into it lets a peer append an element and have it read back as a decrypted part the
+// KDC never sealed. Tagging it optional does not keep it out of the SEQUENCE, it only makes it skippable, which is
+// why the separation has to be a distinct type. Every other message in this package has the same twin.
+type marshalTicket struct {
+	TktVNO int `asn1:"explicit,tag:0"`
+
+	Realm string `asn1:"general,explicit,tag:1"`
+
+	SName types.PrincipalName `asn1:"explicit,tag:2"`
+
+	EncPart types.EncryptedData `asn1:"explicit,tag:3"`
+}
+
 // Ticket implements the Kerberos ticket.
 type Ticket struct {
 	TktVNO int `asn1:"explicit,tag:0"`
@@ -35,8 +52,10 @@ type Ticket struct {
 
 	EncPart types.EncryptedData `asn1:"explicit,tag:3"`
 
-	// Not part of ASN1 bytes so marked as optional so unmarshalling works.
-	DecryptedEncPart EncTicketPart `asn1:"optional"`
+	// Filled in by Decrypt and DecryptEncPart, and deliberately untagged: this type is never handed to the asn1
+	// encoder, marshalTicket is. Note that no struct tag would exclude it if it were, this fork having no "-"
+	// param, which is what made the previous "optional" tag misleading rather than protective.
+	DecryptedEncPart EncTicketPart
 }
 
 // EncTicketPart is the encrypted part of the Ticket.
@@ -112,14 +131,34 @@ func NewTicket(cname types.PrincipalName, crealm string, sname types.PrincipalNa
 }
 
 // Unmarshal bytes b into a Ticket struct.
+//
+// The receiver is replaced rather than filled in, so that unmarshalling one ticket over another does not leave the
+// previous ticket's decrypted part behind for a caller to read as though it belonged to this one.
 func (t *Ticket) Unmarshal(b []byte) error {
-	_, err := asn1.UnmarshalWithParams(b, t, fmt.Sprintf("application,explicit,tag:%d", asn1apptag.Ticket))
-	return err
+	var m marshalTicket
+
+	if _, err := asn1.UnmarshalWithParams(b, &m, fmt.Sprintf("application,explicit,tag:%d", asn1apptag.Ticket)); err != nil {
+		return err
+	}
+
+	*t = Ticket{
+		TktVNO:  m.TktVNO,
+		Realm:   m.Realm,
+		SName:   m.SName,
+		EncPart: m.EncPart,
+	}
+
+	return nil
 }
 
 // Marshal the Ticket.
 func (t *Ticket) Marshal() ([]byte, error) {
-	b, err := asn1.Marshal(*t, asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
+	b, err := asn1.Marshal(marshalTicket{
+		TktVNO:  t.TktVNO,
+		Realm:   t.Realm,
+		SName:   t.SName,
+		EncPart: t.EncPart,
+	}, asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
 	if err != nil {
 		return nil, err
 	}

--- a/messages/ticket_test.go
+++ b/messages/ticket_test.go
@@ -268,3 +268,117 @@ func TestGetPACType_NilLogger(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+// appendToSequence returns b, an [APPLICATION n] wrapping a SEQUENCE, with extra appended inside that SEQUENCE. It
+// is how a peer smuggles an element the type does not define past a decoder that tolerates trailing data.
+func appendToSequence(t *testing.T, b, extra []byte) []byte {
+	t.Helper()
+
+	lenBytes := func(n int) []byte {
+		if n < 128 {
+			//nolint:gosec // G115: guarded by the branch, n is below 128.
+			return []byte{byte(n)}
+		}
+
+		var l []byte
+		for m := n; m > 0; m >>= 8 {
+			l = append([]byte{byte(m & 0xff)}, l...)
+		}
+
+		//nolint:gosec // G115: l holds one octet per byte of an int, so its length cannot exceed 8.
+		return append([]byte{byte(0x80 | len(l))}, l...)
+	}
+
+	hdr := func(p int) int {
+		if b[p] < 0x80 {
+			return 1
+		}
+
+		return 1 + int(b[p]&0x7f)
+	}
+
+	p := 1 + hdr(1)
+	seqTag := b[p]
+	p++
+	p += hdr(p)
+
+	inner := append(append([]byte{}, b[p:]...), extra...)
+	seq := append([]byte{seqTag}, lenBytes(len(inner))...)
+	seq = append(seq, inner...)
+
+	out := append([]byte{b[0]}, lenBytes(len(seq))...)
+
+	return append(out, seq...)
+}
+
+// A Ticket's DecryptedEncPart is filled in by Decrypt, never by the peer. RFC 4120 Section 5.3 defines the wire
+// Ticket as four fields, so an element appended past them must not reach it: a caller reading DecryptedEncPart is
+// entitled to assume the KDC sealed what it finds there.
+func TestTicketUnmarshalShouldNotAcceptADecryptedEncPart(t *testing.T) {
+	t.Parallel()
+
+	tkt := testWireTicket()
+
+	b, err := tkt.Marshal()
+	require.NoError(t, err)
+
+	forged, err := asn1.Marshal(EncTicketPart{
+		Flags:     types.NewKrbFlags(),
+		Key:       types.EncryptionKey{KeyType: 18, KeyValue: []byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")},
+		CRealm:    "EVIL.REALM",
+		CName:     types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{"administrator"}},
+		Transited: TransitedEncoding{TRType: trtype.DOMAIN_X500_COMPRESS},
+		AuthTime:  time.Now().UTC(),
+		EndTime:   time.Now().UTC().Add(time.Hour),
+	}, asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
+	require.NoError(t, err)
+
+	var got Ticket
+
+	// Whether the trailing element is rejected or ignored is the decoder's business; what matters is that it
+	// never becomes the ticket's decrypted part.
+	if err := got.Unmarshal(appendToSequence(t, b, forged)); err == nil {
+		assert.Empty(t, got.DecryptedEncPart.CName.NameString,
+			"a client name appended to the wire ticket became its decrypted part")
+		assert.Empty(t, got.DecryptedEncPart.CRealm)
+		assert.Empty(t, got.DecryptedEncPart.Key.KeyValue,
+			"a session key appended to the wire ticket became its decrypted part")
+	}
+}
+
+func TestTicketMarshalShouldNotEmitTheDecryptedEncPart(t *testing.T) {
+	t.Parallel()
+
+	tkt := testWireTicket()
+
+	clean, err := tkt.Marshal()
+	require.NoError(t, err)
+
+	sessionKey := []byte("SUPER-SECRET-SESSION-KEY-32BYTES")
+	tkt.DecryptedEncPart = EncTicketPart{
+		Flags:     types.NewKrbFlags(),
+		Key:       types.EncryptionKey{KeyType: 18, KeyValue: sessionKey},
+		CRealm:    testRealm,
+		CName:     types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{"testuser"}},
+		Transited: TransitedEncoding{TRType: trtype.DOMAIN_X500_COMPRESS},
+		AuthTime:  time.Now().UTC(),
+		EndTime:   time.Now().UTC().Add(time.Hour),
+	}
+
+	decrypted, err := tkt.Marshal()
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(decrypted), string(sessionKey),
+		"marshalling a decrypted ticket put its session key on the wire")
+	assert.Equal(t, clean, decrypted,
+		"decrypting a ticket must not change the bytes it marshals to")
+}
+
+func testWireTicket() Ticket {
+	return Ticket{
+		TktVNO:  iana.PVNO,
+		Realm:   testRealm,
+		SName:   types.PrincipalName{NameType: nametype.KRB_NT_SRV_INST, NameString: []string{"HTTP", "host.test.gokrb5"}},
+		EncPart: types.EncryptedData{EType: 18, KVNO: 1, Cipher: []byte{1, 2, 3, 4}},
+	}
+}


### PR DESCRIPTION
Ticket and KRBPriv both carry a DecryptedEncPart that Decrypt fills in, tagged optional so that unmarshalling would skip it. Optional does not exclude a field from a SEQUENCE, it only makes it skippable, so the field was encoded and decoded like any other.

Marshalling a ticket that had been decrypted therefore appended its plaintext, session key included, to the bytes going on the wire. Unmarshalling accepted an element appended past the four fields RFC 4120 section 5.3 defines and read it back as a decrypted part the KDC never sealed.

Give both types the private marshal twin every other message in the package already has, and let Unmarshal replace the receiver so a stale decrypted part cannot survive into the next message.