### PR TITLE
fix(client): salt pre-authentication with the client's own principal

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -103,7 +103,7 @@ change will be elaborated on in time):
   the whole tuple RFC 4120 §3.2.3 describes: the client name and realm, the service name and realm, and the
   authenticator's `ctime` and `cusec`. Previously an entry was keyed on the client and the time alone, with the
   service name held as its value and compared on lookup, so a presentation under a second service name both failed
-  to match the stored entry and *replaced* it — which §3.2.3 forbids: "If a server loses track of authenticators
+  to match the stored entry and *replaced* it; which §3.2.3 forbids: "If a server loses track of authenticators
   presented within the allowable clock skew, it MUST reject all requests until the clock skew interval has passed."
   Callers of these two methods must add the argument; there is no compatibility shim, because silently keying on an
   empty realm would reintroduce the collision between a service principal registered in more than one realm.

--- a/client/client.go
+++ b/client/client.go
@@ -147,7 +147,13 @@ func (cl *Client) Key(etype etype.EType, kvno int, krberr *messages.KRBError) (t
 				return types.EncryptionKey{}, 0, fmt.Errorf("could not get PAData from KRBError to generate key from password: %w", err)
 			}
 
-			key, _, err := crypto.GetKeyFromPassword(cl.Credentials.Password(), krberr.CName, krberr.CRealm, etype.GetETypeID(), pas)
+			// RFC 4120 Section 3.1: "the contents of the KRB_ERROR message are not integrity-protected", so the
+			// principal and realm the error names are the attacker's choice wherever it can be substituted. Only
+			// the explicit salt in the pre-authentication data is taken from it; the default salt comes from the
+			// identity this client is authenticating as, so an attacker cannot pick the salt the password is
+			// stretched with.
+			key, _, err := crypto.GetKeyFromPassword(cl.Credentials.Password(), cl.Credentials.CName(),
+				cl.Credentials.Domain(), etype.GetETypeID(), pas)
 
 			return key, 0, err
 		}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -9,7 +9,10 @@ import (
 	"github.com/go-krb5/x/encoding/asn1"
 
 	"github.com/go-krb5/krb5/config"
+	"github.com/go-krb5/krb5/crypto"
+	"github.com/go-krb5/krb5/iana/errorcode"
 	"github.com/go-krb5/krb5/iana/etypeID"
+	"github.com/go-krb5/krb5/iana/nametype"
 	"github.com/go-krb5/krb5/iana/patype"
 	"github.com/go-krb5/krb5/keytab"
 	"github.com/go-krb5/krb5/messages"
@@ -81,3 +84,72 @@ func TestPreAuthETypeSkipsUnsupportedEntries(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, etypeID.AES256_CTS_HMAC_SHA1_96, et.GetETypeID())
 }
+
+func TestKeyShouldSaltWithTheClientsOwnPrincipalNotTheKRBErrors(t *testing.T) {
+	t.Parallel()
+
+	// RFC 4120 Section 3.1: a KRB-ERROR is not integrity protected, so the principal and realm it names are the
+	// attacker's choice on any path where the error can be substituted. The default string-to-key salt must come
+	// from the identity the client is authenticating as.
+	pas, err := asn1.Marshal(types.PADataSequence{},
+		asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
+	require.NoError(t, err)
+
+	krberr := messages.KRBError{
+		ErrorCode: errorcode.KDC_ERR_PREAUTH_REQUIRED,
+		CName:     types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, "attacker"),
+		CRealm:    attackerRealm,
+		EData:     pas,
+	}
+
+	cl := NewWithPassword("testuser", "TEST.GOKRB5", "passwordvalue", &config.Config{})
+
+	et, err := crypto.GetEType(etypeID.AES256_CTS_HMAC_SHA1_96)
+	require.NoError(t, err)
+
+	key, _, err := cl.Key(et, 0, &krberr)
+	require.NoError(t, err)
+
+	expected, _, err := crypto.GetKeyFromPassword("passwordvalue", cl.Credentials.CName(), cl.Credentials.Domain(),
+		etypeID.AES256_CTS_HMAC_SHA1_96, types.PADataSequence{})
+	require.NoError(t, err)
+
+	assert.Equal(t, expected.KeyValue, key.KeyValue)
+}
+
+func TestKeyShouldStillHonourTheExplicitSaltInTheKRBErrors(t *testing.T) {
+	t.Parallel()
+
+	// RFC 4120 Section 5.2.7.5: the salt in PA-ETYPE-INFO2 is what the KDC actually stretched the password with,
+	// so it is honoured even though it too arrives unauthenticated. Only the default is taken from the client.
+	info := types.ETypeInfo2{{EType: etypeID.AES256_CTS_HMAC_SHA1_96, Salt: "TEST.GOKRB5explicitsalt"}}
+
+	v, err := asn1.Marshal(info, asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
+	require.NoError(t, err)
+
+	pas, err := asn1.Marshal(types.PADataSequence{{PADataType: patype.PA_ETYPE_INFO2, PADataValue: v}},
+		asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
+	require.NoError(t, err)
+
+	krberr := messages.KRBError{
+		ErrorCode: errorcode.KDC_ERR_PREAUTH_REQUIRED,
+		CName:     types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, "attacker"),
+		CRealm:    attackerRealm,
+		EData:     pas,
+	}
+
+	cl := NewWithPassword("testuser", "TEST.GOKRB5", "passwordvalue", &config.Config{})
+
+	et, err := crypto.GetEType(etypeID.AES256_CTS_HMAC_SHA1_96)
+	require.NoError(t, err)
+
+	key, _, err := cl.Key(et, 0, &krberr)
+	require.NoError(t, err)
+
+	expected, err := et.StringToKey("passwordvalue", "TEST.GOKRB5explicitsalt", et.GetDefaultStringToKeyParams())
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, key.KeyValue)
+}
+
+const attackerRealm = "EVIL.GOKRB5"

--- a/service/cache.go
+++ b/service/cache.go
@@ -32,8 +32,8 @@ type clientEntries struct {
 // tuple is here.
 //
 // The server name and realm are part of the key rather than of the value. The same section requires that losing
-// track of a presentation reject rather than admit — "If a server loses track of authenticators presented within
-// the allowable clock skew, it MUST reject all requests until the clock skew interval has passed" — and a value can
+// track of a presentation reject rather than admit; "If a server loses track of authenticators presented within
+// the allowable clock skew, it MUST reject all requests until the clock skew interval has passed"; and a value can
 // be displaced by the next presentation under a different server name where a key cannot.
 type replayKey struct {
 	cTime  time.Time
@@ -148,7 +148,7 @@ func (c *Cache) ClearOldEntries(d time.Duration) {
 // sname and srealm must identify the service principal whose key decrypted the ticket the authenticator arrived in,
 // which is the ticket's SName and Realm only where those chose the key. A ticket's unencrypted portion is covered
 // by no checksum, so keying the cache on what it claims would let a captured AP_REQ be replayed indefinitely by
-// rewriting the claim — see service.VerifyAPREQ, which resolves this before calling.
+// rewriting the claim; see service.VerifyAPREQ, which resolves this before calling.
 func (c *Cache) IsReplay(sname types.PrincipalName, srealm string, a types.Authenticator) bool {
 	k := newReplayKey(sname, srealm, a)
 


### PR DESCRIPTION
A KRB-ERROR is not integrity protected, so an attacker able to answer an AS-REQ chose the default string-to-key salt, and setting it to a constant makes one precomputed table work against every user of a realm. The explicit salt in PA-ETYPE-INFO2 is still honoured.