### PR TITLE
fix(spnego): stop at a redirect away from the configured SPN's host

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -115,3 +115,14 @@ change will be elaborated on in time):
   should have caught it and displaced that entry for the next attempt. Deployments using `KeytabPrincipal` had no
   working replay protection at all. No configuration change is needed to pick the fix up, and without the override
   the two values are identical, so nothing changes for acceptors that do not set it.
+- `spnego.Client.Do` stops with an error at a redirect that leaves the host the configured service principal name
+  belongs to, where it previously followed the redirect and negotiated against the new host. The header carrying the
+  old ticket was already deleted before a redirect was followed, but the negotiation that started again at the target
+  used the configured name verbatim, so the client minted a fresh service ticket for the host the caller named and
+  sent it to whichever host the redirect pointed at. That AP-REQ has never been seen by the real service, so its
+  replay cache does not hold it, and nothing binds it to the connection it arrived on unless channel bindings are
+  configured: the redirect target can relay it and authenticate as the user. The comparison is on the host alone,
+  since the derived name carries no port, so a redirect to another port on the same host is still followed. Clients
+  constructed with an empty SPN are unaffected, the name being derived per request from the host actually addressed.
+  A deployment that relies on a redirect to another hostname must construct the client with an empty SPN and let it
+  derive the name, or handle the redirect itself and call `Do` again for the new host.

--- a/spnego/http.go
+++ b/spnego/http.go
@@ -157,6 +157,12 @@ func (c *Client) Do(req *http.Request) (resp *http.Response, err error) {
 				// Picked up a redirect.
 				e.reqTarget.Header.Del(HTTPHeaderAuthRequest)
 
+				if rerr := c.checkRedirectHost(req, e.reqTarget); rerr != nil {
+					c.endNegotiation()
+
+					return resp, rerr
+				}
+
 				c.reqs = append(c.reqs, e.reqTarget)
 				if len(c.reqs) >= c.maxRedirects {
 					c.reqs = c.reqs[:0]
@@ -207,6 +213,27 @@ func (c *Client) Do(req *http.Request) (resp *http.Response, err error) {
 	c.endNegotiation()
 
 	return resp, err
+}
+
+// checkRedirectHost refuses a redirect that leaves the host the configured service principal name belongs to.
+//
+// Deleting the Authorization header before following a redirect closes only half of the hazard: the negotiation
+// then starts again against the new host, and a configured name is used verbatim there. The client would obtain a
+// ticket for the host the caller named and send it to whichever host the redirect points at, in an AP_REQ the real
+// service has never seen and so will not have in its replay cache. Nothing binds an AP_REQ to the connection that
+// carried it unless channel bindings are configured, so that ticket is enough for the redirect target to
+// authenticate as the user against the service the caller meant to reach.
+//
+// The name is compared on the host alone: setRequestSPN builds "HTTP/<host>" with no port, so two ports on one
+// host are one service principal, and a redirect between them stays with the service the caller named. Where no
+// name is configured there is nothing to leave, and the SPN derived per request already follows the host being
+// addressed.
+func (c *Client) checkRedirectHost(from, to *http.Request) error {
+	if c.spn == "" || strings.EqualFold(from.URL.Hostname(), to.URL.Hostname()) {
+		return nil
+	}
+
+	return fmt.Errorf("stopped at the redirect from %s to %s: the service principal name %s the client is configured with does not name the redirect target", from.URL.Hostname(), to.URL.Hostname(), c.spn)
 }
 
 // nextNegotiationLeg sets the Authorization header answering a challenge, reporting whether there is a leg to send.

--- a/spnego/http_redirect_test.go
+++ b/spnego/http_redirect_test.go
@@ -1,0 +1,160 @@
+package spnego
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSPNEGOHTTPClient_ShouldStopAtARedirectAwayFromTheConfiguredSPNsHost(t *testing.T) {
+	var reached atomic.Bool
+
+	elsewhere := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer elsewhere.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://elsewhere.test/", http.StatusFound)
+	}))
+	defer origin.Close()
+
+	httpCl := hostRoutingClient(map[string]string{
+		hostOrigin:    origin.Listener.Addr().String(),
+		hostElsewhere: elsewhere.Listener.Addr().String(),
+	})
+
+	spnegoCl := NewClient(nil, httpCl, "HTTP/origin.test")
+
+	resp, err := spnegoCl.Get("http://origin.test/")
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "elsewhere.test")
+	assert.False(t, reached.Load(), "the redirect target must not be sent a ticket minted for another host")
+}
+
+func TestSPNEGOHTTPClient_ShouldFollowARedirectWithinTheConfiguredSPNsHost(t *testing.T) {
+	var moved atomic.Bool
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/moved" {
+			moved.Store(true)
+			w.WriteHeader(http.StatusOK)
+
+			return
+		}
+
+		http.Redirect(w, r, "/moved", http.StatusFound)
+	}))
+	defer origin.Close()
+
+	httpCl := hostRoutingClient(map[string]string{hostOrigin: origin.Listener.Addr().String()})
+
+	spnegoCl := NewClient(nil, httpCl, "HTTP/origin.test")
+
+	resp, err := spnegoCl.Get("http://origin.test/")
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, moved.Load(), "a redirect that stays with the configured service must still be followed")
+}
+
+func TestSPNEGOHTTPClient_ShouldFollowARedirectToAnotherPortOnTheConfiguredSPNsHost(t *testing.T) {
+	var reached atomic.Bool
+
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer second.Close()
+
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://origin.test:9090/", http.StatusFound)
+	}))
+	defer first.Close()
+
+	httpCl := hostRoutingClient(map[string]string{
+		"origin.test:8080": first.Listener.Addr().String(),
+		"origin.test:9090": second.Listener.Addr().String(),
+	})
+
+	spnegoCl := NewClient(nil, httpCl, "HTTP/origin.test")
+
+	resp, err := spnegoCl.Get("http://origin.test:8080/")
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.True(t, reached.Load(), "another port on the same host is the same service principal")
+}
+
+func TestSPNEGOHTTPClient_ShouldFollowACrossHostRedirectWhenNoSPNIsConfigured(t *testing.T) {
+	var reached atomic.Bool
+
+	elsewhere := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer elsewhere.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://elsewhere.test/", http.StatusFound)
+	}))
+	defer origin.Close()
+
+	httpCl := hostRoutingClient(map[string]string{
+		hostOrigin:    origin.Listener.Addr().String(),
+		hostElsewhere: elsewhere.Listener.Addr().String(),
+	})
+
+	spnegoCl := NewClient(nil, httpCl, "")
+
+	resp, err := spnegoCl.Get("http://origin.test/")
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.True(t, reached.Load(), "a derived SPN follows the host being addressed and is not pinned")
+}
+
+func hostRoutingClient(hosts map[string]string) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				target, ok := hosts[addr]
+				if !ok {
+					host, _, err := net.SplitHostPort(addr)
+					if err != nil {
+						return nil, err
+					}
+
+					if target, ok = hosts[host]; !ok {
+						return nil, fmt.Errorf("no test server for host %q", host)
+					}
+				}
+
+				var d net.Dialer
+
+				return d.DialContext(ctx, network, target)
+			},
+		},
+	}
+}
+
+const (
+	hostOrigin = "origin.test"
+	hostElsewhere = "elsewhere.test"
+)


### PR DESCRIPTION
The Authorization header was deleted before a redirect was followed, but the negotiation starting again at the target used the configured service principal name verbatim, so the client minted a ticket for the host the caller named and sent it to the redirect target. That AP-REQ is absent from the real service's replay cache and bound to no connection, so the target can relay it and authenticate as the user.