### PR TITLE
fix(crypto): derive the key with the chosen enctype's s2kparams

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -19,10 +19,9 @@ func GetKeyFromPassword(passwd string, cname types.PrincipalName, realm string, 
 		return key, et, fmt.Errorf("error getting encryption type: %w", err)
 	}
 
-	sk2p := et.GetDefaultStringToKeyParams()
-
 	var (
 		salt string
+		sk2p string
 		paID int32
 	)
 
@@ -97,6 +96,10 @@ func GetKeyFromPassword(passwd string, cname types.PrincipalName, realm string, 
 
 	if salt == "" {
 		salt = cname.GetSalt(realm)
+	}
+
+	if sk2p == "" {
+		sk2p = et.GetDefaultStringToKeyParams()
 	}
 
 	k, err := et.StringToKey(passwd, salt, sk2p)

--- a/crypto/string_to_key_params_test.go
+++ b/crypto/string_to_key_params_test.go
@@ -1,0 +1,112 @@
+package crypto
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-krb5/x/encoding/asn1"
+
+	"github.com/go-krb5/krb5/iana/etypeID"
+	"github.com/go-krb5/krb5/iana/patype"
+	"github.com/go-krb5/krb5/types"
+)
+
+func TestGetKeyFromPasswordShouldDeriveWithTheChosenETypesStringToKeyParams(t *testing.T) {
+	t.Parallel()
+
+	pas := etypeInfo2PAData(t, types.ETypeInfo2{{EType: etypeID.AES256_CTS_HMAC_SHA384_192, Salt: s2kSalt}})
+
+	cname := types.PrincipalName{NameString: []string{s2kUser}}
+
+	key, et, err := GetKeyFromPassword(s2kPassword, cname, s2kRealm, etypeID.AES256_CTS_HMAC_SHA1_96, pas)
+	require.NoError(t, err)
+	require.Equal(t, etypeID.AES256_CTS_HMAC_SHA384_192, et.GetETypeID())
+
+	expected, err := et.StringToKey(s2kPassword, s2kSalt, et.GetDefaultStringToKeyParams())
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, key.KeyValue)
+}
+
+func TestGetKeyFromPasswordShouldPreferAnExplicitS2KParamsOverTheDefault(t *testing.T) {
+	t.Parallel()
+
+	// RFC 4120 Section 5.2.7.5 carries s2kparams for the KDC to state a count that is not the type's default.
+	iterations, err := hex.DecodeString("00001000")
+	require.NoError(t, err)
+
+	pas := etypeInfo2PAData(t, types.ETypeInfo2{
+		{EType: etypeID.AES256_CTS_HMAC_SHA384_192, Salt: s2kSalt, S2KParams: iterations},
+	})
+
+	cname := types.PrincipalName{NameString: []string{s2kUser}}
+
+	key, et, err := GetKeyFromPassword(s2kPassword, cname, s2kRealm, etypeID.AES256_CTS_HMAC_SHA1_96, pas)
+	require.NoError(t, err)
+	require.Equal(t, etypeID.AES256_CTS_HMAC_SHA384_192, et.GetETypeID())
+
+	expected, err := et.StringToKey(s2kPassword, s2kSalt, "00001000")
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, key.KeyValue)
+	require.NotEqual(t, "00001000", et.GetDefaultStringToKeyParams())
+}
+
+func TestGetKeyFromPasswordShouldDeriveWithTheChosenETypesParamsThroughETypeInfo(t *testing.T) {
+	t.Parallel()
+
+	// PA-ETYPE-INFO has no s2kparams field at all, so the type it names can only be derived with that type's
+	// own default.
+	info := types.ETypeInfo{{EType: etypeID.AES256_CTS_HMAC_SHA384_192, Salt: []byte(s2kSalt)}}
+
+	v, err := asn1.Marshal(info, asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
+	require.NoError(t, err)
+
+	pas := types.PADataSequence{{PADataType: patype.PA_ETYPE_INFO, PADataValue: v}}
+
+	cname := types.PrincipalName{NameString: []string{s2kUser}}
+
+	key, et, err := GetKeyFromPassword(s2kPassword, cname, s2kRealm, etypeID.AES256_CTS_HMAC_SHA1_96, pas)
+	require.NoError(t, err)
+	require.Equal(t, etypeID.AES256_CTS_HMAC_SHA384_192, et.GetETypeID())
+
+	expected, err := et.StringToKey(s2kPassword, s2kSalt, et.GetDefaultStringToKeyParams())
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, key.KeyValue)
+}
+
+func TestGetKeyFromPasswordShouldDeriveWithTheRequestedETypesParamsWithoutPAData(t *testing.T) {
+	t.Parallel()
+
+	cname := types.PrincipalName{NameString: []string{s2kUser}}
+
+	key, et, err := GetKeyFromPassword(s2kPassword, cname, s2kRealm, etypeID.AES256_CTS_HMAC_SHA1_96,
+		types.PADataSequence{})
+	require.NoError(t, err)
+	require.Equal(t, etypeID.AES256_CTS_HMAC_SHA1_96, et.GetETypeID())
+
+	expected, err := et.StringToKey(s2kPassword, cname.GetSalt(s2kRealm), et.GetDefaultStringToKeyParams())
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, key.KeyValue)
+}
+
+const (
+	s2kPassword = "passwordvalue"
+	s2kSalt     = "TEST.GOKRB5testuser"
+	s2kRealm    = "TEST.GOKRB5"
+	s2kUser     = "testuser"
+)
+
+func etypeInfo2PAData(t *testing.T, info types.ETypeInfo2) types.PADataSequence {
+	t.Helper()
+
+	v, err := asn1.Marshal(info, asn1.WithMarshalSlicePreserveTypes(true), asn1.WithMarshalSliceAllowStrings(true))
+	require.NoError(t, err)
+
+	return types.PADataSequence{{PADataType: patype.PA_ETYPE_INFO2, PADataValue: v}}
+}

--- a/spnego/http_redirect_test.go
+++ b/spnego/http_redirect_test.go
@@ -155,6 +155,6 @@ func hostRoutingClient(hosts map[string]string) *http.Client {
 }
 
 const (
-	hostOrigin = "origin.test"
+	hostOrigin    = "origin.test"
 	hostElsewhere = "elsewhere.test"
 )


### PR DESCRIPTION
The parameters were read from the requested encryption type before the pre-authentication data could replace it, and an explicit s2kparams was the only thing that corrected them. Both MIT and Active Directory omit that field for their default counts, so a KDC answering with a type from the other family had the key derived at the wrong iteration count, 4096 against 32768.