### PR TITLE
fix(messages): pick the authenticator key usage by position, not name

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -126,3 +126,14 @@ change will be elaborated on in time):
   constructed with an empty SPN are unaffected, the name being derived per request from the host actually addressed.
   A deployment that relies on a redirect to another hostname must construct the client with an empty SPN and let it
   derive the name, or handle the redirect itself and call `Do` again for the new host.
+- The AP-REQ authenticator key usage is decided by where the AP_REQ sits rather than by what its ticket names.
+  RFC 4120 Section 7.5.1 assigns usage 7 to the "TGS-REQ PA-TGS-REQ padata AP-REQ Authenticator" and usage 11 to an
+  AP-REQ authenticator, and the library previously chose between them by testing whether the ticket's first name
+  component was `krbtgt`. Renewing a service ticket sends that ticket as the credential in the TGS-REQ, so its
+  authenticator was encrypted with 11 where every KDC derives with 7: renewal failed with
+  `KRB_AP_ERR_BAD_INTEGRITY`, and `client.Client.GetCachedTicket` renews whenever a cached ticket is past its end
+  time but inside `renew_till`. Renewal now works, and no configuration change is needed to pick it up. The
+  converse case changes on the wire: an AP-REQ presenting a TGT, which is the user-to-user exchange of RFC 4120
+  Section 3.7, is now built and verified with usage 11 where it previously used 7 in both directions. That agrees
+  with MIT and with the specification, but a peer running an older version of this library on the other side of a
+  user-to-user exchange will not interoperate with it.

--- a/messages/ap_req.go
+++ b/messages/ap_req.go
@@ -38,10 +38,26 @@ type APReq struct {
 }
 
 // NewAPReq generates a new KRB_AP_REQ struct.
+//
+// The authenticator is encrypted with the AP-REQ key usage of RFC 4120 Section 7.5.1. An AP_REQ carried as a
+// TGS-REQ's PA-TGS-REQ takes a different usage and is built by newAPReqPATGSReq.
 func NewAPReq(tkt Ticket, sessionKey types.EncryptionKey, auth types.Authenticator) (APReq, error) {
+	return newAPReq(tkt, sessionKey, auth, keyusage.AP_REQ_AUTHENTICATOR)
+}
+
+// newAPReqPATGSReq generates the KRB_AP_REQ a TGS-REQ carries as its PA-TGS-REQ pre-authentication data.
+//
+// RFC 4120 Section 7.5.1 assigns key usage 7 to the "TGS-REQ PA-TGS-REQ padata AP-REQ Authenticator", which is a
+// property of where the AP_REQ sits and not of what its ticket names. The ticket is a TGT whenever a new service
+// ticket is being obtained, but it is the service ticket itself when one is being renewed, and both take usage 7.
+func newAPReqPATGSReq(tkt Ticket, sessionKey types.EncryptionKey, auth types.Authenticator) (APReq, error) {
+	return newAPReq(tkt, sessionKey, auth, keyusage.TGS_REQ_PA_TGS_REQ_AP_REQ_AUTHENTICATOR)
+}
+
+func newAPReq(tkt Ticket, sessionKey types.EncryptionKey, auth types.Authenticator, usage int) (APReq, error) {
 	var a APReq
 
-	ed, err := encryptAuthenticator(auth, sessionKey, tkt)
+	ed, err := encryptAuthenticator(auth, sessionKey, tkt, usage)
 	if err != nil {
 		return a, krberror.Errorf(err, krberror.KRBMsgError, "error creating Authenticator for AP_REQ")
 	}
@@ -58,16 +74,14 @@ func NewAPReq(tkt Ticket, sessionKey types.EncryptionKey, auth types.Authenticat
 	return a, nil
 }
 
-// Encrypt Authenticator.
-func encryptAuthenticator(a types.Authenticator, sessionKey types.EncryptionKey, tkt Ticket) (types.EncryptedData, error) {
+// encryptAuthenticator encrypts the authenticator with the key usage its AP_REQ's position calls for.
+func encryptAuthenticator(a types.Authenticator, sessionKey types.EncryptionKey, tkt Ticket, usage int) (types.EncryptedData, error) {
 	var ed types.EncryptedData
 
 	m, err := a.Marshal()
 	if err != nil {
 		return ed, krberror.Errorf(err, krberror.EncodingError, "marshaling error of EncryptedData form of Authenticator")
 	}
-
-	usage := authenticatorKeyUsage(tkt.SName)
 
 	ed, err = crypto.GetEncryptedData(m, sessionKey, uint32(usage), tkt.EncPart.KVNO)
 	if err != nil {
@@ -80,9 +94,7 @@ func encryptAuthenticator(a types.Authenticator, sessionKey types.EncryptionKey,
 // DecryptAuthenticator decrypts the Authenticator within the AP_REQ.
 // sessionKey may simply be the key within the decrypted EncPart of the ticket within the AP_REQ.
 func (a *APReq) DecryptAuthenticator(sessionKey types.EncryptionKey) (err error) {
-	usage := authenticatorKeyUsage(a.Ticket.SName)
-
-	ab, err := crypto.DecryptEncPart(a.EncryptedAuthenticator, sessionKey, uint32(usage))
+	ab, err := crypto.DecryptEncPart(a.EncryptedAuthenticator, sessionKey, keyusage.AP_REQ_AUTHENTICATOR)
 	if err != nil {
 		return fmt.Errorf("error decrypting authenticator: %w", err)
 	}
@@ -92,14 +104,6 @@ func (a *APReq) DecryptAuthenticator(sessionKey types.EncryptionKey) (err error)
 	}
 
 	return nil
-}
-
-func authenticatorKeyUsage(pn types.PrincipalName) int {
-	if len(pn.NameString) > 0 && pn.NameString[0] == "krbtgt" {
-		return keyusage.TGS_REQ_PA_TGS_REQ_AP_REQ_AUTHENTICATOR
-	}
-
-	return keyusage.AP_REQ_AUTHENTICATOR
 }
 
 // Unmarshal bytes b into the APReq struct.

--- a/messages/ap_req_test.go
+++ b/messages/ap_req_test.go
@@ -1,13 +1,16 @@
 package messages
 
 import (
+	"bytes"
 	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-krb5/krb5/crypto"
 	"github.com/go-krb5/krb5/iana"
+	"github.com/go-krb5/krb5/iana/etypeID"
 	"github.com/go-krb5/krb5/iana/keyusage"
 	"github.com/go-krb5/krb5/iana/msgtype"
 	"github.com/go-krb5/krb5/iana/nametype"
@@ -54,27 +57,73 @@ func TestMarshalAPReq(t *testing.T) {
 	assert.Equal(t, b, mb)
 }
 
-// TestAuthenticatorKeyUsageEmptyNameStringDoesNotPanic guards against a remotely reachable panic. A service ticket's
-// plaintext Ticket.SName sits outside EncPart, and PrincipalName.NameString may legally be empty, so a client
-// holding any valid service ticket can blank SName and still reach DecryptAuthenticator ->
-// authenticatorKeyUsage(a.Ticket.SName) - an unauthenticated caller must not be able to crash the server this way.
-func TestAuthenticatorKeyUsageEmptyNameStringDoesNotPanic(t *testing.T) {
+// TestDecryptAuthenticatorShouldNotPanicOnAnEmptySName guards a remotely reachable panic. A ticket's plaintext
+// SName sits outside EncPart and PrincipalName.NameString may legally be empty, so a client holding any valid
+// service ticket can blank it and still reach DecryptAuthenticator; nothing on that path may index it.
+func TestDecryptAuthenticatorShouldNotPanicOnAnEmptySName(t *testing.T) {
 	t.Parallel()
 
-	var usage int
+	var a APReq
 
 	assert.NotPanics(t, func() {
-		usage = authenticatorKeyUsage(types.PrincipalName{})
+		_ = a.DecryptAuthenticator(apReqTestKey())
 	})
-	assert.Equal(t, keyusage.AP_REQ_AUTHENTICATOR, usage)
 }
 
-// TestAuthenticatorKeyUsageKrbtgtSelectsTGSReqUsage pins the pre-existing behaviour the guard must not change: a
-// krbtgt SName (as a real TGT carries) still selects the TGS-REQ PA-DATA authenticator key usage.
-func TestAuthenticatorKeyUsageKrbtgtSelectsTGSReqUsage(t *testing.T) {
+// TestNewAPReqShouldUseTheAPREQKeyUsageForATGT pins that the key usage follows the AP_REQ's position rather than
+// what its ticket names. RFC 4120 Section 7.5.1 assigns 11 to an AP-REQ authenticator, and the ticket presented in
+// one is a TGT whenever the exchange is the user-to-user authentication of Section 3.7.
+func TestNewAPReqShouldUseTheAPREQKeyUsageForATGT(t *testing.T) {
 	t.Parallel()
 
-	pn := types.PrincipalName{NameType: nametype.KRB_NT_SRV_INST, NameString: []string{"krbtgt", "TEST.GOKRB5"}}
+	key := apReqTestKey()
+	tgt := Ticket{
+		Realm: testRealm,
+		SName: types.PrincipalName{NameType: nametype.KRB_NT_SRV_INST, NameString: []string{testKrbtgt, testRealm}},
+	}
 
-	assert.Equal(t, keyusage.TGS_REQ_PA_TGS_REQ_AP_REQ_AUTHENTICATOR, authenticatorKeyUsage(pn))
+	apReq, err := NewAPReq(tgt, key, apReqTestAuthenticator(t))
+	require.NoError(t, err)
+
+	_, err = crypto.DecryptEncPart(apReq.EncryptedAuthenticator, key, keyusage.AP_REQ_AUTHENTICATOR)
+	require.NoError(t, err, "an AP-REQ authenticator takes key usage 11 whatever its ticket names")
+}
+
+// TestNewAPReqPATGSReqShouldUseTheTGSREQKeyUsageForAServiceTicket is the converse: the pre-authentication position
+// takes key usage 7, and renewal presents the service ticket being renewed rather than a TGT.
+func TestNewAPReqPATGSReqShouldUseTheTGSREQKeyUsageForAServiceTicket(t *testing.T) {
+	t.Parallel()
+
+	key := apReqTestKey()
+	svc := Ticket{
+		Realm: testRealm,
+		SName: types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{testHTTPService, testHTTPHost}},
+	}
+
+	apReq, err := newAPReqPATGSReq(svc, key, apReqTestAuthenticator(t))
+	require.NoError(t, err)
+
+	_, err = crypto.DecryptEncPart(apReq.EncryptedAuthenticator, key, keyusage.TGS_REQ_PA_TGS_REQ_AP_REQ_AUTHENTICATOR)
+	require.NoError(t, err, "a PA-TGS-REQ authenticator takes key usage 7 whatever its ticket names")
+}
+
+// testKrbtgt and testHTTPService name the two ticket kinds an AP_REQ can carry, a TGT and a service ticket.
+const (
+	testKrbtgt      = "krbtgt"
+	testHTTPService = "HTTP"
+	testHTTPHost    = "host.test.gokrb5"
+)
+
+func apReqTestKey() types.EncryptionKey {
+	return types.EncryptionKey{KeyType: etypeID.AES256_CTS_HMAC_SHA1_96, KeyValue: bytes.Repeat([]byte{0x0E}, 32)}
+}
+
+func apReqTestAuthenticator(t *testing.T) types.Authenticator {
+	t.Helper()
+
+	auth, err := types.NewAuthenticator(testRealm,
+		types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{testUser}})
+	require.NoError(t, err)
+
+	return auth
 }

--- a/messages/kdc_req.go
+++ b/messages/kdc_req.go
@@ -331,7 +331,7 @@ func (k *TGSReq) setPAData(paRealm string, tgt Ticket, sessionKey types.Encrypti
 		Checksum:  cb,
 	}
 	// Create AP_REQ.
-	apReq, err := NewAPReq(tgt, sessionKey, auth)
+	apReq, err := newAPReqPATGSReq(tgt, sessionKey, auth)
 	if err != nil {
 		return krberror.Errorf(err, krberror.KRBMsgError, "error generating new AP_REQ")
 	}

--- a/messages/kdc_req_test.go
+++ b/messages/kdc_req_test.go
@@ -606,3 +606,23 @@ func TestNewASReqHonoursTheConfiguredRenewLifetime(t *testing.T) {
 	// The renew till should follow renew_lifetime, not a value fixed in the source.
 	assert.WithinDuration(t, before.Add(72*time.Hour), a.ReqBody.RTime, 10*time.Second)
 }
+
+func TestNewTGSReqRenewingAServiceTicketShouldUseTheTGSREQAuthenticatorKeyUsage(t *testing.T) {
+	t.Parallel()
+
+	c, err := config.NewFromString(testdata.KRB5_CONF)
+	require.NoError(t, err)
+
+	cname := types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{testUser}}
+	key := types.EncryptionKey{KeyType: 18, KeyValue: bytes.Repeat([]byte{0x0E}, 32)}
+
+	svc := Ticket{
+		Realm: testRealm,
+		SName: types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: []string{testHTTPService, testHTTPHost}},
+	}
+
+	req, err := NewTGSReq(cname, testRealm, testRealm, c, svc, key, svc.SName, true)
+	require.NoError(t, err)
+
+	decryptForwardedAuthenticator(t, req, key)
+}


### PR DESCRIPTION
RFC 4120 Section 7.5.1 assigns key usage 7 to the AP_REQ authenticator in a TGS-REQ's PA-TGS-REQ and 11 to an AP-REQ's, which is a property of where the AP_REQ sits. Choosing between them by testing the ticket's name for krbtgt encrypted a renewal with 11, since renewal presents the service ticket being renewed, and no KDC could read it.