### PR TITLE
fix(config): keep the configured KDC order and check scanner errors

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -137,3 +137,10 @@ change will be elaborated on in time):
   Section 3.7, is now built and verified with usage 11 where it previously used 7 in both directions. That agrees
   with MIT and with the specification, but a peer running an older version of this library on the other side of a
   user-to-user exchange will not interoperate with it.
+- `config.Load`, `config.NewFromString`, `config.NewFromReader` and `config.NewFromScanner` return an error when the
+  scanner stops before the end of the input, where they previously returned the part of the configuration that had
+  been read. `bufio.Scanner` halts at the first line longer than `bufio.MaxScanTokenSize`, 64 KiB, and at any read
+  error, reporting either only through `Err()`, which was never called. A configuration whose tail was dropped came
+  back indistinguishable from a complete one, so directives as consequential as `permitted_enctypes` could be
+  missing with nothing to say so. A caller that was unknowingly relying on a truncated read now sees the error
+  instead of the defaults.

--- a/config/hosts.go
+++ b/config/hosts.go
@@ -137,7 +137,14 @@ func (c *Config) GetKpasswdServers(realm string, tcp bool) (int, map[int]string,
 	return count, kdcs, nil
 }
 
+// randServOrder returns the servers keyed by a randomised preference order.
+//
+// The shuffle works on a copy. The slice a caller passes is the Config's own, and a *Config is documented as
+// shareable between clients with every exchange calling GetKDCs, so permuting it in place would both reorder the
+// configured servers permanently and race with any concurrent call reading the same array.
 func randServOrder(ks []string) map[int]string {
+	ks = append([]string(nil), ks...)
+
 	kdcs := make(map[int]string)
 	count := len(ks)
 	i := 1

--- a/config/hosts_test.go
+++ b/config/hosts_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -97,3 +98,80 @@ func TestResolveKDCNoDNS(t *testing.T) {
 		assert.True(t, found, "Record %s not found in results", s)
 	}
 }
+
+func TestConfig_GetKDCsShouldNotReorderTheConfiguredKDCs(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewFromString(multiKDCConf)
+	require.NoError(t, err)
+
+	before := append([]string(nil), c.Realms[0].KDC...)
+
+	for range 5 {
+		_, _, err = c.GetKDCs("TEST.GOKRB5", true)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, before, c.Realms[0].KDC, "the returned order is randomised per call, the configuration is not")
+}
+
+func TestConfig_GetKpasswdServersShouldNotReorderTheConfiguredServers(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewFromString(multiKDCConf)
+	require.NoError(t, err)
+
+	before := append([]string(nil), c.Realms[0].KPasswdServer...)
+
+	for range 5 {
+		_, _, err = c.GetKpasswdServers("TEST.GOKRB5", true)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, before, c.Realms[0].KPasswdServer)
+}
+
+func TestConfig_GetKDCsShouldBeSafeForConcurrentUse(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewFromString(multiKDCConf)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+
+	for range 8 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for range 20 {
+				if _, _, err := c.GetKDCs("TEST.GOKRB5", true); err != nil {
+					panic(err)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Len(t, c.Realms[0].KDC, 4)
+}
+
+// multiKDCConf names four KDCs and four kpasswd servers so a shuffle has something to permute.
+const multiKDCConf = `
+[libdefaults]
+ default_realm = TEST.GOKRB5
+
+[realms]
+ TEST.GOKRB5 = {
+  kdc = kdc1.test.gokrb5:88
+  kdc = kdc2.test.gokrb5:88
+  kdc = kdc3.test.gokrb5:88
+  kdc = kdc4.test.gokrb5:88
+  kpasswd_server = kpasswd1.test.gokrb5:464
+  kpasswd_server = kpasswd2.test.gokrb5:464
+  kpasswd_server = kpasswd3.test.gokrb5:464
+  kpasswd_server = kpasswd4.test.gokrb5:464
+ }
+`

--- a/config/krb5conf.go
+++ b/config/krb5conf.go
@@ -745,6 +745,10 @@ func NewFromScanner(scanner *bufio.Scanner) (*Config, error) {
 		lines = append(lines, scanner.Text())
 	}
 
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading the configuration: %w", err)
+	}
+
 	for i, start := range sectionLineNum {
 		var end int
 		if i+1 >= len(sectionLineNum) {

--- a/config/krb5conf_test.go
+++ b/config/krb5conf_test.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"bufio"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -761,4 +763,16 @@ func TestParseValuesContainingAnEqualsSign(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "FILE:/etc/krb5.keytab?a=b", c.LibDefaults.DefaultKeytabName)
+}
+
+func TestNewFromStringShouldReportALineTooLongForTheScanner(t *testing.T) {
+	t.Parallel()
+
+	s := "[libdefaults]\n  default_realm = " + strings.Repeat("A", bufio.MaxScanTokenSize+1) + "\n  forwardable = true\n"
+
+	c, err := NewFromString(s)
+
+	require.Error(t, err, "a configuration read only in part must not be returned as if it were whole")
+	assert.ErrorIs(t, err, bufio.ErrTooLong)
+	assert.Nil(t, c)
 }


### PR DESCRIPTION
randServOrder shuffled the caller's slice, which is the Config's own, so every call permuted the configured servers and two clients sharing a Config raced on the same array. NewFromScanner never called Err(), so a file whose tail the scanner never reached came back indistinguishable from a complete one.